### PR TITLE
Worktree-isolated Anki dev: parallel instances, hot-reload, sync isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 meta.json
 dist/
 .DS_Store
+.devmode

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,92 @@
-ADDONS := $(HOME)/Library/Application Support/Anki2/addons21
-LINK   := $(ADDONS)/betteranki
-SRC    := $(CURDIR)
+SRC := $(CURDIR)
 
-.PHONY: dev build clean
+# Per-worktree addon name (override with: make <t> NAME=whatever)
+WT := $(notdir $(CURDIR))
+ifeq ($(WT),betteranki)
+NAME ?= betteranki
+else
+NAME ?= betteranki-$(WT)
+endif
 
-# Re-create the dev symlink so Anki loads this working copy.
+# Each worktree gets its OWN isolated Anki base dir + addons21, so several
+# Ankis run at once without touching each other or your real collection.
+BASE := $(HOME)/Library/Application Support/Anki2-dev/$(NAME)
+LINK := $(BASE)/addons21/$(NAME)
+
+# Anki ships a uv-managed venv; this script runs Anki directly (bypassing the
+# launcher) so we can pass -b and a per-instance USER. Override with ANKI=.
+ANKI    ?= $(HOME)/Library/Application Support/AnkiProgramFiles/.venv/bin/anki
+ANKI_PY ?= $(HOME)/Library/Application Support/AnkiProgramFiles/.venv/bin/python
+
+# Real base, used only by `make seed` as a read source.
+REAL_BASE := $(HOME)/Library/Application Support/Anki2
+
+.PHONY: dev undev run run-fg logs seed deisolate clean-base build clean
+
+# Symlink this worktree into its isolated base AND enable web/ hot-reload.
 dev:
-	@mkdir -p "$(ADDONS)"
+	@mkdir -p "$(BASE)/addons21"
 	@rm -rf "$(LINK)"
 	@ln -s "$(SRC)" "$(LINK)"
-	@echo "linked: $(LINK) -> $(SRC)"
-	@echo "now fully quit and reopen Anki to load changes."
+	@touch "$(SRC)/.devmode"
+	@echo "addon  : $(NAME)"
+	@echo "base   : $(BASE)"
+	@echo "link   : $(LINK) -> $(SRC)"
+	@echo "hotload: web/*.css and web/*.js reload live — no restart needed."
+	@echo "next   : 'make run' (first run = empty collection; 'make seed' for real data)"
+
+# Launch THIS worktree's Anki, backgrounded. Unique USER => unique
+# single-instance key, so it runs alongside other worktrees' Ankis.
+# Output is logged (NOT discarded) so add-on tracebacks are recoverable.
+run:
+	@test -x "$(ANKI)" || { echo "anki not found at: $(ANKI)"; echo "set ANKI=/path/to/.venv/bin/anki"; exit 1; }
+	@mkdir -p "$(BASE)"
+	@USER="$(NAME)" LOGNAME="$(NAME)" nohup "$(ANKI)" -b "$(BASE)" >"$(BASE)/run.log" 2>&1 &
+	@echo "launched $(NAME) (base: $(BASE))"
+	@echo "log    : make logs   (or: tail -f '$(BASE)/run.log')"
+
+# Same, but in the foreground with output on the terminal — use this to see
+# a crash/traceback live while debugging.
+run-fg:
+	@test -x "$(ANKI)" || { echo "anki not found at: $(ANKI)"; echo "set ANKI=/path/to/.venv/bin/anki"; exit 1; }
+	@mkdir -p "$(BASE)"
+	@USER="$(NAME)" LOGNAME="$(NAME)" "$(ANKI)" -b "$(BASE)"
+
+# Tail this worktree's Anki log.
+logs:
+	@touch "$(BASE)/run.log"; tail -n 200 -f "$(BASE)/run.log"
+
+# OPT-IN: copy your real collection into this worktree's base so the heatmap
+# and decks are realistic. Snapshot only; media + add-ons excluded. The copied
+# prefs21.db carries your AnkiWeb login + autoSync, so strip_sync.py clears it
+# afterwards — the dev instance is then a fully local, inert copy that CANNOT
+# sync to your real AnkiWeb account.
+seed:
+	@test -d "$(REAL_BASE)" || { echo "real base not found: $(REAL_BASE)"; exit 1; }
+	@mkdir -p "$(BASE)"
+	@rsync -a --delete \
+		--exclude 'addons21/' --exclude 'backups/' --exclude 'logs/' \
+		--exclude 'collection.media/' --exclude 'collection.media.db*' \
+		"$(REAL_BASE)/" "$(BASE)/"
+	@if [ -f "$(BASE)/prefs21.db" ]; then "$(ANKI_PY)" scripts/strip_sync.py "$(BASE)/prefs21.db"; else echo "strip_sync: no prefs21.db (skipped)"; fi
+	@$(MAKE) -s dev
+	@echo "seeded $(NAME): local copy, logged OUT of AnkiWeb (safe — cannot sync)."
+
+# Make an existing seeded base safe without re-copying (clears AnkiWeb login).
+deisolate:
+	@test -f "$(BASE)/prefs21.db" || { echo "no prefs21.db at $(BASE)"; exit 1; }
+	@"$(ANKI_PY)" scripts/strip_sync.py "$(BASE)/prefs21.db"
+
+# Remove this worktree's symlink + disable its hot-reload (keeps the base).
+undev:
+	@rm -rf "$(LINK)"
+	@rm -f "$(SRC)/.devmode"
+	@echo "unlinked: $(NAME)"
+
+# Nuke this worktree's isolated base entirely.
+clean-base:
+	@rm -rf "$(BASE)"
+	@echo "removed base: $(BASE)"
 
 # Produce dist/betteranki.ankiaddon for AnkiWeb upload.
 build:

--- a/README.md
+++ b/README.md
@@ -31,14 +31,55 @@ No network calls, no bundled binaries — keeps AnkiWeb review trivial.
 
 ## Dev loop
 
-This repo is the source of truth (`~/betteranki`).
-`~/Library/Application Support/Anki2/addons21/betteranki` is a symlink to it.
+Each git worktree gets a **fully isolated Anki**: its own base directory, its
+own `addons21/` (so no add-on conflicts), and a unique single-instance key —
+so multiple worktrees' Ankis run **simultaneously**.
 
-1. Edit a file here.
-2. **Fully quit and reopen Anki** (no hot-reload for add-on assets).
-3. Look at the result.
+Per worktree, once:
 
-`make dev` re-creates the symlink (e.g. after a fresh clone on another machine).
+```
+make dev        # symlink this worktree into its isolated base + hot-reload
+make run        # launch THIS worktree's Anki (runs alongside the others)
+```
+
+Then:
+
+1. Edit `web/*.css`, `web/*.js`, or the heatmap HTML.
+2. **It reloads live** — no Anki restart. CSS updates in place with no
+   flicker; the visible screen re-renders for JS / heatmap changes.
+3. Editing `__init__.py` (Python logic / hooks) still needs a restart of
+   *that* instance — Anki imports add-on Python once at startup.
+
+Real data (optional):
+
+```
+make seed       # copy your real collection into this worktree's base
+```
+
+`make run` on a fresh base starts with an **empty collection** (fine for
+theme/CSS work; the heatmap is empty). `make seed` rsyncs your real
+`Anki2/` collection in (media + add-ons excluded, so it stays light).
+**Do not sync a seeded instance** — it shares your AnkiWeb account and
+syncing a copied collection can push unwanted merges upstream.
+
+How parallelism works:
+
+- `make run` launches Anki's bundled venv binary directly with
+  `-b <isolated base>` and a per-worktree `USER` env. Anki keys its
+  single-instance lock on the username, so a unique `USER` lets instances
+  coexist; `open -a Anki` would only refocus the running one.
+- Bases live in `~/Library/Application Support/Anki2-dev/<NAME>` and persist
+  between runs (profile/settings stick).
+
+Other targets:
+
+- `make undev` — remove this worktree's symlink + `.devmode` (keeps the base).
+- `make clean-base` — delete this worktree's isolated base entirely.
+- A watcher thread (web/ mtimes, ~0.5s poll, stdlib only) runs only when
+  `.devmode` is present; `make build` / `.gitignore` exclude `.devmode`, so
+  shipped installs never start it.
+- `make dev NAME=foo` / `make run ANKI=/path/to/.venv/bin/anki` override
+  the addon name / Anki binary.
 
 ## Building for AnkiWeb
 

--- a/__init__.py
+++ b/__init__.py
@@ -9,11 +9,13 @@
   * reviewer progress bar
 
 Everything visible is driven by web/ assets and config so iterating on the
-look is just editing CSS / config and restarting Anki.
+look is just editing CSS / config. In a `make dev` worktree, web/*.css and
+web/*.js hot-reload live; Python changes still need an Anki restart.
 """
 
 import datetime
 import os
+import threading
 import time
 from typing import Any, Dict, Optional
 
@@ -303,3 +305,131 @@ gui_hooks.state_did_change.append(on_state_did_change)
 gui_hooks.reviewer_did_show_question.append(on_show_question)
 gui_hooks.reviewer_did_show_answer.append(on_show_answer)
 gui_hooks.reviewer_will_end.append(on_reviewer_will_end)
+
+
+# --------------------------------------------------------------------------- #
+# Dev hot-reload — web/ assets only, enabled by `make dev` (a .devmode file).
+#
+# Hard rule: the watcher must NEVER touch Anki during shutdown. Refreshing a
+# view there fires Anki's own signals after the collection is gone, and those
+# errors surface OUTSIDE our try/except (in Anki's slots) -> the "may be
+# caused by an add-on" dialog that blocks quitting. So the thread is tied to
+# the profile lifecycle: it starts only once the profile is open and is
+# stopped on profile_will_close, before any teardown.
+#
+# Never ships: build.py and .gitignore exclude .devmode, so end users (who
+# install the zip, no .devmode) never start the watcher thread.
+# --------------------------------------------------------------------------- #
+ADDON_SRC = os.path.dirname(os.path.abspath(__file__))
+
+_dev_stop = threading.Event()
+_dev_thread: Optional[threading.Thread] = None
+
+
+def _dev_active() -> bool:
+    return os.path.exists(os.path.join(ADDON_SRC, ".devmode"))
+
+
+def _dev_reload_views() -> None:
+    """Runs on the Qt main thread. Bails unless a collection is open and we
+    are not shutting down. Cache-busts our stylesheets in every webview
+    (instant, no flicker), then re-renders the current screen."""
+    if _dev_stop.is_set() or not _dev_active():
+        return
+    if mw is None or getattr(mw, "col", None) is None:
+        return  # no profile / mid-shutdown — never refresh here
+    state = getattr(mw, "state", None)
+    if state not in ("deckBrowser", "overview", "review"):
+        return
+
+    bust = (
+        "(function(){var v=Date.now();"
+        "var ls=document.getElementsByTagName('link');"
+        "for(var i=0;i<ls.length;i++){var l=ls[i];"
+        "if(l.rel==='stylesheet'&&l.href.indexOf('/_addons/%s/web/')!==-1)"
+        "{l.href=l.href.split('?')[0]+'?v='+v;}}})();" % ADDON_DIR
+    )
+    views = []
+    for attr in ("web", "bottomWeb"):
+        w = getattr(mw, attr, None)
+        if w is not None:
+            views.append(w)
+    rv = getattr(mw, "reviewer", None)
+    if rv is not None:
+        if getattr(rv, "web", None) is not None:
+            views.append(rv.web)
+        bottom = getattr(rv, "bottom", None)
+        if bottom is not None and getattr(bottom, "web", None) is not None:
+            views.append(bottom.web)
+    for w in views:
+        try:
+            w.eval(bust)
+        except Exception:
+            pass
+
+    try:
+        if state == "deckBrowser":
+            mw.deckBrowser.refresh()
+        elif state == "overview":
+            mw.overview.refresh()
+        elif state == "review":
+            try:
+                with open(os.path.join(ADDON_SRC, "web", "reviewer.js")) as fh:
+                    mw.reviewer.web.eval(fh.read())
+            except Exception:
+                pass
+            _push_progress()
+    except Exception:
+        pass
+
+
+def _dev_watch() -> None:
+    web_dir = os.path.join(ADDON_SRC, "web")
+    seen: Dict[str, float] = {}
+    primed = False
+    # _dev_stop.wait() doubles as the sleep AND an instant exit signal.
+    while not _dev_stop.is_set() and _dev_active():
+        changed = False
+        try:
+            for name in os.listdir(web_dir):
+                path = os.path.join(web_dir, name)
+                if not os.path.isfile(path):
+                    continue
+                mtime = os.path.getmtime(path)
+                if seen.get(path) != mtime:
+                    if primed:
+                        changed = True
+                    seen[path] = mtime
+        except Exception:
+            pass
+        primed = True
+        if changed and not _dev_stop.is_set():
+            try:
+                mw.taskman.run_on_main(_dev_reload_views)
+            except Exception:
+                pass
+        _dev_stop.wait(0.5)
+
+
+def _dev_start() -> None:
+    """Start the watcher once a profile is open. Idempotent."""
+    global _dev_thread
+    if not _dev_active():
+        return
+    if _dev_thread is not None and _dev_thread.is_alive():
+        return
+    _dev_stop.clear()
+    _dev_thread = threading.Thread(
+        target=_dev_watch, name="betteranki-devwatch", daemon=True
+    )
+    _dev_thread.start()
+
+
+def _dev_shutdown() -> None:
+    """Stop the watcher before Anki tears anything down."""
+    _dev_stop.set()
+
+
+gui_hooks.profile_did_open.append(_dev_start)
+gui_hooks.main_window_did_init.append(_dev_start)
+gui_hooks.profile_will_close.append(_dev_shutdown)

--- a/build.py
+++ b/build.py
@@ -17,11 +17,12 @@ OUT_DIR = os.path.join(ROOT, "dist")
 OUT = os.path.join(OUT_DIR, "betteranki.ankiaddon")
 
 # Anything matching these (path-relative-to-root) is never shipped.
-EXCLUDE_DIRS = {".git", "dist", "__pycache__"}
+EXCLUDE_DIRS = {".git", "dist", "__pycache__", "scripts"}
 EXCLUDE_FILES = {
     "meta.json",
     ".DS_Store",
     ".gitignore",
+    ".devmode",
     "build.py",
     "Makefile",
 }

--- a/scripts/strip_sync.py
+++ b/scripts/strip_sync.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Remove AnkiWeb sync credentials from a (copied) Anki prefs21.db.
+
+`make seed` rsyncs your real base into the worktree's dev base. That copy
+includes prefs21.db, which holds your AnkiWeb login (`syncKey`/`syncUser`)
+and `autoSync`. Without this step a seeded dev instance would log into your
+real AnkiWeb account and auto-sync — pulling your real data and pushing test
+changes back. Clearing the auth keys makes Anki treat the dev profile as
+logged out, so it is a fully local, inert snapshot that cannot touch your
+account. (Anki reads profiles with pickle; it writes protocol=4, so we match.)
+
+Usage:  strip_sync.py /path/to/prefs21.db
+"""
+
+import pickle
+import sqlite3
+import sys
+
+# syncKey/syncUser absent => Anki is "logged out" and cannot sync at all.
+# The rest are cleared for cleanliness; autoSync=False is belt-and-suspenders.
+SYNC_KEYS = (
+    "syncKey",
+    "syncUser",
+    "hostNum",
+    "currentSyncUrl",
+    "customSyncUrl",
+)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: strip_sync.py /path/to/prefs21.db", file=sys.stderr)
+        return 2
+    db = sys.argv[1]
+    con = sqlite3.connect(db)
+    try:
+        rows = con.execute("select name, data from profiles").fetchall()
+        changed = 0
+        for name, data in rows:
+            if name == "_global" or data is None:
+                continue
+            try:
+                prof = pickle.loads(data)
+            except Exception:
+                continue
+            if not isinstance(prof, dict):
+                continue
+            before = dict(prof)
+            for k in SYNC_KEYS:
+                prof.pop(k, None)
+            prof["autoSync"] = False
+            if prof != before:
+                con.execute(
+                    "update profiles set data = ? where name = ?",
+                    (pickle.dumps(prof, protocol=4), name),
+                )
+                changed += 1
+        con.commit()
+    finally:
+        con.close()
+    print(f"strip_sync: cleared AnkiWeb sync from {changed} profile(s) in {db}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Tooling so each git worktree gets a fully isolated, parallel Anki dev environment with live `web/` hot-reload — no AnkiWeb risk.

- **Parallel instances**: each worktree → its own Anki base + `addons21/`; a unique per-worktree `USER` gives a distinct single-instance key, so multiple worktrees' Ankis run simultaneously. `make run`/`run-fg`/`logs`.
- **Hot-reload watcher** (`__init__.py`): web/ mtime watcher, lifecycle-managed — starts on `profile_did_open`, hard-stops on `profile_will_close` so it can never fire during shutdown (the cause of the earlier unclosable "may be caused by an add-on" dialog). Gated by `.devmode`; stdlib-only.
- **Sync isolation**: `make seed` copies the real collection for realistic decks/heatmap, then `scripts/strip_sync.py` clears AnkiWeb `syncKey`/`syncUser` + `autoSync` so the seeded base is a local, inert copy that **cannot** sync to the real account. `make deisolate` fixes an existing base.
- `build.py`/`.gitignore` exclude `.devmode` and `scripts/` from the shipped `.ankiaddon`. README documents the workflow.

Rebased onto `main` (includes 207edf8). `__init__.py` 3-way merged cleanly — token/deck-redesign features and the dev watcher both intact; `py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)