### PR TITLE
BetterAnki redesign: editorial homepage, sidebar nav, reviewer chrome…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ No network calls, no bundled binaries — keeps AnkiWeb review trivial.
 
 | Path | Purpose |
 |---|---|
-| `__init__.py` | hooks, heatmap generation, progress logic, config |
-| `web/theme.css` | the redesign — the main file to iterate on |
-| `web/heatmap.css` | heatmap styling |
+| `__init__.py` | hooks, masthead + heatmap generation, progress, config |
+| `web/theme.css` | the deck-homepage "study ledger" redesign |
+| `web/heatmap.css` / `.js` | heatmap styling; scroll-to-newest + tooltip |
+| `web/toolbar.css` | top toolbar redesign (flat full-width header) |
 | `web/reviewer.css` / `.js` | progress bar |
 | `config.json` / `config.md` | user-facing settings + their help text |
 | `manifest.json` | name, version, `conflicts` with rival add-ons |

--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ web/*.js hot-reload live; Python changes still need an Anki restart.
 """
 
 import datetime
+import html
 import os
 import threading
 import time
@@ -26,12 +27,15 @@ from aqt.reviewer import Reviewer
 from aqt.webview import WebContent
 
 # Optional bits — guarded so a renamed API can never break the whole add-on.
+# NB: the webview's `context` for the bars is the *wrapper* passed to
+# stdHtml() — TopToolbar / BottomToolbar — NOT Toolbar / BottomBar. Matching
+# the wrong class is why the toolbar was never themed.
 try:
-    from aqt.toolbar import Toolbar as _ToolbarCtx
+    from aqt.toolbar import TopToolbar as _ToolbarCtx
 except Exception:
     _ToolbarCtx = None
 try:
-    from aqt.toolbar import BottomBar as _BottomCtx
+    from aqt.toolbar import BottomToolbar as _BottomCtx
 except Exception:
     _BottomCtx = None
 try:
@@ -66,36 +70,155 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
     if not themed:
         return
 
-    accent = _config().get("accent", "#6c8cff")
+    cfg = _config()
+    accent = cfg.get("accent", "#6c8cff")
+    theme_pref = cfg.get("theme", "system")  # "system" | "light" | "dark"
+    # User-supplied display fonts are prepended to the existing stacks.
+    serif_user = (cfg.get("font_serif") or "").strip()
+    sans_user = (cfg.get("font_sans") or "").strip()
+    serif_decl = f"--rf-serif:{serif_user}, ui-serif, 'New York', Georgia, serif;" \
+        if serif_user else ""
+    sans_decl = f"--rf-sans:{sans_user}, ui-sans-serif, -apple-system, system-ui, sans-serif;" \
+        if sans_user else ""
     # tokens.css derives --accent from --rf-accent; inject the latter here.
+    # `data-rf-theme` on <html> forces light/dark over the system @media.
+    extras = ""
+    if theme_pref in ("light", "dark"):
+        extras = (
+            f"<script>document.documentElement.dataset.rfTheme="
+            f"'{theme_pref}';</script>"
+        )
     web_content.head += (
-        f"<style>:root,.night-mode,body{{--rf-accent:{accent};}}</style>"
+        f"<style>:root,.night-mode,body{{"
+        f"--rf-accent:{accent};{serif_decl}{sans_decl}}}</style>"
+        + extras
     )
     web_content.css.append(f"{WEB}/tokens.css")
 
-    if isinstance(context, (DeckBrowser, Overview)):
+    if isinstance(context, (DeckBrowser, Overview, Reviewer)):
+        # theme.css defines the --rf-* design tokens used by reviewer.css
+        # (back button, answer divider, progress strip), so the reviewer
+        # needs it too — otherwise it falls back to hardcoded dark colors
+        # even in light mode. The heavy homepage layout in theme.css is
+        # scoped to .ba-home / .ba-over and won't touch the reviewer.
         web_content.css.append(f"{WEB}/theme.css")
     if isinstance(context, DeckBrowser):
         web_content.css.append(f"{WEB}/heatmap.css")
+        web_content.js.append(f"{WEB}/heatmap.js")
+        # Tag the deck browser's <center> so theme.css can scope the heavy
+        # homepage layout to it alone — the Overview shares this stylesheet
+        # and must keep its own simple layout (just palette + type).
+        # Add `ba-single` when there's only one top-level deck so the hero
+        # composition can take over from the (now-hidden) table.
+        try:
+            klass = "ba-home" + (
+                " ba-single" if _top_decks_count() == 1 else " ba-multi"
+            )
+            web_content.body = web_content.body.replace(
+                "<center>", f'<center class="{klass}">', 1
+            )
+        except Exception:
+            pass
+    if isinstance(context, Overview):
+        # Scope Overview's <center> so theme.css can give it its own layout.
+        try:
+            web_content.body = web_content.body.replace(
+                "<center>", '<center class="ba-over">', 1
+            )
+        except Exception:
+            pass
+    # Sidebar nav — deck browser + overview only. The reviewer gets full
+    # focus (no sidebar) so the card area isn't competing with chrome.
+    if cfg.get("sidebar_nav", True) and isinstance(
+        context, (DeckBrowser, Overview)
+    ):
+        web_content.css.append(f"{WEB}/sidebar.css")
+        web_content.js.append(f"{WEB}/sidebar.js")
+        # Embed the standing data in <head> as a global so sidebar.js reads
+        # it synchronously on its first run.
+        try:
+            import json as _json
+            payload = _build_standing_payload()
+            web_content.head += (
+                "<script>window.__baStandingData = "
+                + _json.dumps(payload) + ";</script>"
+            )
+        except Exception:
+            pass
+    # Floating Settings cog — only when the sidebar is OFF on the homepage.
+    no_side = not cfg.get("sidebar_nav", True)
+    if no_side and isinstance(context, (DeckBrowser, Overview)):
+        web_content.css.append(f"{WEB}/sidebar.css")  # for .ba-cog
+        web_content.body = (
+            '<button class="ba-cog" onclick="pycmd(\'ba:settings\')" '
+            'title="BetterAnki settings">⚙</button>' + web_content.body
+        )
+    # Reviewer: no sidebar, but the user needs a way back to the deck list.
+    # A small floating "← Decks" link top-left, plus a subtle settings cog
+    # (so they can still tweak from inside a session if they really need to).
+    if isinstance(context, Reviewer):
+        web_content.css.append(f"{WEB}/sidebar.css")  # for .ba-back / .ba-cog
+        web_content.body = (
+            '<button class="ba-back" onclick="pycmd(\'ba:decks\')" '
+            'title="Back to decks (Esc)">Decks</button>'
+            + web_content.body
+        )
     if _is(context, _ToolbarCtx):
         web_content.css.append(f"{WEB}/toolbar.css")
-    if isinstance(context, Reviewer) and _config().get("show_progress", True):
+    # Reviewer's bottom bar (Show Answer, Edit, More, answer buttons) lives
+    # in BottomToolbar — restyle it so it doesn't look like 2003 Anki.
+    if _is(context, _BottomCtx):
+        web_content.css.append(f"{WEB}/reviewer-bottom.css")
+    # reviewer.css always loads on the reviewer — it owns the back button,
+    # answer divider, card chrome, AND the progress strip styling. Gating it
+    # on show_progress used to break the back button + card colors when the
+    # progress bar was off. show_progress only controls the JS that injects
+    # the progress bar element.
+    if isinstance(context, Reviewer):
         web_content.css.append(f"{WEB}/reviewer.css")
-        web_content.js.append(f"{WEB}/reviewer.js")
+        if cfg.get("show_progress", True):
+            web_content.js.append(f"{WEB}/reviewer.js")
 
 
 # --------------------------------------------------------------------------- #
 # Integrated action buttons (replace Anki's native bottom strip on the deck
 # list). These pycmds are handled by the deck browser's own link handler.
 # --------------------------------------------------------------------------- #
-def _actions_html() -> str:
-    return (
-        '<div class="ba-actions">'
-        "<button class=\"primary\" onclick=\"pycmd('create')\">+ New Deck</button>"
-        "<button onclick=\"pycmd('shared')\">Get Shared</button>"
-        "<button onclick=\"pycmd('import')\">Import File</button>"
-        "</div>"
-    )
+# --------------------------------------------------------------------------- #
+# Standing computation — used by the sidebar and the single-deck hero.
+# --------------------------------------------------------------------------- #
+
+
+def _standing() -> Dict[str, Any]:
+    counts = _counts_by_day()
+    shift = _day_shift_seconds()
+    today_idx = int((time.time() + shift) // 86400)
+    streak = 0
+    probe = today_idx if counts.get(today_idx, 0) > 0 else today_idx - 1
+    while counts.get(probe, 0) > 0:
+        streak += 1
+        probe -= 1
+    out: Dict[str, Any] = {
+        "today": counts.get(today_idx, 0),
+        "total": sum(counts.values()),
+        "streak": streak,
+        "new": None,
+        "learn": None,
+        "due": None,
+    }
+    try:
+        tree = mw.col.sched.deck_due_tree()
+        n = lr = rv = 0
+        for c in getattr(tree, "children", []):
+            n += int(getattr(c, "new_count", 0) or 0)
+            lr += int(getattr(c, "learn_count", 0) or 0)
+            rv += int(getattr(c, "review_count", 0) or 0)
+        out["new"], out["learn"], out["due"] = n, lr, rv
+    except Exception:
+        pass
+    return out
+
+
 
 
 # --------------------------------------------------------------------------- #
@@ -131,6 +254,11 @@ def _counts_by_day() -> Dict[int, int]:
     return {int(d): int(n) for d, n in rows}
 
 
+_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+
 def build_heatmap_html(weeks: int = 53) -> str:
     col = mw.col
     if not col:
@@ -147,7 +275,11 @@ def build_heatmap_html(weeks: int = 53) -> str:
     def dow(idx: int) -> int:  # 0 = Sunday .. 6 = Saturday
         return (idx + 4) % 7
 
-    start_idx = today_idx - (weeks * 7 - 1)
+    # Render the full history so you can scroll back through past years, but
+    # never fewer than `weeks` columns so a fresh collection still looks full.
+    floor_idx = today_idx - (weeks * 7 - 1)
+    earliest = min(counts) if counts else floor_idx
+    start_idx = min(earliest, floor_idx)
     grid_start = start_idx - dow(start_idx)  # back up to a Sunday
 
     nonzero = [c for c in counts.values() if c > 0]
@@ -158,9 +290,20 @@ def build_heatmap_html(weeks: int = 53) -> str:
             return 0
         return min(4, 1 + int(n * 4 / (peak + 0.0001)))
 
-    cells = []
     columns = (today_idx - grid_start) // 7 + 1
+
+    cells = []
+    month_spans = []  # [label, span_in_columns]
+    prev_month = prev_year = None
     for w in range(columns):
+        cd = date_for(grid_start + w * 7)  # the column's Sunday
+        if cd.month != prev_month:
+            year = f" {cd.year}" if cd.year != prev_year else ""
+            month_spans.append([_MONTHS[cd.month - 1] + year, 1])
+            prev_month, prev_year = cd.month, cd.year
+        else:
+            month_spans[-1][1] += 1
+
         col_cells = []
         for r in range(7):
             idx = grid_start + w * 7 + r
@@ -169,11 +312,31 @@ def build_heatmap_html(weeks: int = 53) -> str:
                 continue
             n = counts.get(idx, 0)
             d = date_for(idx)
-            tip = f"{d.isoformat()} — {n} review{'s' if n != 1 else ''}"
+            human = f"{_WEEKDAYS[dow(idx)]}, {d.day} {_MONTHS[d.month - 1]} {d.year}"
+            if idx == today_idx:
+                rel = "Today"
+            elif idx == today_idx - 1:
+                rel = "Yesterday"
+            else:
+                rel = ""
+            is_peak = "1" if (n == peak and peak >= 8) else "0"
             col_cells.append(
-                f'<div class="rf-hm-cell rf-hm-l{level(n)}" title="{tip}"></div>'
+                f'<div class="rf-hm-cell rf-hm-l{level(n)}" '
+                f'data-count="{n}" data-human="{human}" '
+                f'data-rel="{rel}" data-peak="{is_peak}"></div>'
             )
         cells.append('<div class="rf-hm-col">' + "".join(col_cells) + "</div>")
+
+    # Only label months wide enough to fit the text without colliding.
+    months_html = "".join(
+        f'<span class="rf-hm-mon" style="width:{span * 14}px">'
+        f'{label if span >= 4 else ""}</span>'
+        for label, span in month_spans
+    )
+    weekdays_html = "".join(
+        f'<span class="rf-hm-wd">{_WEEKDAYS[i] if i in (1, 3, 5) else ""}</span>'
+        for i in range(7)
+    )
 
     total = sum(counts.values())
     streak = 0
@@ -195,7 +358,16 @@ def build_heatmap_html(weeks: int = 53) -> str:
           <b>{total}</b> total
         </span>
       </div>
-      <div class="rf-hm-grid">{''.join(cells)}</div>
+      <div class="rf-hm-body">
+        <div class="rf-hm-wds">
+          <span class="rf-hm-mon-spacer"></span>
+          {weekdays_html}
+        </div>
+        <div class="rf-hm-scroll">
+          <div class="rf-hm-months">{months_html}</div>
+          <div class="rf-hm-grid">{''.join(cells)}</div>
+        </div>
+      </div>
       <div class="rf-hm-foot">
         <span>Less</span>{legend}<span>More</span>
       </div>
@@ -213,8 +385,24 @@ def on_deck_browser_will_render_content(
             heatmap = build_heatmap_html(int(cfg.get("heatmap_weeks", 53)))
         except Exception as e:
             heatmap = f"<!-- betteranki heatmap error: {e} -->"
-    # order: integrated actions, then Anki's #studiedToday, then heatmap
-    content.stats = _actions_html() + content.stats + heatmap
+    # Single-deck hero replaces the table (CSS hides the table in this mode).
+    hero = ""
+    try:
+        if _top_decks_count() == 1:
+            hero = _single_deck_hero()
+    except Exception:
+        pass
+    # Wrap the streak / today / all-time stats together with the heatmap so
+    # they read as a single integrated "practice record" band on the page.
+    try:
+        practice_head = _practice_header_html()
+    except Exception:
+        practice_head = ""
+    practice = (
+        f'<section class="ba-practice">{practice_head}{heatmap}</section>'
+        if heatmap else ""
+    )
+    content.stats = hero + content.stats + practice
 
 
 # --------------------------------------------------------------------------- #
@@ -233,24 +421,446 @@ def _set_bottom_visible(visible: bool) -> None:
 
 
 def _update_title() -> None:
+    # Anki sets "<profile> - Anki" late in profile load; collapse it to a
+    # clean "Anki" (we re-assert it after render so ours wins that race).
     try:
         mw.setWindowTitle("Anki")
     except Exception:
         pass
 
 
+def _mark_toolbar_state(state: Optional[str] = None) -> None:
+    """Tag the toolbar <body> with the current screen so toolbar.css can
+    highlight the active section (e.g. Decks on the deck list). The toolbar
+    DOM survives state changes — only the content webview swaps — so a single
+    eval sticks. Best-effort and fully guarded."""
+    tw = getattr(mw, "toolbarWeb", None)
+    if tw is None:
+        return
+    raw = state if state is not None else getattr(mw, "state", "")
+    safe = "".join(ch for ch in str(raw) if ch.isalnum())
+    try:
+        tw.eval(
+            "document.body && document.body.setAttribute("
+            "'data-rf-state','%s');" % safe
+        )
+    except Exception:
+        pass
+
+
 def on_state_did_change(new_state: str, old_state: str) -> None:
-    _set_bottom_visible(new_state != "deckBrowser")
+    cfg = _config()
+    hide_decks = cfg.get("hide_bottom_on_decks", True)
+    hide_over = cfg.get("hide_bottom_on_overview", True)
+    if new_state == "deckBrowser":
+        _set_bottom_visible(not hide_decks)
+    elif new_state == "overview":
+        _set_bottom_visible(not hide_over)
+    else:
+        _set_bottom_visible(True)  # always keep reviewer answer buttons
     _update_title()
+    _mark_toolbar_state(new_state)
+    _apply_chrome()
+    _mark_sidebar_active(new_state)
+    _push_sidebar_standing()
+
+
+def _post_render_fixups() -> None:
+    if _config().get("hide_bottom_on_decks", True):
+        _set_bottom_visible(False)
+    _update_title()
+    _mark_toolbar_state()
+    _apply_chrome()
+    _push_sidebar_standing()
+    _refresh_sync_status()
+
+
+# --------------------------------------------------------------------------- #
+# Sidebar nav — hide Anki's top toolbar webview and route `ba:*` pycmds.
+# --------------------------------------------------------------------------- #
+def _sidebar_on() -> bool:
+    return bool(_config().get("sidebar_nav", True))
+
+
+def _set_top_toolbar_visible(visible: bool) -> None:
+    tw = getattr(mw, "toolbarWeb", None)
+    if tw is None:
+        return
+    try:
+        tw.setVisible(visible)
+    except Exception:
+        pass
+
+
+def _apply_chrome() -> None:
+    """Hide Anki's top toolbar webview when the sidebar is on. Anki re-shows
+    it on state transitions, so we re-hide after each render."""
+    _set_top_toolbar_visible(not _sidebar_on())
+
+
+def _mark_sidebar_active(state: Optional[str] = None) -> None:
+    """Tell every themed webview's sidebar which item is current. Cheap and
+    safe — no-ops if the sidebar JS hasn't initialised yet."""
+    raw = state if state is not None else getattr(mw, "state", "")
+    cmd = {"deckBrowser": "decks", "overview": "decks",
+           "review": "decks"}.get(str(raw), "")
+    if not cmd:
+        return
+    js = "window.__baSetActive && window.__baSetActive('%s');" % cmd
+    for attr in ("web",):
+        w = getattr(mw, attr, None)
+        if w is not None:
+            try:
+                w.eval(js)
+            except Exception:
+                pass
+
+
+def _open_settings() -> None:
+    """Open the BetterAnki settings dialog."""
+    try:
+        from .settings import open_settings
+        open_settings(mw)
+    except Exception as e:
+        try:
+            from aqt.utils import showWarning
+            showWarning(f"BetterAnki settings: {e}")
+        except Exception:
+            pass
+
+
+def _on_js_message(handled, message, context):
+    """Dispatch `ba:<cmd>` pycmds from our sidebar/settings. Filter hook:
+    return (True, None) when we handle it."""
+    if not isinstance(message, str) or not message.startswith("ba:"):
+        return handled
+    cmd = message[3:]
+    try:
+        if cmd == "decks":
+            mw.moveToState("deckBrowser")
+        elif cmd == "add":
+            mw.onAddCard()
+        elif cmd == "browse":
+            mw.onBrowse()
+        elif cmd == "stats":
+            mw.onStats()
+        elif cmd == "sync":
+            mw.on_sync_button_clicked()
+        elif cmd == "settings":
+            _open_settings()
+        elif cmd == "create":
+            _open_new_deck()
+        elif cmd == "import":
+            mw.onImport()
+        elif cmd.startswith("study:"):
+            tail = cmd.split(":", 1)[1]
+            if tail.isdigit():
+                _start_studying(int(tail))
+            else:
+                return handled
+        elif cmd == "prefs":
+            try:
+                mw.onPrefs()
+            except Exception:
+                return handled
+        elif cmd.startswith("deck-opts:"):
+            tail = cmd.split(":", 1)[1]
+            if tail.isdigit():
+                # Use Anki's own _showOptions which puts up the full context
+                # menu — Rename, Options, Export, Delete — same as clicking
+                # the gear next to a deck row in the deck-list view.
+                try:
+                    mw.deckBrowser._showOptions(tail)  # type: ignore[attr-defined]
+                except Exception:
+                    # Fallback: at least open the review-settings dialog.
+                    try:
+                        from aqt.deckoptions import display_options_for_deck_id
+                        from anki.decks import DeckId
+                        display_options_for_deck_id(DeckId(int(tail)))
+                    except Exception:
+                        return handled
+            else:
+                return handled
+        else:
+            return handled
+    except Exception:
+        return handled
+    return (True, None)
+
+
+def _open_new_deck() -> None:
+    """Open the standard New Deck dialog (same one Anki uses)."""
+    try:
+        from aqt.operations.deck import add_deck_dialog
+        add_deck_dialog(parent=mw)
+    except Exception:
+        try:
+            # Fallback for older Anki APIs.
+            mw.deckBrowser._on_create()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+
+def _start_studying(did: int) -> None:
+    """Select a deck and go straight into the reviewer (one-click study from
+    the single-deck hero)."""
+    try:
+        mw.col.decks.select(did)
+        try:
+            mw.col.startTimebox()
+        except Exception:
+            pass
+        mw.moveToState("review")
+    except Exception:
+        # If anything goes wrong, fall back to opening the overview.
+        try:
+            mw.moveToState("overview")
+        except Exception:
+            pass
+
+
+def _practice_header_html() -> str:
+    """Streak + today/minutes/all-time as a header band above the heatmap.
+    These stats used to live in the sidebar; they fit better here next to
+    the visual record of activity."""
+    try:
+        s = _standing()
+    except Exception:
+        return ""
+    streak = int(s.get("streak", 0) or 0)
+    today_n = int(s.get("today", 0) or 0)
+    today_min = _minutes_today()
+    total = int(s.get("total", 0) or 0)
+    # Phosphor-inspired flame: tall body + a small inner highlight that
+    # reads as the cool core of the fire.
+    flame = (
+        '<svg class="ba-flame" viewBox="0 0 24 24" '
+        'fill="currentColor" aria-hidden="true">'
+        '<path d="M12 2c.5 3 2 4.5 3.5 6.2C17 10 18.5 12 18.5 14.5'
+        '  c0 3.6-2.9 6.5-6.5 6.5s-6.5-2.9-6.5-6.5c0-1.6.6-2.9 1.5-3.8'
+        '  C8 11.6 9 12 10 12c0-2 0-4.5 2-10z"/>'
+        '<path d="M12.5 17.5c-1.4 0-2.5-1.1-2.5-2.5c0-.9.4-1.6 1.2-2'
+        '  c.7-.4 1.6-.8 1.9-1.7c.5 1 1.3 1.7 1.6 2.6c.1.4.2.8.2 1.2'
+        '  c0 1.4-1.1 2.4-2.4 2.4z" opacity=".55"/>'
+        '</svg>'
+    )
+    return f"""
+    <header class="ba-practice-head">
+      <div class="ba-practice-streak" title="Consecutive days reviewed">
+        {flame}
+        <span class="ba-practice-streak-n">{streak}</span>
+        <span class="ba-practice-streak-l">day streak</span>
+      </div>
+      <div class="ba-practice-meta">
+        <div class="ba-practice-stat">
+          <span class="n">{today_n:,}</span>
+          <span class="l">today</span>
+        </div>
+        <div class="ba-practice-stat">
+          <span class="n">{today_min}</span>
+          <span class="l">minutes</span>
+        </div>
+        <div class="ba-practice-stat">
+          <span class="n">{total:,}</span>
+          <span class="l">all-time</span>
+        </div>
+      </div>
+    </header>
+    """
+
+
+def _single_deck_hero() -> str:
+    """When the user has just one top-level deck, present it as a hero with
+    the deck name + actionable stats + a primary Study button instead of a
+    one-row table that would feel silly."""
+    try:
+        tree = mw.col.sched.deck_due_tree()
+        kids = getattr(tree, "children", [])
+        if len(kids) != 1:
+            return ""
+        d = kids[0]
+        name = html.escape(getattr(d, "name", ""))
+        new_n = int(getattr(d, "new_count", 0) or 0)
+        learn_n = int(getattr(d, "learn_count", 0) or 0)
+        rev_n = int(getattr(d, "review_count", 0) or 0)
+        did = int(getattr(d, "deck_id", 0))
+        total = new_n + learn_n + rev_n
+        # The whole card IS the action — no button. Click anywhere on it to
+        # start studying. Big numbers carry the visual weight; deck title is
+        # small because it's incidental once the user knows which deck.
+        click = "" if not total else f"pycmd('ba:study:{did}')"
+        tabindex = "-1" if not total else "0"
+        disabled = "ba-hero--done" if not total else ""
+        # Deck name lives ABOVE the card now (a quiet header). The card is
+        # focused on the numbers + the click-anywhere action. The small gear
+        # next to the name opens this deck's options dialog (otherwise hard
+        # to reach in single-deck mode since the deck row is hidden).
+        return f"""
+        <header class="ba-deck-head ba-rise">
+          <h1 class="ba-deck-name">{name}</h1>
+          <button class="ba-deck-opts"
+                  onclick="event.stopPropagation();pycmd('ba:deck-opts:{did}')"
+                  title="Deck options" aria-label="Deck options">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5h0a1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h0a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h0a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v0a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/>
+            </svg>
+          </button>
+        </header>
+        <button class="ba-hero ba-rise {disabled}" tabindex="{tabindex}"
+                onclick="{click}" aria-label="Study {name}">
+          <div class="ba-hero-stats">
+            <div class="ba-hero-stat ba-due">
+              <span class="ba-hero-n">{rev_n}</span>
+              <span class="ba-hero-l">Due</span>
+            </div>
+            <div class="ba-hero-stat ba-new">
+              <span class="ba-hero-n">{new_n}</span>
+              <span class="ba-hero-l">New</span>
+            </div>
+            <div class="ba-hero-stat ba-learn">
+              <span class="ba-hero-n">{learn_n}</span>
+              <span class="ba-hero-l">Learn</span>
+            </div>
+          </div>
+        </button>
+        <script>
+          (function() {{
+            var card = document.querySelector('.ba-hero');
+            if (!card || card.classList.contains('ba-hero--done')) return;
+            document.addEventListener('keydown', function(e) {{
+              if ((e.key === 'Enter' || e.key === ' ')
+                  && !e.target.closest('input, textarea, [contenteditable]')) {{
+                e.preventDefault();
+                card.click();
+              }}
+            }});
+          }})();
+        </script>
+        """
+    except Exception:
+        return ""
+
+
+def _minutes_today() -> int:
+    """Total minutes reviewed today, from the revlog. 0 on any error."""
+    try:
+        shift = _day_shift_seconds()
+        today_idx = int((time.time() + shift) // 86400)
+        row = mw.col.db.first(
+            "select sum(time) from revlog where "
+            "cast((id/1000 + ?) / 86400 as int) = ?",
+            shift, today_idx,
+        )
+        if row and row[0]:
+            return int(float(row[0]) / 60000.0)
+    except Exception:
+        pass
+    return 0
+
+
+def _top_decks_count() -> int:
+    try:
+        tree = mw.col.sched.deck_due_tree()
+        return len(getattr(tree, "children", []))
+    except Exception:
+        return 0
+
+
+def _last_7_days_active() -> list:
+    """A 7-bool list, oldest → today, for the sidebar mini-grid."""
+    try:
+        counts = _counts_by_day()
+        shift = _day_shift_seconds()
+        today_idx = int((time.time() + shift) // 86400)
+        return [bool(counts.get(today_idx - i, 0) > 0) for i in range(6, -1, -1)]
+    except Exception:
+        return [False] * 7
+
+
+def _build_standing_payload() -> Dict[str, Any]:
+    s = _standing()
+    return {
+        "streak": s.get("streak", 0),
+        "due": s.get("due"),
+        "new": s.get("new"),
+        "learn": s.get("learn"),
+        "today": s.get("today", 0),
+        "todayMin": _minutes_today(),
+        "total": s.get("total", 0),
+        "singleDeck": _top_decks_count() == 1,
+        "last7": _last_7_days_active(),
+    }
+
+
+def _push_sidebar_sync(state: str) -> None:
+    """Update the sidebar's Sync indicator state. `state` is one of:
+    "" (clean), "pending", "full", "active"."""
+    safe = "".join(ch for ch in state if ch.isalnum())
+    js = "window.__baSetSync && window.__baSetSync('%s');" % safe
+    for w in (getattr(mw, "web", None),):
+        if w is not None:
+            try:
+                w.eval(js)
+            except Exception:
+                pass
+
+
+def _refresh_sync_status() -> None:
+    """Ask Anki for the current sync status and push it to the sidebar."""
+    try:
+        from aqt.sync import get_sync_status
+        from anki.sync_pb2 import SyncStatusResponse
+
+        def on_status(status):
+            req = getattr(status, "required", 0)
+            if req == SyncStatusResponse.NORMAL_SYNC:
+                _push_sidebar_sync("pending")
+            elif req == SyncStatusResponse.FULL_SYNC:
+                _push_sidebar_sync("full")
+            else:
+                _push_sidebar_sync("")
+        get_sync_status(mw, on_status)
+    except Exception:
+        # Older Anki / API change: fall back to silently clearing.
+        _push_sidebar_sync("")
+
+
+def _push_sidebar_standing() -> None:
+    """Push the day's standing into every webview's sidebar for live updates
+    (state changes, post-render). The initial render is bootstrapped via a
+    <head> global; this is for changes after that."""
+    try:
+        payload = _build_standing_payload()
+    except Exception:
+        return
+    import json as _json
+    js = f"window.__baSetStanding && window.__baSetStanding({_json.dumps(payload)});"
+    for attr in ("web",):
+        w = getattr(mw, attr, None)
+        if w is not None:
+            try:
+                w.eval(js)
+            except Exception:
+                pass
+    # Reviewer has its own webview.
+    rv = getattr(mw, "reviewer", None)
+    if rv is not None and getattr(rv, "web", None) is not None:
+        try:
+            rv.web.eval(js)
+        except Exception:
+            pass
 
 
 def on_deck_browser_did_render(deck_browser: DeckBrowser) -> None:
-    # The deck browser re-shows the bottom strip when it draws; hide it again
-    # on the next event-loop tick so our in-page actions stand alone.
+    # The deck browser re-shows the bottom strip and Anki (re)sets the window
+    # title around render; re-assert our state on the next event-loop tick so
+    # our in-page actions stand alone and the title/active-section stick.
     if QTimer is not None:
-        QTimer.singleShot(0, lambda: _set_bottom_visible(False))
+        QTimer.singleShot(0, _post_render_fixups)
     else:
-        _set_bottom_visible(False)
+        _post_render_fixups()
 
 
 # --------------------------------------------------------------------------- #
@@ -305,6 +915,64 @@ gui_hooks.state_did_change.append(on_state_did_change)
 gui_hooks.reviewer_did_show_question.append(on_show_question)
 gui_hooks.reviewer_did_show_answer.append(on_show_answer)
 gui_hooks.reviewer_will_end.append(on_reviewer_will_end)
+
+# Sidebar nav: route `ba:*` pycmds to the right mw methods + settings dialog.
+gui_hooks.webview_did_receive_js_message.append(_on_js_message)
+
+# Sync status indicator — show pending/full when there are changes to push,
+# and a soft pulse while a sync is in progress.
+try:
+    gui_hooks.sync_will_start.append(lambda *a: _push_sidebar_sync("active"))
+    gui_hooks.sync_did_finish.append(lambda *a: _refresh_sync_status())
+except Exception:
+    pass
+
+# Hide Anki's top toolbar webview as soon as the main window / profile is up.
+gui_hooks.main_window_did_init.append(_apply_chrome)
+gui_hooks.profile_did_open.append(_apply_chrome)
+
+# Re-tag the toolbar after Anki rebuilds it (e.g. sync-status redraw), so the
+# active-section highlight isn't lost. Optional — guarded per add-on policy.
+try:
+    gui_hooks.top_toolbar_did_redraw.append(lambda tb: _mark_toolbar_state())
+except Exception:
+    pass
+
+# Anki add-on dialog "Config" → open our settings UI instead of raw JSON.
+try:
+    mw.addonManager.setConfigAction(__name__, _open_settings)
+except Exception:
+    pass
+
+
+def _add_tools_menu_action() -> None:
+    try:
+        from aqt.qt import QAction, QKeySequence, QShortcut, Qt
+        act = QAction("BetterAnki Settings…", mw)
+        # Cmd+, on macOS / Ctrl+, elsewhere — the canonical "preferences" key.
+        act.setShortcut(QKeySequence("Ctrl+,"))
+        # Use the enum (NOT a literal int — the values differ between Qt5/6).
+        act.setShortcutContext(Qt.ShortcutContext.ApplicationShortcut)
+        act.triggered.connect(_open_settings)
+        mw.form.menuTools.addAction(act)
+        # Belt-and-braces: also register a global QShortcut on the main
+        # window so the key fires regardless of focus.
+        sc = QShortcut(QKeySequence("Ctrl+,"), mw)
+        sc.setContext(Qt.ShortcutContext.ApplicationShortcut)
+        sc.activated.connect(_open_settings)
+        # And a macOS Cmd+, equivalent (some Qt builds need it explicitly).
+        sc2 = QShortcut(QKeySequence("Meta+,"), mw)
+        sc2.setContext(Qt.ShortcutContext.ApplicationShortcut)
+        sc2.activated.connect(_open_settings)
+    except Exception as e:
+        try:
+            from aqt.utils import showWarning
+            showWarning(f"BetterAnki: failed to register settings shortcut: {e}")
+        except Exception:
+            pass
+
+
+gui_hooks.main_window_did_init.append(_add_tools_menu_action)
 
 
 # --------------------------------------------------------------------------- #

--- a/config.json
+++ b/config.json
@@ -1,6 +1,12 @@
 {
+  "theme": "system",
   "accent": "#6c8cff",
+  "sidebar_nav": true,
   "show_heatmap": true,
   "show_progress": true,
-  "heatmap_weeks": 53
+  "hide_bottom_on_decks": true,
+  "hide_bottom_on_overview": true,
+  "heatmap_weeks": 53,
+  "font_serif": "",
+  "font_sans": ""
 }

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,670 @@
+"""BetterAnki — settings dialog.
+
+A native Qt dialog dressed in the same editorial system the rest of the
+add-on uses. Sections in a scrollable column (no tabs), serif headers,
+refined toggles, and a clean accent swatch. Saves to mw.addonManager
+config on every change; CSS/JS updates apply on next render.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+from aqt import mw
+from aqt.qt import (
+    QApplication,
+    QButtonGroup,
+    QCheckBox,
+    QColor,
+    QColorDialog,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPalette,
+    QPushButton,
+    QRadioButton,
+    QScrollArea,
+    QSize,
+    QSpinBox,
+    Qt,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+ADDON = __name__.split(".")[0]
+
+
+# --------------------------------------------------------------------------- #
+# Palettes
+# --------------------------------------------------------------------------- #
+PAL_DARK: Dict[str, str] = {
+    "paper": "#0b0c0f",
+    "panel": "#15171c",
+    "ink": "#eceae2",
+    "ink_dim": "#9b978a",
+    "ink_faint": "#5d5a51",
+    "line": "rgba(236,234,226,0.10)",
+    "line2": "rgba(236,234,226,0.20)",
+    "hover": "rgba(236,234,226,0.05)",
+}
+PAL_LIGHT: Dict[str, str] = {
+    "paper": "#f6f3ec",
+    "panel": "#fbf9f3",
+    "ink": "#1f1d18",
+    "ink_dim": "#6a6557",
+    "ink_faint": "#a39d8b",
+    "line": "rgba(31,29,24,0.10)",
+    "line2": "rgba(31,29,24,0.22)",
+    "hover": "rgba(31,29,24,0.04)",
+}
+
+
+def _resolve_palette() -> Tuple[Dict[str, str], bool]:
+    """Pick dark or light to match the user's theme preference (which itself
+    falls back to the OS appearance when set to "system")."""
+    cfg = mw.addonManager.getConfig(ADDON) or {}
+    pref = cfg.get("theme", "system")
+    if pref == "dark":
+        return PAL_DARK, True
+    if pref == "light":
+        return PAL_LIGHT, False
+    # "system" — inspect Qt's palette.
+    try:
+        c = QApplication.palette().color(QPalette.ColorRole.Window)
+        is_dark = (c.red() + c.green() + c.blue()) < 384
+        return (PAL_DARK if is_dark else PAL_LIGHT), is_dark
+    except Exception:
+        return PAL_DARK, True
+
+
+SERIF = '"New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif'
+SANS = '"SF Pro Text", "Helvetica Neue", "Segoe UI", system-ui, sans-serif'
+
+
+def _qss(p: Dict[str, str], accent: str) -> str:
+    return f"""
+QDialog, QScrollArea, QWidget#root, QWidget#content {{
+    background: {p['paper']};
+    color: {p['ink']};
+    font-family: {SANS};
+}}
+QScrollArea {{ border: 0; }}
+QScrollBar:vertical {{
+    background: transparent;
+    width: 10px;
+    margin: 4px 0;
+}}
+QScrollBar::handle:vertical {{
+    background: {p['line2']};
+    border-radius: 5px;
+    min-height: 30px;
+}}
+QScrollBar::handle:vertical:hover {{ background: {p['ink_faint']}; }}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+
+QLabel {{
+    color: {p['ink']};
+    font-family: {SANS};
+    font-size: 12pt;
+    background: transparent;
+}}
+QLabel[role="title"] {{
+    font-family: {SERIF};
+    font-size: 22pt;
+    font-weight: 500;
+    letter-spacing: -0.5px;
+    padding: 0 0 4px 0;
+    color: {p['ink']};
+}}
+QLabel[role="subtitle"] {{
+    font-size: 10pt;
+    color: {p['ink_dim']};
+    padding-bottom: 6px;
+}}
+QLabel[role="section"] {{
+    font-family: {SANS};
+    font-size: 9pt;
+    font-weight: 600;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: {p['ink_faint']};
+    padding-top: 22px;
+    padding-bottom: 4px;
+}}
+QLabel[role="field"] {{
+    color: {p['ink_dim']};
+    font-size: 11pt;
+}}
+QLabel[role="hint"] {{
+    color: {p['ink_faint']};
+    font-size: 10pt;
+    font-style: italic;
+    font-family: {SERIF};
+}}
+QFrame[role="rule"] {{
+    background: {p['line']};
+    max-height: 1px;
+    min-height: 1px;
+    border: 0;
+}}
+
+QCheckBox {{
+    color: {p['ink']};
+    spacing: 12px;
+    font-size: 11.5pt;
+    padding: 4px 0;
+}}
+QCheckBox::indicator {{
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    border: 1px solid {p['line2']};
+    background: {p['panel']};
+}}
+QCheckBox::indicator:hover {{
+    border-color: {p['ink_faint']};
+}}
+QCheckBox::indicator:checked {{
+    background: {accent};
+    border-color: {accent};
+    /* white check via a data: SVG so the indicator is obviously "on" — a
+       plain accent fill alone reads as "indeterminate" to many users. */
+    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2.6' stroke-linecap='round' stroke-linejoin='round'><polyline points='3,8 7,12 13,4'/></svg>");
+}}
+QCheckBox::indicator:disabled {{
+    background: {p['hover']};
+    border-color: {p['line']};
+}}
+
+QRadioButton {{
+    color: {p['ink']};
+    spacing: 10px;
+    font-size: 11.5pt;
+    padding: 3px 0;
+}}
+QRadioButton::indicator {{
+    width: 16px;
+    height: 16px;
+    border-radius: 8px;
+    border: 1px solid {p['line2']};
+    background: {p['panel']};
+}}
+QRadioButton::indicator:hover {{ border-color: {p['ink_faint']}; }}
+QRadioButton::indicator:checked {{
+    border: 5px solid {accent};
+    background: {p['paper']};
+}}
+
+QPushButton {{
+    background: transparent;
+    color: {p['ink_dim']};
+    border: 1px solid {p['line2']};
+    border-radius: 8px;
+    padding: 8px 16px;
+    font-size: 11pt;
+    font-weight: 500;
+}}
+QPushButton:hover {{
+    color: {p['ink']};
+    background: {p['hover']};
+    border-color: {p['ink_faint']};
+}}
+QPushButton#primary {{
+    color: white;
+    background: {accent};
+    border: 1px solid {accent};
+}}
+QPushButton#primary:hover {{
+    /* darken accent a touch on hover so it actually reads as interactive */
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 {accent}, stop:1 {accent});
+    color: white;
+    border-color: {accent};
+}}
+QPushButton#primary:pressed {{ background: {accent}; }}
+
+QSpinBox, QLineEdit {{
+    background: {p['panel']};
+    color: {p['ink']};
+    border: 1px solid {p['line2']};
+    border-radius: 7px;
+    padding: 7px 10px;
+    font-size: 11.5pt;
+    selection-background-color: {accent};
+}}
+QSpinBox:focus, QLineEdit:focus {{
+    border-color: {accent};
+    outline: none;
+}}
+/* Compact, visible spin buttons — were hidden, which made the control feel
+   broken. Show small up/down chevrons in the dim ink color. */
+QSpinBox {{ padding-right: 22px; }}
+QSpinBox::up-button {{
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width: 18px;
+    border: 0;
+    background: transparent;
+}}
+QSpinBox::down-button {{
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 18px;
+    border: 0;
+    background: transparent;
+}}
+QSpinBox::up-arrow {{
+    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239b978a' stroke-width='1.6' stroke-linecap='round'><polyline points='3,7 6,4 9,7'/></svg>");
+    width: 10px; height: 6px;
+}}
+QSpinBox::down-arrow {{
+    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239b978a' stroke-width='1.6' stroke-linecap='round'><polyline points='3,5 6,8 9,5'/></svg>");
+    width: 10px; height: 6px;
+}}
+
+QLineEdit[placeholderText] {{ color: {p['ink_faint']}; }}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+class ColorSwatch(QPushButton):
+    """A 56×30 swatch button that opens the system color picker."""
+
+    def __init__(self, color: str, on_change, parent=None):
+        super().__init__(parent)
+        self._color = color
+        self._on_change = on_change
+        self.setFixedSize(QSize(56, 30))
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._restyle()
+        self.clicked.connect(self._pick)
+
+    def value(self) -> str:
+        return self._color
+
+    def _restyle(self):
+        self.setStyleSheet(
+            f"QPushButton {{ background: {self._color};"
+            f" border: 1px solid rgba(255,255,255,0.15); border-radius: 7px; }}"
+        )
+
+    def _pick(self):
+        c = QColorDialog.getColor(QColor(self._color), self, "Choose accent")
+        if c.isValid():
+            self._color = c.name()
+            self._restyle()
+            self._on_change(self._color)
+
+
+def _hrule(palette: Dict[str, str]) -> QFrame:
+    f = QFrame()
+    f.setProperty("role", "rule")
+    f.setFrameShape(QFrame.Shape.HLine)
+    f.setStyleSheet(f"QFrame {{ background: {palette['line']}; }}")
+    f.setFixedHeight(1)
+    return f
+
+
+def _section_label(text: str) -> QLabel:
+    lbl = QLabel(text)
+    lbl.setProperty("role", "section")
+    return lbl
+
+
+def _field_row(label_text: str, widget: QWidget,
+               hint: Optional[str] = None) -> QWidget:
+    """A `Label  ───  Control` row, vertically aligned, with optional hint."""
+    container = QWidget()
+    v = QVBoxLayout(container)
+    v.setContentsMargins(0, 4, 0, 4)
+    v.setSpacing(4)
+    top = QHBoxLayout()
+    top.setContentsMargins(0, 0, 0, 0)
+    top.setSpacing(12)
+    lbl = QLabel(label_text)
+    lbl.setProperty("role", "field")
+    lbl.setMinimumWidth(160)
+    top.addWidget(lbl)
+    top.addStretch(1)
+    top.addWidget(widget, 0, Qt.AlignmentFlag.AlignRight)
+    v.addLayout(top)
+    if hint:
+        h = QLabel(hint)
+        h.setProperty("role", "hint")
+        h.setWordWrap(True)
+        v.addWidget(h)
+    return container
+
+
+# --------------------------------------------------------------------------- #
+# Dialog
+# --------------------------------------------------------------------------- #
+class SettingsDialog(QDialog):
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("BetterAnki — Settings")
+        self.setMinimumSize(QSize(560, 640))
+        self.setObjectName("root")
+        self._cfg: Dict[str, Any] = mw.addonManager.getConfig(ADDON) or {}
+        self._palette, _ = _resolve_palette()
+        self._build()
+        self._apply_styles()
+
+    # ----- config helpers ----- #
+    def _g(self, key: str, default: Any) -> Any:
+        v = self._cfg.get(key)
+        return default if v is None else v
+
+    def _set(self, key: str, value: Any) -> None:
+        self._cfg[key] = value
+        try:
+            mw.addonManager.writeConfig(ADDON, self._cfg)
+        except Exception:
+            pass
+        try:
+            state = getattr(mw, "state", "")
+            if state == "deckBrowser":
+                mw.deckBrowser.refresh()
+            elif state == "overview":
+                mw.overview.refresh()
+        except Exception:
+            pass
+
+    # ----- styling ----- #
+    def _apply_styles(self) -> None:
+        accent = self._g("accent", "#6c8cff")
+        self.setStyleSheet(_qss(self._palette, accent))
+
+    # ----- ui ----- #
+    def _build(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        # Scrollable content
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        outer.addWidget(scroll, 1)
+
+        content = QWidget()
+        content.setObjectName("content")
+        scroll.setWidget(content)
+
+        v = QVBoxLayout(content)
+        v.setContentsMargins(36, 30, 36, 22)
+        v.setSpacing(6)
+
+        # Title
+        title = QLabel("Settings")
+        title.setProperty("role", "title")
+        v.addWidget(title)
+        subtitle = QLabel("BetterAnki preferences — saved as you change them.")
+        subtitle.setProperty("role", "subtitle")
+        v.addWidget(subtitle)
+        v.addSpacing(10)
+        v.addWidget(_hrule(self._palette))
+
+        # ----- Appearance ----- #
+        v.addWidget(_section_label("Appearance"))
+
+        # Theme radio group
+        self._theme_group = QButtonGroup(self)
+        theme_box = QWidget()
+        tb = QVBoxLayout(theme_box)
+        tb.setContentsMargins(0, 0, 0, 0)
+        tb.setSpacing(2)
+        current = self._g("theme", "system")
+        for value, label in [
+            ("system", "System (follow OS appearance)"),
+            ("light", "Light"),
+            ("dark", "Dark"),
+        ]:
+            rb = QRadioButton(label)
+            rb.setChecked(current == value)
+            self._theme_group.addButton(rb)
+            rb.toggled.connect(
+                lambda checked, val=value: checked and self._theme_changed(val)
+            )
+            tb.addWidget(rb)
+        v.addWidget(_field_row("Theme", theme_box))
+
+        # Accent
+        self._accent_btn = ColorSwatch(
+            self._g("accent", "#6c8cff"),
+            lambda c: (self._set("accent", c), self._apply_styles()),
+        )
+        v.addWidget(_field_row(
+            "Accent",
+            self._accent_btn,
+            "Recolors links, the streak number, current-deck rule, and the "
+            "primary Study button.",
+        ))
+
+        # ----- Features ----- #
+        v.addWidget(_hrule(self._palette))
+        v.addWidget(_section_label("Features"))
+
+        for key, label, default, hint in [
+            ("sidebar_nav", "Left sidebar navigation", True,
+             "Replaces Anki's top toolbar with the BetterAnki rail."),
+            ("show_heatmap", "Review-activity heatmap", True,
+             "GitHub-style grid of your reviews on the deck homepage."),
+            ("show_progress", "Reviewer progress bar", True,
+             "Thin progress strip at the top of the reviewer."),
+            ("hide_bottom_on_decks", "Hide bottom strip on deck list", True,
+             "Frees the homepage from Anki's legacy bottom bar."),
+            ("hide_bottom_on_overview", "Hide bottom strip on deck overview",
+             True,
+             "Removes the Options / Custom Study / Description row."),
+        ]:
+            cb = QCheckBox(label)
+            cb.setChecked(bool(self._g(key, default)))
+            cb.toggled.connect(
+                lambda checked, k=key: self._set(k, bool(checked))
+            )
+            row = QVBoxLayout()
+            row.setContentsMargins(0, 0, 0, 0)
+            row.setSpacing(0)
+            wrap = QWidget()
+            wrap.setLayout(row)
+            row.addWidget(cb)
+            h = QLabel("    " + hint)
+            h.setProperty("role", "hint")
+            h.setWordWrap(True)
+            h.setContentsMargins(28, 0, 0, 6)
+            row.addWidget(h)
+            v.addWidget(wrap)
+
+        # ----- Heatmap ----- #
+        v.addWidget(_hrule(self._palette))
+        v.addWidget(_section_label("Heatmap"))
+
+        weeks = QSpinBox()
+        weeks.setRange(8, 260)
+        weeks.setSingleStep(1)
+        weeks.setValue(int(self._g("heatmap_weeks", 53)))
+        weeks.setFixedWidth(96)
+        weeks.valueChanged.connect(
+            lambda val: self._set("heatmap_weeks", int(val))
+        )
+        v.addWidget(_field_row(
+            "Minimum weeks shown",
+            weeks,
+            "The heatmap always extends back to your first review; never "
+            "renders fewer than this many columns.",
+        ))
+
+        # ----- Typography ----- #
+        v.addWidget(_hrule(self._palette))
+        v.addWidget(_section_label("Typography"))
+
+        serif = QLineEdit(self._g("font_serif", ""))
+        serif.setPlaceholderText('e.g. "Iowan Old Style", Georgia')
+        serif.setMinimumWidth(220)
+        serif.editingFinished.connect(
+            lambda: self._set("font_serif", serif.text().strip())
+        )
+        v.addWidget(_field_row(
+            "Display serif", serif,
+            "Prepended to the existing serif stack. Headings, deck names. "
+            "Leave blank for the system default.",
+        ))
+
+        sans = QLineEdit(self._g("font_sans", ""))
+        sans.setPlaceholderText('e.g. "Inter", "SF Pro Text"')
+        sans.setMinimumWidth(220)
+        sans.editingFinished.connect(
+            lambda: self._set("font_sans", sans.text().strip())
+        )
+        v.addWidget(_field_row(
+            "Body sans", sans,
+            "Prepended to the existing sans stack. Labels, counts, UI.",
+        ))
+
+        # ----- Anki — surfaces native Anki dialogs we couldn't merge inline ----- #
+        v.addWidget(_hrule(self._palette))
+        v.addWidget(_section_label("Anki"))
+
+        def _open(fn, *args):
+            """Close our dialog then call fn(*args). Anki dialogs can't be
+            modal-stacked nicely; close-then-open keeps focus sane."""
+            def go():
+                try:
+                    self.accept()
+                except Exception:
+                    pass
+                try:
+                    fn(*args)
+                except Exception:
+                    pass
+            return go
+
+        def native_btn(label: str, hint: str, callback) -> QWidget:
+            wrap = QWidget()
+            row = QVBoxLayout(wrap)
+            row.setContentsMargins(0, 0, 0, 0)
+            row.setSpacing(2)
+            b = QPushButton(label + "  →")
+            b.setCursor(Qt.CursorShape.PointingHandCursor)
+            b.clicked.connect(callback)
+            b.setStyleSheet("text-align: left;")
+            row.addWidget(b)
+            h = QLabel("    " + hint)
+            h.setProperty("role", "hint")
+            h.setWordWrap(True)
+            row.addWidget(h)
+            return wrap
+
+        v.addWidget(native_btn(
+            "Open Anki Preferences",
+            "The standard Anki preferences dialog (review settings, sync, "
+            "appearance, etc.).",
+            _open(mw.onPrefs),
+        ))
+
+        def _open_current_deck_opts():
+            try:
+                from aqt.deckoptions import display_options_for_deck_id
+                from anki.decks import DeckId
+                did = DeckId(int(mw.col.decks.get_current_id()))
+                self.accept()
+                display_options_for_deck_id(did)
+            except Exception:
+                pass
+
+        v.addWidget(native_btn(
+            "Open deck options",
+            "Configure the current deck's review settings, new-card limits, "
+            "FSRS parameters, etc.",
+            _open_current_deck_opts,
+        ))
+
+        v.addWidget(native_btn(
+            "Manage note types",
+            "Add, edit, and delete note types (card templates).",
+            _open(mw.onNoteTypes),
+        ))
+
+        v.addWidget(native_btn(
+            "Open add-ons",
+            "Manage installed add-ons.",
+            _open(mw.addonManager.onAddonsDialog),
+        ))
+
+        v.addSpacing(20)
+        v.addStretch(1)
+
+        # ----- Footer (sticky) ----- #
+        footer = QWidget()
+        footer.setObjectName("root")
+        f = QHBoxLayout(footer)
+        f.setContentsMargins(36, 14, 36, 18)
+        f.setSpacing(10)
+        restore = QPushButton("Restore defaults")
+        restore.clicked.connect(self._restore_defaults)
+        close_btn = QPushButton("Close")
+        close_btn.setObjectName("primary")
+        close_btn.clicked.connect(self.accept)
+        f.addWidget(restore)
+        f.addStretch(1)
+        f.addWidget(close_btn)
+
+        outer.addWidget(_hrule(self._palette))
+        outer.addWidget(footer)
+
+    # ----- handlers ----- #
+    def _theme_changed(self, value: str) -> None:
+        self._set("theme", value)
+        # Re-resolve the dialog palette so the dialog itself reflects the
+        # new choice immediately (Light ↔ Dark switch is live).
+        self._palette, _ = _resolve_palette()
+        self._apply_styles()
+
+    def _restore_defaults(self) -> None:
+        defaults = {
+            "theme": "system",
+            "accent": "#6c8cff",
+            "sidebar_nav": True,
+            "show_heatmap": True,
+            "show_progress": True,
+            "hide_bottom_on_decks": True,
+            "hide_bottom_on_overview": True,
+            "heatmap_weeks": 53,
+            "font_serif": "",
+            "font_sans": "",
+        }
+        self._cfg = defaults
+        try:
+            mw.addonManager.writeConfig(ADDON, defaults)
+        except Exception:
+            pass
+        # Re-render the deck browser with defaults; rebuild the dialog so the
+        # widgets reflect the new state. The dialog stays open.
+        try:
+            state = getattr(mw, "state", "")
+            if state == "deckBrowser":
+                mw.deckBrowser.refresh()
+        except Exception:
+            pass
+        # Rebuild the dialog in-place so radio/checkbox/swatch states reset.
+        try:
+            # Clear all children from the dialog
+            for child in self.findChildren(QWidget):
+                child.deleteLater()
+            old_layout = self.layout()
+            if old_layout is not None:
+                QWidget().setLayout(old_layout)
+        except Exception:
+            pass
+        self._palette, _ = _resolve_palette()
+        self._build()
+        self._apply_styles()
+
+
+def open_settings(parent: Any = None) -> None:
+    dlg = SettingsDialog(parent or mw)
+    dlg.exec()

--- a/web/heatmap.css
+++ b/web/heatmap.css
@@ -2,7 +2,7 @@
 
 .rf-heatmap {
   margin: 28px auto 8px;
-  max-width: 760px;
+  max-width: 860px;
   background: var(--rf-surface, #171a21);
   border: 1px solid var(--rf-border, #272b36);
   border-radius: var(--rf-radius, 12px);
@@ -14,19 +14,72 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 .rf-hm-title { font-weight: 700; font-size: 14px; }
 .rf-hm-stats { color: var(--rf-text-dim, #9aa0ad); font-size: 12px; }
 .rf-hm-stats b { color: var(--rf-text, #e6e8ee); }
 
-.rf-hm-grid {
+/* body = fixed weekday gutter + a horizontally scrolling calendar */
+.rf-hm-body { display: flex; align-items: flex-start; }
+
+.rf-hm-wds {
   display: flex;
-  gap: 3px;
-  overflow-x: auto;
-  padding-bottom: 4px;
+  flex-direction: column;
+  flex: none;
+  margin-right: 6px;
+  font-size: 9px;
+  color: var(--rf-text-dim, #9aa0ad);
 }
-.rf-hm-col { display: flex; flex-direction: column; gap: 3px; }
+.rf-hm-mon-spacer { height: 20px; flex: none; } /* aligns with months row */
+.rf-hm-wd {
+  flex: none;
+  height: 11px;
+  margin-bottom: 3px;
+  line-height: 11px;
+  text-align: right;
+}
+.rf-hm-wd:last-child { margin-bottom: 0; }
+
+.rf-hm-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 2px;
+  scroll-behavior: smooth;
+  scrollbar-width: none;             /* hidden by default */
+  scrollbar-color: var(--rf-border, #3a4150) transparent;
+}
+.rf-hm-scroll::-webkit-scrollbar { height: 0; width: 0; }
+.rf-hm-scroll:hover { scrollbar-width: thin; }
+.rf-hm-scroll:hover::-webkit-scrollbar { height: 6px; }
+.rf-hm-scroll::-webkit-scrollbar-track { background: transparent; }
+.rf-hm-scroll::-webkit-scrollbar-thumb {
+  background: var(--rf-border, #3a4150);
+  border-radius: 4px;
+}
+.rf-hm-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--rf-text-dim, #5a6172);
+}
+
+.rf-hm-months {
+  display: flex;
+  height: 15px;
+  margin-bottom: 5px;
+  font-size: 10px;
+  color: var(--rf-text-dim, #9aa0ad);
+}
+.rf-hm-mon { flex: none; white-space: nowrap; line-height: 15px; }
+
+.rf-hm-grid { display: flex; }
+.rf-hm-col {
+  display: flex;
+  flex-direction: column;
+  flex: none;          /* keep 11px under overflow so the grid scrolls */
+  width: 11px;
+  margin-right: 3px;
+}
 
 .rf-hm-cell {
   width: 11px;
@@ -34,6 +87,8 @@
   border-radius: 3px;
   background: #20242e;
 }
+.rf-hm-col .rf-hm-cell { flex: none; margin-bottom: 3px; }
+.rf-hm-col .rf-hm-cell:last-child { margin-bottom: 0; }
 .rf-hm-empty { background: transparent; }
 
 .rf-hm-l0 { background: #20242e; }
@@ -42,13 +97,47 @@
 .rf-hm-l3 { background: #4f9ae0; }
 .rf-hm-l4 { background: #7fc4ff; }
 
+.rf-hm-col .rf-hm-cell:not(.rf-hm-empty) { cursor: pointer; }
+.rf-hm-col .rf-hm-cell:not(.rf-hm-empty):hover {
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 0 0 1.5px var(--rf-text, #e6e8ee);
+}
+
 .rf-hm-foot {
   display: flex;
   align-items: center;
   gap: 4px;
   justify-content: flex-end;
-  margin-top: 10px;
+  margin-top: 12px;
   font-size: 11px;
   color: var(--rf-text-dim, #9aa0ad);
 }
 .rf-hm-foot .rf-hm-cell { width: 10px; height: 10px; }
+
+/* custom instant tooltip (replaces the slow native title) */
+.rf-hm-tip {
+  position: fixed;
+  z-index: 99999;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: opacity .06s linear, transform .06s linear;
+  background: var(--rf-bg, #0f1217);
+  border: 1px solid var(--rf-border, #2c3340);
+  border-radius: 8px;
+  padding: 8px 11px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .45);
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+.rf-hm-tip.show { opacity: 1; transform: translateY(0); }
+.rf-hm-tip-n {
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--rf-text, #e6e8ee);
+}
+.rf-hm-tip-d { color: var(--rf-text-dim, #9aa0ad); margin-top: 1px; }
+.rf-hm-tip-rel { color: var(--rf-accent, #6c8cff); font-weight: 600; }
+.rf-hm-tip-peak { color: #f0a93b; margin-top: 3px; font-size: 11px; }

--- a/web/heatmap.js
+++ b/web/heatmap.js
@@ -1,0 +1,155 @@
+/* BetterAnki — heatmap behavior: open on the newest activity (scrolled fully
+   right, so the latest days are never cropped), and an instant custom tooltip
+   in place of the slow native `title`. Pure progressive enhancement: if this
+   never runs the grid is still a valid static heatmap. */
+(function () {
+  "use strict";
+
+  var TIP_ID = "rf-hm-tip";
+  // Per-scroll-element guard; survives deck-browser re-renders (new node = new
+  // init) without rebinding the same element twice.
+  var seen = (window.__betterankiHM = window.__betterankiHM || new WeakSet());
+
+  function tipEl() {
+    var t = document.getElementById(TIP_ID);
+    if (!t) {
+      t = document.createElement("div");
+      t.id = TIP_ID;
+      t.className = "rf-hm-tip";
+      document.body.appendChild(t);
+    }
+    return t;
+  }
+
+  function countText(n) {
+    if (n <= 0) return "No reviews";
+    return n === 1 ? "1 review" : n + " reviews";
+  }
+
+  function showTip(cell) {
+    var n = parseInt(cell.getAttribute("data-count") || "0", 10) || 0;
+    var human = cell.getAttribute("data-human") || "";
+    var rel = cell.getAttribute("data-rel") || "";
+    var peak = cell.getAttribute("data-peak") === "1";
+
+    var html =
+      '<div class="rf-hm-tip-n">' + countText(n) + "</div>" +
+      '<div class="rf-hm-tip-d">' + human +
+      (rel ? ' &middot; <span class="rf-hm-tip-rel">' + rel + "</span>" : "") +
+      "</div>";
+    if (peak && n > 0)
+      html += '<div class="rf-hm-tip-peak">★ Best day so far</div>';
+
+    var t = tipEl();
+    t.innerHTML = html;
+    t.classList.add("show");
+
+    // Measure, then place centered above the cell, clamped to the viewport.
+    var r = cell.getBoundingClientRect();
+    var tw = t.offsetWidth;
+    var th = t.offsetHeight;
+    var left = r.left + r.width / 2 - tw / 2;
+    var top = r.top - th - 8;
+    if (top < 4) top = r.bottom + 8; // flip below near the top edge
+    left = Math.max(4, Math.min(left, window.innerWidth - tw - 4));
+    t.style.left = Math.round(left) + "px";
+    t.style.top = Math.round(top) + "px";
+  }
+
+  function hideTip() {
+    var t = document.getElementById(TIP_ID);
+    if (t) t.classList.remove("show");
+  }
+
+  function onOver(e) {
+    var cell = e.target && e.target.closest
+      ? e.target.closest(".rf-hm-cell")
+      : null;
+    if (!cell || cell.classList.contains("rf-hm-empty")) {
+      hideTip();
+      return;
+    }
+    showTip(cell);
+  }
+
+  function onOut(e) {
+    var to = e.relatedTarget;
+    if (to && to.closest && to.closest(".rf-hm-cell:not(.rf-hm-empty)")) return;
+    hideTip();
+  }
+
+  function init(scroll) {
+    if (!scroll || seen.has(scroll)) return;
+    seen.add(scroll);
+
+    // Default view = newest activity. scrollLeft auto-clamps to the max, so
+    // assigning a huge value parks today flush at the right edge. Retried
+    // because column widths settle a frame or two after first paint.
+    var atRight = true;       // user-controlled: have they scrolled away?
+    var userScrolled = false;
+    var toRight = function () {
+      scroll.scrollLeft = scroll.scrollWidth;
+    };
+    toRight();
+    requestAnimationFrame(toRight);
+    setTimeout(toRight, 60);
+    setTimeout(toRight, 250);
+
+    // Track whether the user has scrolled left themselves. Once they have,
+    // resize won't snap them back — we respect their position.
+    var userInitiated = false;
+    scroll.addEventListener("scroll", function () {
+      hideTip();
+      if (userInitiated) {
+        var maxLeft = scroll.scrollWidth - scroll.clientWidth;
+        atRight = (maxLeft - scroll.scrollLeft) < 4;
+      }
+    }, { passive: true });
+    // Distinguish programmatic scrolls from user scrolls.
+    scroll.addEventListener("wheel", function () { userInitiated = true; }, { passive: true });
+    scroll.addEventListener("touchstart", function () { userInitiated = true; }, { passive: true });
+    scroll.addEventListener("pointerdown", function () { userInitiated = true; }, { passive: true });
+
+    // On window resize, if the user hadn't scrolled away from "today", snap
+    // back to the right edge. Today should stay visible when the window
+    // narrows.
+    function onResize() {
+      if (atRight) toRight();
+    }
+    window.addEventListener("resize", onResize, { passive: true });
+
+    // ResizeObserver catches sidebar-width-driven changes too (the heatmap's
+    // own clientWidth changes without a window resize when content reflows).
+    try {
+      new ResizeObserver(function () {
+        if (atRight) toRight();
+      }).observe(scroll);
+    } catch (e) {}
+
+    scroll.addEventListener("mouseover", onOver);
+    scroll.addEventListener("mouseout", onOut);
+  }
+
+  function scan() {
+    var els = document.querySelectorAll(".rf-hm-scroll");
+    for (var i = 0; i < els.length; i++) init(els[i]);
+  }
+
+  if (document.readyState !== "loading") scan();
+  document.addEventListener("DOMContentLoaded", scan);
+  window.addEventListener("load", scan);
+
+  // The deck browser re-renders its content (and the dev watcher hot-reloads
+  // it); re-scan when the DOM changes, debounced to one check per frame.
+  var pending = false;
+  try {
+    new MutationObserver(function () {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(function () {
+        pending = false;
+        scan();
+      });
+    }).observe(document.documentElement, { childList: true, subtree: true });
+  } catch (e) {}
+})();

--- a/web/reviewer-bottom.css
+++ b/web/reviewer-bottom.css
@@ -1,0 +1,223 @@
+/* BetterAnki — reviewer bottom bar.
+
+   Anki 25.x DOM (aqt/reviewer.py):
+     <center id=outer>
+       <table id=innertable>
+         <tr>
+           <td.stat>      <button>Edit</button>            ← E
+           <td#middle>    {show-answer | ease buttons}
+           <td.stat>      <button>More ▾<span#time></span></button>  ← M
+   show-answer state injects in #middle:
+     <table><tr><td.stat2><button#ansbut>Show Answer <span.stattxt>{counts}</span></button>
+   ease state injects 2–4 plain <button>s in #middle (one is #defease).
+
+   This stylesheet strips ALL button chrome. The bottom bar reads as quiet
+   typography — a letterspaced "press SPACE" cue for show-answer, and four
+   stat-columns (KEY · LABEL · INTERVAL) for the ease state, matching the
+   numerics language of the homepage hero. */
+
+:root {
+  --rf-paper: #0b0c0f;
+  --rf-ink: #eceae2;
+  --rf-ink-dim: #9b978a;
+  --rf-ink-faint: #5d5a51;
+  --rf-line: rgba(236, 234, 226, 0.10);
+  --rf-line-2: rgba(236, 234, 226, 0.20);
+  --rf-row-hover: rgba(236, 234, 226, 0.05);
+  --rf-due: #79b69b;
+  --rf-new: #8bb0e6;
+  --rf-learn: #d7a76c;
+  --rf-sans: ui-sans-serif, -apple-system, "SF Pro Text", system-ui, sans-serif;
+  --rf-serif: ui-serif, "New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) {
+    --rf-paper: #f6f3ec;
+    --rf-ink: #1f1d18;
+    --rf-ink-dim: #6a6557;
+    --rf-ink-faint: #a39d8b;
+    --rf-line: rgba(31, 29, 24, 0.10);
+    --rf-line-2: rgba(31, 29, 24, 0.22);
+    --rf-row-hover: rgba(31, 29, 24, 0.04);
+    --rf-due: #2f8462;
+    --rf-new: #2f5fb5;
+    --rf-learn: #a05f1e;
+  }
+}
+
+html, body {
+  background: var(--rf-paper) !important;
+  color: var(--rf-ink) !important;
+  font-family: var(--rf-sans) !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+/* Outer / table layout */
+#outer {
+  width: 100%;
+  padding: 18px 26px 22px !important;
+  box-sizing: border-box;
+}
+#innertable {
+  border: 0 !important;
+  background: transparent !important;
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  width: 100% !important;
+}
+#innertable td {
+  border: 0 !important;
+  padding: 0 !important;
+  vertical-align: middle !important;
+}
+#innertable td.stat {
+  width: 1%;
+  white-space: nowrap;
+  vertical-align: middle !important;
+}
+#middle {
+  text-align: center;
+}
+#middle table {
+  margin: 0 auto !important;
+  border-collapse: collapse !important;
+  width: auto !important;
+}
+#middle table td { padding: 0 !important; }
+/* Only the ease-state tds get the counter; the show-answer state wraps its
+   button in a td.stat2 which we exclude. */
+#middle table tr td:not(.stat2) { counter-increment: ba-ease; }
+
+/* Reset: kill all the default button chrome — we use pure typography. */
+button {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 8px !important;
+  padding: 8px 12px !important;
+  margin: 0 !important;
+  color: var(--rf-ink-dim) !important;
+  font: 500 11.5px/1 var(--rf-sans) !important;
+  letter-spacing: 0.06em !important;
+  cursor: pointer !important;
+  box-shadow: none !important;
+  outline: none !important;
+  transition: color 160ms ease, background 160ms ease !important;
+}
+button:hover {
+  color: var(--rf-ink) !important;
+  background: var(--rf-row-hover) !important;
+}
+button:active { transform: translateY(1px) !important; }
+
+/* Edit / More — quietly tucked in the corners */
+button[onclick*="'edit'"],
+button[onclick*="'more'"] {
+  font: 500 10.5px/1 var(--rf-sans) !important;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase !important;
+  color: var(--rf-ink-faint) !important;
+  padding: 8px 10px !important;
+}
+button[onclick*="'edit'"]:hover,
+button[onclick*="'more'"]:hover { color: var(--rf-ink-dim) !important; }
+.stattxt {
+  color: var(--rf-ink-faint) !important;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ===== SHOW ANSWER — pure typography, no button =====
+   Stack: a letterspaced label + the colored count summary below. */
+#outer button#ansbut,
+button#ansbut {
+  display: inline-flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  gap: 7px !important;
+  padding: 10px 18px !important;
+  background: transparent !important;
+  color: var(--rf-ink) !important;
+  font: 600 13px/1 var(--rf-sans) !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.32em !important;
+  border-radius: 10px !important;
+}
+button#ansbut:hover { color: var(--rf-accent, #6c8cff) !important; background: transparent !important; }
+button#ansbut .stattxt {
+  display: block;
+  font: 500 11.5px/1 var(--rf-sans) !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  color: var(--rf-ink-faint) !important;
+  margin: 0 !important;
+}
+button#ansbut .new-count   { color: var(--rf-new)   !important; font-weight: 600; }
+button#ansbut .learn-count { color: var(--rf-learn) !important; font-weight: 600; }
+button#ansbut .review-count{ color: var(--rf-due)   !important; font-weight: 600; }
+button#ansbut u { text-decoration: none; font-weight: 700; color: var(--rf-ink) !important; }
+
+/* ===== EASE BUTTONS — four stat columns =====
+   Each <button> becomes: KEY NUMBER (big) · LABEL (uppercase) · INTERVAL (dim).
+   The key counter (1/2/3/4) is injected with CSS counter-increment so it
+   shows the user's keyboard shortcut, not the label.
+
+   Hover: subtle background tint + key in accent.
+   Default ease (#defease, usually Good): key is in accent by default. */
+#middle table { counter-reset: ba-ease 0; }
+#outer #middle table tr td button,
+#middle table tr td button {
+  display: inline-flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  gap: 8px !important;
+  min-width: 90px !important;
+  padding: 12px 14px !important;
+  background: transparent !important;
+  color: var(--rf-ink-dim) !important;
+  font: 600 10px/1 var(--rf-sans) !important;
+  letter-spacing: 0.18em !important;
+  text-transform: uppercase !important;
+  border-radius: 10px !important;
+  margin: 0 6px !important;
+  position: relative;
+}
+/* Inject the key number above the label — only for ease buttons (non-stat2) */
+#middle table tr td:not(.stat2) button::before {
+  content: counter(ba-ease);
+  display: block;
+  font: 500 26px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.025em;
+  color: var(--rf-ink);
+  text-transform: none;
+  margin-bottom: 2px;
+}
+#middle table tr td button:hover {
+  background: var(--rf-row-hover) !important;
+  color: var(--rf-ink) !important;
+}
+#middle table tr td button:hover::before {
+  color: var(--rf-accent, #6c8cff);
+}
+/* Real Anki uses .nobold inside ease buttons for the interval; .stattxt
+   on the show-answer button for the count summary. Style both. */
+#middle table tr td button .nobold,
+#middle table tr td button .stattxt {
+  display: block;
+  font: 500 10px/1 var(--rf-sans) !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.04em !important;
+  text-transform: none !important;
+  color: var(--rf-ink-faint) !important;
+  margin: 0 !important;
+}
+
+/* Default ease — the key number is accent, signaling Enter would pick it. */
+#outer #middle button#defease,
+button#defease { color: var(--rf-ink) !important; }
+#outer #middle button#defease::before,
+button#defease::before { color: var(--rf-accent, #6c8cff); }
+#outer #middle button#defease:hover,
+button#defease:hover { background: var(--rf-row-hover) !important; }

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -1,29 +1,125 @@
-/* BetterAnki — reviewer progress bar.
-   Kept deliberately minimal so it never fights with user note styling. */
+/* BetterAnki — reviewer card-area chrome.
+   We don't touch card content (user note types are sacred), but we own the
+   surrounding chrome: page background, body typography, the answer divider,
+   the top progress strip, and the small back affordance. */
 
+html, body {
+  background: var(--rf-paper, #0b0c0f) !important;
+  color: var(--rf-ink, #eceae2) !important;
+}
+/* Anki sets `<body class="card cardN">` on the reviewer. We center the
+   reading column by giving body symmetric padding via calc — viewports
+   ≥ 784px get an auto-centered 720px column; narrower viewports collapse
+   to a 32px gutter. Doing this on body (instead of a wrapper) means we
+   don't need to modify Anki's reviewer DOM, and the back-button (fixed)
+   and progress strip (fixed) aren't affected. */
+body {
+  font-family: var(--rf-sans, ui-sans-serif, -apple-system, system-ui, sans-serif);
+  padding-top: 56px !important;
+  padding-bottom: 84px !important;
+  padding-left: max(32px, calc((100% - 720px) / 2)) !important;
+  padding-right: max(32px, calc((100% - 720px) / 2)) !important;
+  margin: 0 !important;
+  line-height: 1.55;
+  text-align: center;
+  font-size: 18px;
+}
+
+/* `<body class="card">` would otherwise inherit our generic `.card` rule
+   below — make sure body never gets its own max-width / centering. */
+body.card {
+  max-width: none !important;
+}
+
+/* Generic .card rules — apply to a card wrapper if the user's template uses
+   one, but NOT to body (handled above). */
+:not(body).card {
+  max-width: 720px;
+  margin: 0 auto;
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--rf-ink, #eceae2);
+}
+
+/* The answer divider — Anki ships <hr id=answer>. Render as a hairline
+   with a centred "ANSWER" caption that visually breaks the line. The
+   caption sits in a paper-colored chip so the line appears to interrupt
+   around it. */
+#answer {
+  border: 0;
+  position: relative;
+  height: 1px;
+  background: var(--rf-line, rgba(127, 127, 127, 0.18));
+  margin: 38px auto 28px;
+  max-width: 720px;
+  overflow: visible;
+}
+#answer::after {
+  content: "Answer";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--rf-paper, #0b0c0f);
+  padding: 0 14px;
+  color: var(--rf-ink-faint, #5d5a51);
+  font: 600 9.5px/1 var(--rf-sans, system-ui, sans-serif);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+/* Progress strip across the top — accent only. No floating "X/Y" label. */
 #reforge-progress {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  height: 4px;
-  background: rgba(255, 255, 255, 0.06);
+  height: 3px;
+  background: var(--rf-line, rgba(255, 255, 255, 0.06));
   z-index: 9999;
+  pointer-events: none;
 }
-
 #reforge-progress-fill {
   height: 100%;
   width: 0%;
   background: var(--rf-accent, #6c8cff);
-  transition: width 0.25s ease;
+  transition: width 220ms cubic-bezier(.2, .7, .2, 1);
 }
+/* The progress-remaining text was visually noisy + redundant with the
+   counts in the bottom bar. Hide it. */
+#reforge-progress-label { display: none !important; }
 
-#reforge-progress-label {
-  position: fixed;
-  top: 8px;
-  right: 12px;
-  font: 600 11px/1 var(--rf-font, system-ui, sans-serif);
-  color: var(--rf-text-dim, #9aa0ad);
-  z-index: 9999;
-  pointer-events: none;
+/* Back-to-decks affordance — small chevron + "Decks" always visible. Stable
+   geometry (no width changes) so hover never feels jumpy. Only color +
+   opacity respond to hover. */
+.ba-back {
+  position: fixed !important;
+  top: 12px !important;
+  left: 16px !important;
+  z-index: 200 !important;
+  display: inline-flex !important;
+  align-items: center;
+  gap: 6px;
+  background: transparent !important;
+  border: 0 !important;
+  padding: 7px 12px 7px 8px !important;
+  border-radius: 999px !important;
+  font: 500 11.5px/1 var(--rf-sans, system-ui, sans-serif) !important;
+  letter-spacing: 0.04em !important;
+  color: var(--rf-ink-faint, #5d5a51) !important;
+  cursor: pointer !important;
+  opacity: 0.55 !important;
+  transition: opacity 180ms ease, color 180ms ease, background 180ms ease !important;
+}
+.ba-back::before {
+  content: "‹";
+  font-size: 18px;
+  line-height: 1;
+  font-weight: 400;
+  margin-right: 1px;
+}
+.ba-back:hover {
+  opacity: 1 !important;
+  color: var(--rf-ink, #eceae2) !important;
+  background: var(--rf-row-hover, rgba(127, 127, 127, 0.06)) !important;
 }

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -1,0 +1,247 @@
+/* BetterAnki — left sidebar.
+   Vertical layered structure: wordmark · totals · nav · quick · (stretch) ·
+   streak block · footer. Sections separated by subtle rules + breathing
+   space. Standing data is bootstrapped from window.__baStandingData and
+   refreshed via window.__baSetStanding(). */
+
+body.ba-with-side {
+  padding-left: var(--rf-side-w, 264px);
+  box-sizing: border-box;
+}
+
+.ba-side {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--rf-side-w, 264px);
+  background: var(--rf-paper);
+  border-right: 1px solid var(--rf-line);
+  display: flex;
+  flex-direction: column;
+  padding: 24px 18px 16px;
+  z-index: 50;
+  font-family: var(--rf-sans);
+  color: var(--rf-ink);
+  -webkit-user-select: none;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.ba-side, .ba-side * {
+  box-sizing: border-box;
+  min-width: 0;
+}
+
+/* Shared rule for between-section breaks. */
+.ba-side-head,
+.ba-side-totals,
+.ba-side-nav,
+.ba-side-quick {
+  border-bottom: 1px solid var(--rf-line);
+  padding-bottom: 16px;
+  margin-bottom: 16px;
+}
+
+/* ---------------------------- WORDMARK ---------------------------- */
+.ba-side-head {
+  padding: 0 4px 18px;
+}
+.ba-side-mark {
+  font: 500 18px/1 var(--rf-serif);
+  letter-spacing: -0.005em;
+  color: var(--rf-ink);
+}
+
+/* ---------------------------- CROSS-DECK TOTALS ---------------------------- */
+/* Hidden in single-deck mode (hero owns the numbers). */
+.ba-side-totals {
+  margin: 0 0 16px 0;
+  padding: 4px 6px 16px;
+  display: grid;
+  gap: 9px;
+}
+.ba-side-totals .ba-side-stat {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.ba-side-totals dt {
+  font: 600 10.5px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-faint);
+  margin: 0;
+}
+.ba-side-totals dd {
+  margin: 0;
+  font: 600 16px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  color: var(--rf-ink);
+}
+.ba-side-stat--due dd   { color: var(--rf-due); }
+.ba-side-stat--new dd   { color: var(--rf-new); }
+.ba-side-stat--learn dd { color: var(--rf-learn); }
+.ba-side.ba-side--single .ba-side-totals {
+  display: none;
+}
+
+/* ---------------------------- NAV / QUICK ---------------------------- */
+.ba-side-nav,
+.ba-side-quick,
+.ba-side-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;             /* slightly more breathing room between rows */
+}
+.ba-side-foot {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--rf-line);
+}
+
+.ba-side-item {
+  -webkit-appearance: none;
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  padding: 10px 12px;        /* more vertical space per item */
+  text-align: left;
+  font: 500 12.5px/1 var(--rf-sans);
+  letter-spacing: 0.005em;
+  color: var(--rf-ink-dim);
+  cursor: pointer;
+  transition: background 200ms ease, color 200ms ease;
+  position: relative;
+}
+.ba-side-item .ba-side-l { flex: 1; }
+.ba-side-icon {
+  flex: none;
+  width: 14px; height: 14px;
+  color: var(--rf-ink-faint);
+  transition: color 200ms ease;
+}
+/* Hover changes ONLY the background — nothing else moves. No text-color
+   change, no icon-color change, no font-weight, no transform. The bg fade
+   alone signals interactivity without any optical weight shift. */
+.ba-side-item:hover {
+  background: var(--rf-row-hover);
+}
+
+.ba-side-item[data-active="true"] {
+  color: var(--rf-ink);
+  background: var(--rf-row-current);
+}
+.ba-side-item[data-active="true"] .ba-side-icon { color: var(--rf-ink); }
+.ba-side-item[data-active="true"]::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 8px; bottom: 8px;
+  width: 2px; border-radius: 2px;
+  background: var(--rf-accent, #6c8cff);
+}
+
+/* Quick actions — slightly lighter weight to read as actions. */
+.ba-side-act {
+  font-size: 12px !important;
+  color: var(--rf-ink-faint) !important;
+}
+.ba-side-act:hover {
+  background: var(--rf-row-hover) !important;
+  color: var(--rf-ink-dim) !important;
+}
+
+/* Streak block + lifetime stats moved out of the sidebar; styles deleted. */
+
+/* ---------------------------- SYNC ---------------------------- */
+.ba-side-item[data-cmd="sync"] .ba-side-dot {
+  width: 6px; height: 6px; border-radius: 999px;
+  background: var(--rf-ink-faint);
+  opacity: 0;
+  transition: opacity 160ms ease, background 160ms ease,
+              transform 160ms ease;
+}
+/* "Pending" (changes to push) — small accent dot */
+.ba-side-item[data-cmd="sync"].ba-sync-pending { color: var(--rf-accent, #6c8cff); }
+.ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-icon { color: var(--rf-accent, #6c8cff); }
+.ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-dot {
+  opacity: 1;
+  background: var(--rf-accent, #6c8cff);
+}
+/* "Full" — warning amber */
+.ba-side-item[data-cmd="sync"].ba-sync-full { color: var(--rf-learn); }
+.ba-side-item[data-cmd="sync"].ba-sync-full  .ba-side-icon { color: var(--rf-learn); }
+.ba-side-item[data-cmd="sync"].ba-sync-full  .ba-side-dot {
+  opacity: 1;
+  background: var(--rf-learn);
+}
+/* Active sync — gentle pulse */
+.ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon {
+  animation: ba-spin 1.4s linear infinite;
+}
+@keyframes ba-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Hover-reveal keyboard chip (absolutely positioned, no layout shift). */
+.ba-side-key {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%) translateX(6px);
+  opacity: 0;
+  pointer-events: none;
+  font: 600 9.5px/1 var(--rf-sans);
+  letter-spacing: 0.06em;
+  color: var(--rf-ink-dim);
+  background: var(--rf-row-current);
+  border: 1px solid var(--rf-line);
+  border-radius: 5px;
+  padding: 3px 6px;
+  text-transform: uppercase;
+  min-width: 18px;
+  text-align: center;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+.ba-side-item:hover .ba-side-key {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* ---------------------------- FLOATING COG ---------------------------- */
+.ba-cog {
+  position: fixed;
+  top: 12px;
+  right: 14px;
+  z-index: 200;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  border: 1px solid var(--rf-line);
+  background: var(--rf-panel);
+  color: var(--rf-ink-dim);
+  font: 400 15px/1 var(--rf-sans);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.55;
+  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.ba-cog:hover {
+  opacity: 1;
+  color: var(--rf-ink);
+  border-color: var(--rf-line-2);
+}
+body.ba-with-side .ba-cog { display: none; }
+
+/* .ba-back styling lives in reviewer.css — it's only used on the reviewer
+   webview, and that's where the relevant base context (paper, ink, line)
+   is set up. */

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -1,0 +1,195 @@
+/* BetterAnki — left sidebar (info + nav).
+   Prepends a <aside class="ba-side"> to <body> on every themed page. The
+   sidebar shows: identity + today's standing (date, streak, due/new/learning)
+   + primary nav + quick actions + sync/settings. Python pushes live data via
+   window.__baSetStanding({...}) after each render. */
+(function () {
+  "use strict";
+  if (window.__betterankiSide) return;
+  window.__betterankiSide = true;
+
+  function send(cmd) {
+    try { if (typeof pycmd === "function") pycmd("ba:" + cmd); } catch (e) {}
+  }
+
+  // ---- icons (inline SVG, stroke uses currentColor) -------------------- //
+  // Lightweight stroke set tuned to feel editorial, not iconographic.
+  var ICONS = {
+    decks:    '<path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 12l9 4 9-4"/><path d="M3 17l9 4 9-4"/>',
+    add:      '<path d="M12 5v14"/><path d="M5 12h14"/>',
+    browse:   '<circle cx="11" cy="11" r="6.5"/><path d="M20 20l-4.3-4.3"/>',
+    stats:    '<path d="M4 19V9"/><path d="M10 19V5"/><path d="M16 19v-8"/><path d="M22 19h-22"/>',
+    create:   '<path d="M12 5v14"/><path d="M5 12h14"/>',
+    "import": '<path d="M12 4v12"/><path d="M6 10l6-6 6 6"/><path d="M4 20h16"/>',
+    sync:     '<path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/>',
+    settings: '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5 1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h0a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h0a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v0a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/>',
+  };
+  function iconSVG(name) {
+    var body = ICONS[name];
+    if (!body) return "";
+    return '<svg class="ba-side-icon" viewBox="0 0 24 24" width="14" height="14" '
+         + 'fill="none" stroke="currentColor" stroke-width="1.7" '
+         + 'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+         + body + '</svg>';
+  }
+
+  // ---- nav rows -------------------------------------------------------- //
+  function makeRow(it) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.className = "ba-side-item";
+    b.setAttribute("data-cmd", it.cmd);
+    if (it.active) b.setAttribute("data-active", "true");
+    if (it.cls) b.classList.add(it.cls);
+    var inner = iconSVG(it.cmd)
+              + '<span class="ba-side-l">' + it.label + "</span>";
+    if (it.dot) inner += '<span class="ba-side-dot"></span>';
+    if (it.key) inner += '<span class="ba-side-key">' + it.key + "</span>";
+    b.innerHTML = inner;
+    b.addEventListener("click", function (e) { e.preventDefault(); send(it.cmd); });
+    return b;
+  }
+
+  function build() {
+    var aside = document.createElement("aside");
+    aside.className = "ba-side";
+    aside.innerHTML = ''
+      // Wordmark
+      + '<div class="ba-side-head">'
+      +   '<span class="ba-side-mark">Better Anki</span>'
+      + '</div>'
+      // Cross-deck totals — hidden in single-deck mode (the hero owns them).
+      + '<dl class="ba-side-totals">'
+      +   '<div class="ba-side-stat ba-side-stat--due">'
+      +     '<dt>Due</dt><dd data-x="due">—</dd></div>'
+      +   '<div class="ba-side-stat ba-side-stat--new">'
+      +     '<dt>New</dt><dd data-x="new">—</dd></div>'
+      +   '<div class="ba-side-stat ba-side-stat--learn">'
+      +     '<dt>Learning</dt><dd data-x="learn">—</dd></div>'
+      + '</dl>';
+
+    // Primary nav
+    var nav = document.createElement("nav");
+    nav.className = "ba-side-nav";
+    [
+      { cmd: "decks",  label: "Decks",  key: "D", active: true },
+      { cmd: "add",    label: "Add",    key: "A" },
+      { cmd: "browse", label: "Browse", key: "B" },
+      { cmd: "stats",  label: "Stats",  key: "T" },
+    ].forEach(function (it) { nav.appendChild(makeRow(it)); });
+    aside.appendChild(nav);
+
+    // Quick actions
+    var quick = document.createElement("div");
+    quick.className = "ba-side-quick";
+    [
+      { cmd: "create", label: "New deck",    cls: "ba-side-act" },
+      { cmd: "import", label: "Import file", cls: "ba-side-act" },
+    ].forEach(function (it) { quick.appendChild(makeRow(it)); });
+    aside.appendChild(quick);
+
+    // Streak + lifetime stats moved out of the sidebar and into the
+    // practice/heatmap section on the main page.
+
+    // Foot — sync + settings.
+    var foot = document.createElement("div");
+    foot.className = "ba-side-foot";
+    [
+      { cmd: "sync",     label: "Sync",     key: "Y", dot: true },
+      { cmd: "settings", label: "Settings", key: ",", cls: "ba-side-settings" },
+    ].forEach(function (it) { foot.appendChild(makeRow(it)); });
+    aside.appendChild(foot);
+
+    return aside;
+  }
+
+  // ---- state cache (so Python can push before the DOM is built) ------- //
+  var pending = { standing: null, active: null, sync: null };
+
+  function applyStanding(d) {
+    if (!d) return;
+    var keys = ["streak", "due", "new", "learn", "today", "todayMin", "total"];
+    for (var i = 0; i < keys.length; i++) {
+      var k = keys[i];
+      var els = document.querySelectorAll('[data-x="' + k + '"]');
+      if (!els.length) continue;
+      var v = d[k];
+      var txt = (typeof v === "number") ? fmtNum(v) : (v == null ? "—" : String(v));
+      for (var j = 0; j < els.length; j++) els[j].textContent = txt;
+    }
+    // 7-day mini-grid (oldest → today). Each entry true/false.
+    if (d.last7 && d.last7.length === 7) {
+      var dots = document.querySelectorAll(".ba-side-7d-dot");
+      for (var k2 = 0; k2 < 7; k2++) {
+        if (!dots[k2]) continue;
+        dots[k2].classList.toggle("ba-on", !!d.last7[k2]);
+      }
+    }
+    // In single-deck mode the hero owns Due/New/Learning, so hide the
+    // sidebar copy to avoid doubling the same numbers.
+    var aside = document.querySelector(".ba-side");
+    if (aside) aside.classList.toggle("ba-side--single", !!d.singleDeck);
+  }
+  function applyActive(cmd) {
+    var els = document.querySelectorAll(".ba-side-item");
+    for (var i = 0; i < els.length; i++) {
+      if (els[i].getAttribute("data-cmd") === cmd) els[i].setAttribute("data-active", "true");
+      else els[i].removeAttribute("data-active");
+    }
+  }
+  function applySync(state) {
+    var el = document.querySelector('.ba-side-item[data-cmd="sync"]');
+    if (!el) return;
+    el.classList.remove("ba-sync-pending", "ba-sync-full", "ba-sync-active");
+    if (state === "pending") el.classList.add("ba-sync-pending");
+    else if (state === "full") el.classList.add("ba-sync-full");
+    else if (state === "active") el.classList.add("ba-sync-active");
+  }
+
+  function inject() {
+    if (document.querySelector(".ba-side")) return;
+    var aside = build();
+    document.body.insertBefore(aside, document.body.firstChild || null);
+    document.body.classList.add("ba-with-side");
+    if (pending.standing) applyStanding(pending.standing);
+    if (pending.active)   applyActive(pending.active);
+    if (pending.sync)     applySync(pending.sync);
+  }
+
+  // ---- public hooks ---------------------------------------------------- //
+  function fmtNum(n) {
+    if (n === null || n === undefined) return "—";
+    return (typeof n === "number") ? n.toLocaleString() : String(n);
+  }
+  window.__baSetStanding = function (d) {
+    pending.standing = d || pending.standing;
+    applyStanding(d);
+  };
+  window.__baSetActive = function (cmd) {
+    pending.active = cmd;
+    applyActive(cmd);
+  };
+  window.__baSetSync = function (state) {
+    pending.sync = state;
+    applySync(state);
+  };
+
+  // Bootstrap from the <head>-embedded standing data (set by the addon
+  // before any body script runs) — eliminates the eval-vs-IIFE race.
+  if (window.__baStandingData) pending.standing = window.__baStandingData;
+
+  if (document.readyState !== "loading") inject();
+  else document.addEventListener("DOMContentLoaded", inject);
+
+  var moScheduled = false;
+  try {
+    new MutationObserver(function () {
+      if (moScheduled) return;
+      moScheduled = true;
+      requestAnimationFrame(function () {
+        moScheduled = false;
+        if (!document.querySelector(".ba-side")) inject();
+      });
+    }).observe(document.documentElement, { childList: true, subtree: true });
+  } catch (e) {}
+})();

--- a/web/theme.css
+++ b/web/theme.css
@@ -1,202 +1,791 @@
-/* BetterAnki — deck homepage redesign.
-   Targets Anki 25.09's real deck-browser DOM:
-     <center>
-       <table[.fancy] cellspacing=0 cellpadding=3>
-         <tr><th colspan=5>Deck</th><th class=count>New</th>…<th class=optscol></th></tr>
-         <tr class='deck' id=N>
-           <td class=decktd colspan=5>[a.collapse][a.deck]</td>
-           <td align=end><span class="new-count">…</span></td>   (×3)
-           <td class=opts><a><img class=gears></a></td>
-         </tr>
-       </table><br>%(stats)s
-     </center>
-   Colors come from tokens.css (which overrides Anki's own --vars). */
+/* BetterAnki — deck homepage + global palette.
 
+   Loads on the deck browser AND the Overview. The heavy homepage layout is
+   scoped to `.ba-home` (a class the add-on adds to the deck browser's
+   <center> only) so the Overview keeps its own simple stacking.
+
+   Two themes, system-aware:
+     • default to @media (prefers-color-scheme: light|dark)
+     • settings can override via :root[data-rf-theme="light"|"dark"]
+*/
+
+/* ============================ THEME TOKENS ============================ */
+/* dark = default */
+:root {
+  --rf-paper: #0b0c0f;
+  --rf-panel: #121319;
+  --rf-ink: #eceae2;
+  --rf-ink-strong: #ffffff;
+  --rf-ink-dim: #9b978a;
+  --rf-ink-faint: #5d5a51;
+  --rf-line: rgba(236, 234, 226, 0.09);
+  --rf-line-2: rgba(236, 234, 226, 0.18);
+  --rf-row-hover: rgba(236, 234, 226, 0.04);
+  --rf-row-current: rgba(236, 234, 226, 0.03);
+  --rf-glow: radial-gradient(120% 70% at 50% -8%,
+              rgba(120, 130, 170, 0.08), transparent 60%);
+
+  --rf-due: #79b69b;
+  --rf-new: #8bb0e6;
+  --rf-learn: #d7a76c;
+
+  --rf-serif: ui-serif, "New York", "Hoefler Text", "Iowan Old Style",
+              "Charter", Georgia, serif;
+  --rf-sans: ui-sans-serif, -apple-system, "SF Pro Text", "Helvetica Neue",
+             "Segoe UI", system-ui, sans-serif;
+  --rf-measure: 720px;
+  --rf-side-w: 264px;
+
+  /* shared with heatmap.css (it uses var(...,fallback)) */
+  --rf-surface: var(--rf-panel);
+  --rf-border: var(--rf-line);
+  --rf-text: var(--rf-ink);
+  --rf-text-dim: var(--rf-ink-dim);
+  --rf-radius: 14px;
+  --rf-bg: #060708;
+}
+
+/* light = system */
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) {
+    --rf-paper: #f6f3ec;
+    --rf-panel: #fbf9f3;
+    --rf-ink: #1f1d18;
+    --rf-ink-strong: #000000;
+    --rf-ink-dim: #6a6557;
+    --rf-ink-faint: #a39d8b;
+    --rf-line: rgba(31, 29, 24, 0.08);
+    --rf-line-2: rgba(31, 29, 24, 0.18);
+    --rf-row-hover: rgba(31, 29, 24, 0.035);
+    --rf-row-current: rgba(31, 29, 24, 0.025);
+    --rf-glow: radial-gradient(120% 70% at 50% -8%,
+                rgba(255, 230, 190, 0.55), transparent 60%);
+
+    --rf-due: #2f8462;
+    --rf-new: #2f5fb5;
+    --rf-learn: #a05f1e;
+
+    --rf-bg: #ffffff;
+  }
+}
+
+/* explicit overrides (settings) */
+:root[data-rf-theme="light"] {
+  --rf-paper: #f6f3ec;
+  --rf-panel: #fbf9f3;
+  --rf-ink: #1f1d18;
+  --rf-ink-strong: #000000;
+  --rf-ink-dim: #6a6557;
+  --rf-ink-faint: #a39d8b;
+  --rf-line: rgba(31, 29, 24, 0.08);
+  --rf-line-2: rgba(31, 29, 24, 0.18);
+  --rf-row-hover: rgba(31, 29, 24, 0.035);
+  --rf-row-current: rgba(31, 29, 24, 0.025);
+  --rf-glow: radial-gradient(120% 70% at 50% -8%,
+              rgba(255, 230, 190, 0.55), transparent 60%);
+  --rf-due: #2f8462;
+  --rf-new: #2f5fb5;
+  --rf-learn: #a05f1e;
+  --rf-bg: #ffffff;
+}
+:root[data-rf-theme="dark"] {
+  --rf-paper: #0b0c0f;
+  --rf-panel: #121319;
+  --rf-ink: #eceae2;
+  --rf-ink-strong: #ffffff;
+  --rf-ink-dim: #9b978a;
+  --rf-ink-faint: #5d5a51;
+  --rf-line: rgba(236, 234, 226, 0.09);
+  --rf-line-2: rgba(236, 234, 226, 0.18);
+  --rf-row-hover: rgba(236, 234, 226, 0.04);
+  --rf-row-current: rgba(236, 234, 226, 0.03);
+  --rf-glow: radial-gradient(120% 70% at 50% -8%,
+              rgba(120, 130, 170, 0.08), transparent 60%);
+  --rf-due: #79b69b;
+  --rf-new: #8bb0e6;
+  --rf-learn: #d7a76c;
+  --rf-bg: #060708;
+}
+
+/* heatmap cells get a light-mode scale (the dark scale is in heatmap.css) */
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) .rf-hm-l0 { background: rgba(31,29,24,.07); }
+  :root:not([data-rf-theme="dark"]) .rf-hm-l1 { background: #cfe0f5; }
+  :root:not([data-rf-theme="dark"]) .rf-hm-l2 { background: #8eb1de; }
+  :root:not([data-rf-theme="dark"]) .rf-hm-l3 { background: #4d7fc4; }
+  :root:not([data-rf-theme="dark"]) .rf-hm-l4 { background: #1f5cae; }
+}
+:root[data-rf-theme="light"] .rf-hm-l0 { background: rgba(31,29,24,.07); }
+:root[data-rf-theme="light"] .rf-hm-l1 { background: #cfe0f5; }
+:root[data-rf-theme="light"] .rf-hm-l2 { background: #8eb1de; }
+:root[data-rf-theme="light"] .rf-hm-l3 { background: #4d7fc4; }
+:root[data-rf-theme="light"] .rf-hm-l4 { background: #1f5cae; }
+
+/* ============================== BASE ============================== */
+html, body {
+  background: var(--rf-paper) !important;
+  color: var(--rf-ink);
+}
 body {
-  font-family: -apple-system, "SF Pro Text", "Inter", system-ui, sans-serif;
+  margin: 0 !important;
+  font-family: var(--rf-sans);
   -webkit-font-smoothing: antialiased;
+  -webkit-user-select: none;
 }
+/* Border-box everywhere inside our scopes so width:100% + padding never
+   overflows the parent. Fixes the narrow-display card overflow. */
+.ba-home, .ba-home *,
+.ba-over, .ba-over * {
+  box-sizing: border-box;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background: var(--rf-glow);
+}
+.descfont { color: var(--rf-ink-dim) !important; }
 
-center {
-  display: block;
-  padding: 30px 16px 52px;
-}
-
-/* Kill Anki's frosted ".fancy" panel — we want individual row cards instead. */
-table,
-table.fancy {
-  background: transparent !important;
-  box-shadow: none !important;
-  -webkit-backdrop-filter: none !important;
-  backdrop-filter: none !important;
-  border: none !important;
-  border-collapse: separate !important;
-  border-spacing: 0 10px !important;
-  width: 100%;
-  max-width: 720px;
-  margin: 0 auto;
-}
-
-/* Header row -> quiet uppercase column labels. */
-th {
-  background: transparent !important;
-  border: none !important;
-  color: var(--fg-faint) !important;
-  font: 700 11px/1 inherit !important;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  text-align: end;
-  padding: 2px 16px 12px !important;
-}
-th[align="start"],
-th:first-child {
-  text-align: start;
-}
-th.optscol {
-  width: 44px;
-}
-
-/* Each deck row -> a card. Radius/borders live on the cells because a <tr>
-   can't carry border-radius in table layout. */
-tr.deck td {
-  background: var(--canvas-elevated) !important;
-  border-top: 1px solid var(--border-subtle) !important;
-  border-bottom: 1px solid var(--border-subtle) !important;
-  padding: 16px 14px !important;
-  vertical-align: middle;
-  transition: background 130ms ease;
-}
-tr.deck td.decktd {
-  border-left: 1px solid var(--border-subtle) !important;
-  border-top-left-radius: 14px;
-  border-bottom-left-radius: 14px;
-  padding-left: 20px !important;
-}
-tr.deck td.opts {
-  border-right: 1px solid var(--border-subtle) !important;
-  border-top-right-radius: 14px;
-  border-bottom-right-radius: 14px;
-}
-tr.deck:hover td,
-.current td,
-tr.deck.current td {
-  background: #20242e !important;
-}
-
-/* Deck name — the readability fix. */
-a.deck,
-a.deck:visited {
-  color: var(--fg) !important;
-  font-weight: 650 !important;
-  font-size: 15px !important;
-  text-decoration: none !important;
-}
-a.deck:hover {
-  color: #ffffff !important;
-}
-a.deck.filtered {
-  color: var(--rf-accent, #6c8cff) !important;
-}
-
-a.collapse,
-span.collapse {
-  color: var(--fg-faint) !important;
-  margin-right: 10px;
-  text-decoration: none !important;
-}
-
-/* Counts -> pill chips with strong, distinct hues. */
-td[align="end"] {
-  text-align: end;
-  padding-right: 8px !important;
-}
-.new-count,
-.learn-count,
-.review-count {
-  display: inline-block;
-  min-width: 26px;
-  text-align: center;
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-weight: 700;
+/* a single utility for ledger figures: clean sans tabular, NOT serif */
+.ba-num {
+  font-family: var(--rf-sans);
   font-variant-numeric: tabular-nums;
-}
-.new-count {
-  color: #cfe4ff !important;
-  background: rgba(90, 169, 255, 0.16);
-}
-.learn-count {
-  color: #ffd9b8 !important;
-  background: rgba(255, 158, 87, 0.16);
-}
-.review-count {
-  color: #c4f0d8 !important;
-  background: rgba(79, 208, 138, 0.16);
-}
-.zero-count {
-  color: var(--fg-faint) !important;
-  font-weight: 600;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: 0;
 }
 
-/* Gear: revealed on row hover. */
-img.gears {
-  width: 16px;
-  height: 16px;
-  opacity: 0;
-  filter: invert(82%);
-  transition: opacity 120ms ease;
-}
-tr.deck:hover img.gears {
-  opacity: 0.5;
-}
-td.opts a:hover img.gears {
-  opacity: 1;
-}
-
-/* "Studied N cards today" -> quiet caption. */
-#studiedToday {
-  max-width: 720px;
-  margin: 24px auto 4px !important;
-  color: var(--fg-subtle) !important;
-  font-size: 12.5px;
-  text-align: center;
-}
-
-/* Action buttons injected into the page (replaces Anki's bottom strip). */
-.ba-actions {
+/* ===================================================================== */
+/* Homepage layout — scoped to the deck browser only                     */
+/* ===================================================================== */
+.ba-home {
   display: flex;
-  gap: 10px;
-  justify-content: center;
-  flex-wrap: wrap;
-  max-width: 720px;
-  margin: 4px auto 2px;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 40px 32px;
+  min-height: 100vh;
+  box-sizing: border-box;
 }
-.ba-actions button {
+/* Single-deck mode is a fixed-size composition; center it in the viewport so
+   the user never has to scroll on the homepage. */
+.ba-home.ba-single {
+  justify-content: center;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  gap: 0;                       /* spacing handled by each section's own margin */
+}
+.ba-home.ba-single .ba-deck-head { margin-bottom: 6px; }
+.ba-home.ba-single .ba-hero { margin-bottom: 28px; }
+.ba-home > br { display: none; }
+.ba-home > * {
+  width: 100%;
+  max-width: var(--rf-measure);
+}
+
+/* page-load reveal: one calm staggered rise */
+@keyframes ba-rise {
+  from { opacity: 0; transform: translateY(10px); }
+}
+.ba-home > table,
+.ba-home .ba-practice,
+.ba-home .ba-hero {
+  animation: ba-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+.ba-home > table { animation-delay: 0.05s; }
+.ba-home .ba-practice { animation-delay: 0.18s; }
+@media (prefers-reduced-motion: reduce) {
+  .ba-home > table, .ba-home .ba-practice, .ba-home .ba-hero {
+    animation: none;
+  }
+}
+
+/* order: hero (single-deck) or deck list (multi) → practice section */
+.ba-home .ba-hero { order: 0; }
+.ba-home > table { order: 1; }
+.ba-home .ba-practice { order: 2; }
+/* Legacy classes the addon no longer renders — safety net for stale state. */
+.ba-mast, .ba-mast-row, .ba-stand, .ba-actions { display: none !important; }
+
+/* --------------------------- DECK LIST ---------------------------- */
+/* Anki ships a 5-column table. We drop the column-header row entirely and
+   render counts as a compact inline group on the right of each row, so it
+   reads as a clean list — not a spreadsheet. */
+.ba-home > table {
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  table-layout: auto;
+}
+/* The "Deck NEW LEARN DUE" header row — gone. */
+.ba-home > table > tbody > tr:first-child,
+.ba-home > table > thead > tr {
+  display: none !important;
+}
+/* Force the deck table to fit its container width regardless of intrinsic
+   min-content. Without this, Anki's `.decktd { min-width: 15em }` + `.count
+   { min-width: 4em }` pushes the table wider than the available content
+   area at narrow widths, and `align-items: center` on .ba-home lets it
+   spill both sides (the left side ends up under the sidebar). */
+.ba-home > table {
+  width: 100% !important;
+  max-width: var(--rf-measure);
+  table-layout: fixed;
+}
+.ba-home .decktd {
+  min-width: 0 !important;
+  max-width: none !important;
+  overflow: hidden;
+}
+.ba-home th.optscol { width: 36px; }
+.ba-home th.count   { width: 56px; }    /* fixed-layout column widths */
+.ba-home tr.deck td[align="end"] { width: 56px; }
+.ba-home tr.deck td.opts { width: 36px; }
+@media (max-width: 820px) {
+  .ba-home th.count, .ba-home tr.deck td[align="end"] { width: 44px; }
+}
+
+.ba-home tr.deck td {
+  background: transparent !important;
+  border: 0 !important;
+  border-bottom: 1px solid var(--rf-line) !important;
+  border-radius: 0 !important;
+  padding: 16px 10px !important;
+  vertical-align: middle;
+  transition: background 120ms ease;
+}
+.ba-home tr.deck td.decktd { padding-left: 4px !important; }
+.ba-home tr.deck td[align="end"] { padding: 16px 6px !important; }
+.ba-home tr.deck:hover:not(.top-level-drag-row) td {
+  background: var(--rf-row-hover) !important;
+  border-radius: 0 !important;
+}
+.ba-home tr.deck.current td,
+.ba-home .current td {
+  background: var(--rf-row-current) !important;
+  border-radius: 0 !important;
+}
+.ba-home tr.deck.current td.decktd {
+  box-shadow: inset 2px 0 0 var(--rf-accent, #6c8cff);
+}
+.ba-home tr.deck.current a.deck { color: var(--rf-ink-strong) !important; }
+.ba-home tr.top-level-drag-row td {
+  padding: 0 !important; height: 6px; border: 0 !important;
+  background: transparent !important;
+}
+
+.ba-home a.deck,
+.ba-home a.deck:visited {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+  color: var(--rf-ink) !important;
+  font: 500 16px/1.25 var(--rf-serif) !important;
+  letter-spacing: -0.005em;
+  text-decoration: none !important;
+}
+.ba-home a.deck:hover { color: var(--rf-ink-strong) !important; text-decoration: none !important; }
+.ba-home a.deck.filtered {
+  color: var(--rf-accent, #6c8cff) !important;
+  font-style: italic;
+}
+.ba-home a.collapse,
+.ba-home span.collapse {
+  display: inline-block;
+  width: 1.2em;
+  color: var(--rf-ink-faint) !important;
+  font: 400 13px/1 var(--rf-sans);
+  text-decoration: none !important;
+}
+.ba-home a.collapse:hover { color: var(--rf-ink) !important; }
+
+/* Counts: tight sans tabular figures grouped on the right of each row.
+   Visually they read as a single small cluster, not three table columns. */
+.ba-home td[align="end"] {
+  text-align: right;
+  font: 500 13.5px/1 var(--rf-sans) !important;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.005em;
+  width: 1%;             /* shrink-wrap to content */
+  white-space: nowrap;
+}
+.ba-home td[align="end"] span {
+  display: inline-block;
+  min-width: 22px;
+  text-align: right;
+}
+.ba-home .new-count    { color: var(--rf-new)   !important; }
+.ba-home .learn-count  { color: var(--rf-learn) !important; }
+.ba-home .review-count { color: var(--rf-due)   !important; }
+.ba-home .zero-count   { color: var(--rf-ink-faint) !important; font-weight: 400; }
+
+.ba-home img.gears {
+  width: 14px; height: 14px;
+  opacity: 0;
+  filter: invert(86%);
+  transition: opacity 120ms ease;
+  vertical-align: middle;
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) .ba-home img.gears { filter: invert(20%); }
+}
+:root[data-rf-theme="light"] .ba-home img.gears { filter: invert(20%); }
+.ba-home tr.deck:hover img.gears { opacity: 0.45; }
+.ba-home td.opts a:hover img.gears { opacity: 0.95; }
+
+/* ---------------- PRACTICE — streak + stats + heatmap as ONE band ---------------- */
+.ba-practice {
+  order: 2;
+  width: 100%;
+  max-width: var(--rf-measure);
+  margin: 36px auto 0;
+}
+.ba-practice-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 4px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+/* Streak — a fire-icon pill so it reads as its own little badge. */
+.ba-practice-streak {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 13px 6px 10px;
+  background: rgba(108, 140, 255, 0.10);
+  background: color-mix(in srgb, var(--rf-accent, #6c8cff) 11%, transparent);
+  border: 1px solid rgba(108, 140, 255, 0.28);
+  border-color: color-mix(in srgb, var(--rf-accent, #6c8cff) 32%, transparent);
+  border-radius: 999px;
+  line-height: 1;
+}
+.ba-flame {
+  width: 13px;
+  height: 14px;
+  color: var(--rf-accent, #6c8cff);
+  flex: none;
+  transform: translateY(-0.5px);
+}
+.ba-practice-streak-n {
+  font: 600 15px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.01em;
+  color: var(--rf-accent, #6c8cff);
+}
+.ba-practice-streak-l {
+  font: 500 11px/1 var(--rf-sans);
+  letter-spacing: 0.04em;
+  color: var(--rf-ink-dim);
+}
+.ba-practice-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 22px;
+  flex-wrap: wrap;
+}
+@media (max-width: 720px) {
+  .ba-practice-head { gap: 12px; }
+  .ba-practice-meta { gap: 14px; }
+}
+.ba-practice-stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.ba-practice-stat .n {
+  font: 600 14px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  color: var(--rf-ink);
+}
+.ba-practice-stat .l {
+  font: 500 10.5px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-faint);
+}
+
+/* Heatmap inside the practice section — no panel chrome, just the grid. */
+.ba-home .ba-practice .rf-heatmap {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+.ba-home .rf-hm-head { display: none !important; }
+.ba-home .rf-hm-foot {
+  margin-top: 14px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rf-ink-faint);
+}
+
+/* Anki's "Studied N cards today" caption — folded into the practice header. */
+.ba-home #studiedToday { display: none !important; }
+
+/* ============================ SINGLE-DECK HERO ============================ */
+/* Composition: a quiet deck title ABOVE a focused click-anywhere card.
+   The card has the three big numbers + a slide-in "Study →" cue on hover. */
+.ba-home.ba-single > table,
+.ba-home.ba-single > table * { display: none !important; }
+
+/* Deck title — big editorial heading, sits tight against the card. */
+.ba-deck-head {
+  order: 0;
+  width: 100%;
+  max-width: var(--rf-measure);
+  margin: 0 auto;
+  padding: 0 8px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  text-align: left;       /* counteract <center>'s legacy text-align: center */
+}
+.ba-deck-name {
+  margin: 0 0 4px;
+  font: 500 42px/1 var(--rf-serif);
+  letter-spacing: -0.025em;
+  color: var(--rf-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+/* Deck options gear — sits next to the title, opens this deck's options. */
+.ba-deck-opts {
   -webkit-appearance: none;
   appearance: none;
-  border: 1px solid var(--border) !important;
-  background: var(--canvas-elevated) !important;
-  color: var(--fg) !important;
-  font: 600 13px/1 -apple-system, "SF Pro Text", system-ui, sans-serif;
-  padding: 11px 17px;
-  border-radius: 11px;
+  flex: none;
+  background: transparent;
+  border: 0;
+  padding: 8px;
+  border-radius: 999px;
   cursor: pointer;
-  transition: border-color 120ms ease, background 120ms ease, filter 120ms ease;
+  color: var(--rf-ink-faint);
+  opacity: 0.55;
+  transition: opacity 160ms ease, color 160ms ease, background 160ms ease;
+  align-self: center;
+  margin-bottom: 4px;
 }
-.ba-actions button:hover {
-  border-color: var(--rf-accent, #6c8cff) !important;
-  background: #20242e !important;
-}
-.ba-actions button.primary {
-  background: var(--rf-accent, #6c8cff) !important;
-  border-color: var(--rf-accent, #6c8cff) !important;
-  color: #ffffff !important;
-}
-.ba-actions button.primary:hover {
-  filter: brightness(1.08);
+.ba-deck-opts svg { width: 18px; height: 18px; display: block; }
+.ba-deck-opts:hover {
+  opacity: 1;
+  color: var(--rf-ink);
+  background: var(--rf-row-hover);
 }
 
-/* ---- Overview (deck landing page) gets the same base ---- */
-.descfont {
-  color: var(--fg-subtle) !important;
+/* The card. Click anywhere to study. */
+.ba-hero {
+  -webkit-appearance: none;
+  appearance: none;
+  order: 1;
+  display: block;
+  position: relative;
+  width: 100%;
+  max-width: var(--rf-measure);      /* matches heatmap width below */
+  margin: 0 auto;
+  padding: 28px 36px 30px;
+  box-sizing: border-box;
+  background: var(--rf-panel);
+  border: 1px solid var(--rf-line-2);
+  border-radius: 16px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 240ms ease, transform 160ms ease,
+              box-shadow 280ms ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 }
+
+/* Hover — accent border + a soft top-anchored glow + a feather-light
+   elevation. Earlier versions used a heavy 22% accent drop shadow that
+   read as a dark blue blot on light paper; this version stays subtle
+   in both themes (theme-specific tweaks live below). */
+.ba-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(120% 80% at 50% 0%,
+              color-mix(in srgb, var(--rf-accent, #6c8cff) 9%, transparent),
+              transparent 70%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 260ms ease;
+}
+.ba-hero:hover::before,
+.ba-hero.is-hover::before { opacity: 1; }
+.ba-hero:hover,
+.ba-hero.is-hover {
+  border-color: var(--rf-accent, #6c8cff);
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 14%, transparent),
+    0 10px 22px color-mix(in srgb, var(--rf-accent, #6c8cff) 10%, transparent);
+}
+/* Light mode shadows read heavier on warm paper — dial them back further. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) .ba-hero:hover,
+  :root:not([data-rf-theme="dark"]) .ba-hero.is-hover {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 16%, transparent),
+      0 6px 16px color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent);
+  }
+  :root:not([data-rf-theme="dark"]) .ba-hero::before {
+    background: radial-gradient(120% 80% at 50% 0%,
+                color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent),
+                transparent 70%);
+  }
+}
+:root[data-rf-theme="light"] .ba-hero:hover,
+:root[data-rf-theme="light"] .ba-hero.is-hover {
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 16%, transparent),
+    0 6px 16px color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent);
+}
+:root[data-rf-theme="light"] .ba-hero::before {
+  background: radial-gradient(120% 80% at 50% 0%,
+              color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent),
+              transparent 70%);
+}
+/* Dark mode benefits from a slightly stronger sweep — the dark panel
+   would otherwise absorb the gradient. */
+:root[data-rf-theme="dark"] .ba-hero::before {
+  background: radial-gradient(120% 80% at 50% 0%,
+              color-mix(in srgb, var(--rf-accent, #6c8cff) 12%, transparent),
+              transparent 70%);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) .ba-hero::before {
+    background: radial-gradient(120% 80% at 50% 0%,
+                color-mix(in srgb, var(--rf-accent, #6c8cff) 12%, transparent),
+                transparent 70%);
+  }
+}
+.ba-hero:active { transform: translateY(0); }
+.ba-hero:focus-visible {
+  outline: 2px solid var(--rf-accent, #6c8cff);
+  outline-offset: 4px;
+}
+.ba-hero.ba-hero--done {
+  cursor: default;
+  border-color: var(--rf-line);
+}
+.ba-hero.ba-hero--done::before { display: none; }
+.ba-hero.ba-hero--done:hover {
+  border-color: var(--rf-line);
+  transform: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+/* Hover Study pill removed — the card's accent border + glow already
+   signal interactivity, and the user didn't want an inline cue. */
+.ba-hero.ba-hero--done .ba-hero-go { display: none; }
+.ba-hero-arrow {
+  font-family: var(--rf-sans);
+  font-weight: 500;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+/* Big numbers — what actually matters. Three equal columns. */
+.ba-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  align-items: end;
+  position: relative; /* sit above the ::before gradient */
+}
+.ba-hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+}
+.ba-hero-n {
+  font: 500 54px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.025em;
+  color: var(--rf-ink);
+}
+.ba-hero-l {
+  font: 600 10px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--rf-ink-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ba-hero-stat.ba-due   .ba-hero-n { color: var(--rf-due); }
+.ba-hero-stat.ba-new   .ba-hero-n { color: var(--rf-new); }
+.ba-hero-stat.ba-learn .ba-hero-n { color: var(--rf-learn); }
+.ba-hero--done .ba-hero-n { color: var(--rf-ink-faint); }
+
+/* Responsive — keep the three numbers in a row at narrow widths, just scale
+   the type down so they don't crowd. */
+@media (max-width: 820px) {
+  .ba-hero { padding: 22px 24px 22px; }
+  .ba-hero-n { font-size: 44px; }
+  .ba-hero-go { right: 18px; top: 18px; }
+}
+@media (max-width: 620px) {
+  .ba-hero { padding: 18px 16px 18px; }
+  .ba-hero-n { font-size: 36px; }
+  .ba-hero-l { font-size: 9px; letter-spacing: 0.08em; }
+  .ba-hero-stats { gap: 8px; }
+  .ba-deck-name { font-size: 17px; }
+  .ba-hero-go { font-size: 9px; padding: 5px 9px; top: 14px; right: 14px; }
+}
+
+/* ===================================================================== */
+/* Overview (per-deck landing) — scoped redesign                         */
+/* The Anki DOM is a nested table; we flatten it via display:block/flex.  */
+/* ===================================================================== */
+.ba-over {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 80px 32px 80px;
+  min-height: 100vh;
+  box-sizing: border-box;
+  text-align: center;
+}
+.ba-over > *:not(table) {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto !important;
+}
+.ba-over h3 {
+  font: 500 36px/1.05 var(--rf-serif) !important;
+  letter-spacing: -0.015em;
+  color: var(--rf-ink) !important;
+  margin: 0 0 14px !important;
+}
+.ba-over .smallLink {
+  display: inline-block;
+  color: var(--rf-ink-faint) !important;
+  font: 600 10px/1 var(--rf-sans) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  margin: 0 0 26px !important;
+  text-decoration: none !important;
+}
+.ba-over .smallLink:hover { color: var(--rf-accent, #6c8cff) !important; }
+.ba-over .descfont,
+.ba-over .description {
+  color: var(--rf-ink-dim) !important;
+  font: italic 400 15px/1.6 var(--rf-serif) !important;
+  margin: 0 auto 36px !important;
+  max-width: 480px;
+}
+
+/* Flatten the nested table layout to a clean column */
+.ba-over > table {
+  width: 100% !important;
+  max-width: 600px !important;
+  margin: 0 auto !important;
+  border-collapse: collapse !important;
+  background: transparent !important;
+  display: block;
+}
+.ba-over > table,
+.ba-over > table tbody,
+.ba-over > table tr,
+.ba-over > table td {
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+  vertical-align: top;
+}
+.ba-over > table > tbody { display: block; }
+.ba-over > table > tbody > tr {
+  display: flex !important;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+}
+.ba-over > table > tbody > tr > td {
+  display: block !important;
+}
+/* The inner counts table — 3-up horizontal stat row */
+.ba-over > table > tbody > tr > td > table {
+  display: block;
+  margin: 0 auto;
+  background: transparent !important;
+}
+.ba-over > table > tbody > tr > td > table tbody {
+  display: flex;
+  gap: 56px;
+}
+.ba-over > table > tbody > tr > td > table tr {
+  display: flex;
+  flex-direction: column-reverse; /* number on top, label below */
+  align-items: center;
+  gap: 6px;
+}
+.ba-over > table > tbody > tr > td > table td {
+  font: 600 10px/1 var(--rf-sans) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-dim) !important;
+}
+.ba-over > table > tbody > tr > td > table td b {
+  font-weight: 500;
+}
+.ba-over > table > tbody > tr > td > table td b span {
+  font: 500 36px/1 var(--rf-sans) !important;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.01em;
+  text-transform: none;
+}
+.ba-over .new-count    { color: var(--rf-new)   !important; }
+.ba-over .learn-count  { color: var(--rf-learn) !important; }
+.ba-over .review-count { color: var(--rf-due)   !important; }
+.ba-over .bury-count {
+  display: block !important;
+  margin-left: 0 !important;
+  color: var(--rf-ink-faint) !important;
+  font: 500 11px/1 var(--rf-sans) !important;
+  margin-top: 4px;
+}
+.ba-over .bury-count:empty { display: none !important; }
+
+/* "Study Now" — the page's primary CTA */
+.ba-over #study,
+.ba-over button#study {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  min-width: 220px;
+  padding: 16px 30px !important;
+  font: 600 14px/1 var(--rf-sans) !important;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff !important;
+  background: var(--rf-accent, #6c8cff) !important;
+  border: 0 !important;
+  border-radius: 12px !important;
+  box-shadow: 0 6px 20px rgba(108, 140, 255, 0.18) !important;
+  cursor: pointer;
+  transition: filter 120ms ease, transform 90ms ease;
+}
+.ba-over #study:hover { filter: brightness(1.08); }
+.ba-over #study:active { transform: scale(0.98); }

--- a/web/tokens.css
+++ b/web/tokens.css
@@ -1,34 +1,104 @@
 /* BetterAnki — design tokens.
-   Anki 25.09 colors every built-in component (deck browser, toolbar, bottom
+   Anki 25.x colors every built-in component (deck browser, toolbar, bottom
    bars, overview, reviewer chrome) through these CSS custom properties.
    Overriding them here recolors Anki's own UI coherently instead of fighting
-   individual selectors. --rf-accent is injected from config in <head>. */
+   individual selectors.
 
-:root,
-.night-mode,
-body {
-  --canvas: #0e1014 !important;
-  --canvas-elevated: #181b22 !important;
-  --canvas-inset: #14171d !important;
-  --canvas-overlay: #181b22 !important;
-  --canvas-glass: rgba(20, 23, 29, 0.72) !important;
+   We respect system appearance:
+     • dark = default
+     • @media (prefers-color-scheme: light) flips the palette
+     • :root[data-rf-theme="light|dark"] (settings override) wins
 
-  --fg: #eef1f6 !important;
-  --fg-subtle: #aeb4c0 !important;
-  --fg-faint: #6b7280 !important;
-  --fg-disabled: #4b5563 !important;
+   --rf-accent is injected from config in the page <head>. */
 
-  --border: #2b313c !important;
-  --border-subtle: #232831 !important;
+/* All variables live on :root only — declaring them on `body` too would let
+   body's own value win over an attribute override on :root in light mode. */
+
+/* ---------------------------- DARK (default) ---------------------------- */
+:root {
+  --canvas: #0b0c0f !important;
+  --canvas-elevated: #14161b !important;
+  --canvas-inset: #0d0e12 !important;
+  --canvas-overlay: #16181f !important;
+  --canvas-glass: rgba(20, 22, 28, 0.72) !important;
+
+  --fg: #eceae2 !important;
+  --fg-subtle: #9b978a !important;
+  --fg-faint: #5d5a51 !important;
+  --fg-disabled: #45433d !important;
+
+  --border: #2a2d36 !important;
+  --border-subtle: #1d2027 !important;
   --border-radius-medium: 14px !important;
 
   --accent: var(--rf-accent, #6c8cff) !important;
   --link: var(--rf-accent, #6c8cff) !important;
 
-  --state-new: #5aa9ff !important;
-  --state-learn: #ff9e57 !important;
-  --state-review: #4fd08a !important;
+  --state-new: #8bb0e6 !important;
+  --state-learn: #d7a76c !important;
+  --state-review: #79b69b !important;
 
+  --shadow: rgba(0, 0, 0, 0.45) !important;
+}
+
+/* ---------------------------- LIGHT (system) ---------------------------- */
+@media (prefers-color-scheme: light) {
+  :root:not([data-rf-theme="dark"]) {
+    --canvas: #f6f3ec !important;
+    --canvas-elevated: #fbf9f3 !important;
+    --canvas-inset: #f1eee6 !important;
+    --canvas-overlay: #ffffff !important;
+    --canvas-glass: rgba(255, 252, 244, 0.72) !important;
+
+    --fg: #1f1d18 !important;
+    --fg-subtle: #6a6557 !important;
+    --fg-faint: #a39d8b !important;
+    --fg-disabled: #c8c2b3 !important;
+
+    --border: #d8d2c2 !important;
+    --border-subtle: #e6e1d0 !important;
+
+    --state-new: #2f5fb5 !important;
+    --state-learn: #a05f1e !important;
+    --state-review: #2f8462 !important;
+
+    --shadow: rgba(40, 36, 28, 0.18) !important;
+  }
+}
+
+/* --------------------------- explicit overrides -------------------------- */
+:root[data-rf-theme="light"] {
+  --canvas: #f6f3ec !important;
+  --canvas-elevated: #fbf9f3 !important;
+  --canvas-inset: #f1eee6 !important;
+  --canvas-overlay: #ffffff !important;
+  --canvas-glass: rgba(255, 252, 244, 0.72) !important;
+  --fg: #1f1d18 !important;
+  --fg-subtle: #6a6557 !important;
+  --fg-faint: #a39d8b !important;
+  --fg-disabled: #c8c2b3 !important;
+  --border: #d8d2c2 !important;
+  --border-subtle: #e6e1d0 !important;
+  --state-new: #2f5fb5 !important;
+  --state-learn: #a05f1e !important;
+  --state-review: #2f8462 !important;
+  --shadow: rgba(40, 36, 28, 0.18) !important;
+}
+:root[data-rf-theme="dark"] {
+  --canvas: #0b0c0f !important;
+  --canvas-elevated: #14161b !important;
+  --canvas-inset: #0d0e12 !important;
+  --canvas-overlay: #16181f !important;
+  --canvas-glass: rgba(20, 22, 28, 0.72) !important;
+  --fg: #eceae2 !important;
+  --fg-subtle: #9b978a !important;
+  --fg-faint: #5d5a51 !important;
+  --fg-disabled: #45433d !important;
+  --border: #2a2d36 !important;
+  --border-subtle: #1d2027 !important;
+  --state-new: #8bb0e6 !important;
+  --state-learn: #d7a76c !important;
+  --state-review: #79b69b !important;
   --shadow: rgba(0, 0, 0, 0.45) !important;
 }
 

--- a/web/toolbar.css
+++ b/web/toolbar.css
@@ -1,34 +1,162 @@
-/* BetterAnki — top toolbar restyle.
-   DOM (Anki 25.09): .header > .left-tray / .toolbar / .right-tray;
-   nav links are a.hitem with ids #decks #add #browse #stats #sync. */
+/* BetterAnki — top toolbar.
 
+   Replaces Anki's default "fancy" floating gray pill with one cohesive,
+   full-width dark header that color-matches the page below and the macOS
+   title bar above, so the whole top of the window reads as a single
+   designed surface.
+
+   DOM (Anki 25.x, aqt/toolbar.py):
+     .header > .left-tray | .toolbar | .right-tray
+     nav links: a.hitem with ids #decks #add #browse #stats #sync
+     #sync contains <img id=sync-spinner> (hidden until syncing; .spin)
+   Body classes Anki toggles: .fancy (floating pill), .flat (reviewer),
+   .hidden (auto-hide). We restyle visuals only and never touch .hidden's
+   show/hide transforms. Heavy !important: we're overriding shipped CSS. */
+
+html,
+body {
+  background: var(--canvas, #0e1014) !important;
+}
+body,
+body.fancy {
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden;
+}
+
+/* One flat bar. Kill the pill: elevated bg, shadow, rounded corners, blur. */
 .header {
-  background: var(--canvas) !important;
+  display: grid !important;
+  grid-template-columns: 1fr auto 1fr !important;
+  align-items: center !important;
+  background: var(--canvas, #0e1014) !important;
+  border-bottom: 1px solid var(--border-subtle, #232831) !important;
+  padding: 7px 16px !important;
   -webkit-backdrop-filter: none !important;
   backdrop-filter: none !important;
-  border-bottom: 1px solid var(--border-subtle) !important;
-  padding: 6px 14px !important;
 }
 
-.toolbar {
-  gap: 4px;
+.toolbar,
+body.fancy .toolbar,
+body.fancy:not(.flat) .toolbar {
+  justify-self: center;
+  display: flex !important;
+  align-items: center;
+  gap: 3px;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+  overflow: visible !important;
 }
 
-a.hitem {
-  color: var(--fg-subtle) !important;
-  font-weight: 600 !important;
+.left-tray {
+  justify-self: start;
+}
+.right-tray {
+  justify-self: end;
+}
+.left-tray,
+.right-tray {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Nav links — refined, medium weight, smooth pill hover. */
+a.hitem,
+body.fancy a.hitem,
+body.fancy:not(.flat) a.hitem {
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.2px;
+  line-height: 1;
+  color: var(--fg-subtle, #aeb4c0) !important;
+  background: transparent !important;
+  border: 1px solid transparent !important;
+  border-radius: 9px !important;
   padding: 7px 13px !important;
-  border-radius: 9px;
+  margin: 0 !important;
+  box-shadow: none !important;
   text-decoration: none !important;
-  transition: background 120ms ease, color 120ms ease;
+  cursor: pointer;
+  transition: background 130ms ease, color 130ms ease, transform 90ms ease;
+}
+/* Anki adds extra edge padding to the first/last pill — normalize it. */
+a.hitem:first-child,
+body.fancy a.hitem:first-child {
+  padding-left: 13px !important;
+}
+a.hitem:last-child,
+body.fancy a.hitem:last-child {
+  padding-right: 13px !important;
 }
 
-a.hitem:hover {
-  color: var(--fg) !important;
-  background: var(--canvas-elevated) !important;
+a.hitem:hover,
+body.fancy a.hitem:hover,
+body.fancy:not(.flat) a.hitem:hover {
+  color: var(--fg, #eef1f6) !important;
+  background: rgba(255, 255, 255, 0.06) !important;
+  border-color: transparent !important;
   text-decoration: none !important;
 }
+a.hitem:active,
+body.fancy a.hitem:active {
+  transform: scale(0.96);
+  background: rgba(255, 255, 255, 0.04) !important;
+}
+a.hitem:focus {
+  outline: 0 !important;
+}
 
-a#sync.hitem {
-  color: var(--rf-accent, #6c8cff) !important;
+/* Current section — set by Python via <body data-rf-state>. Only the deck
+   list maps to a persistent screen; Add/Browse/Stats open dialogs. */
+body[data-rf-state="deckBrowser"] a#decks {
+  color: var(--accent, #6c8cff) !important;
+  background: rgba(108, 140, 255, 0.16) !important;
+  background: color-mix(in srgb, var(--accent, #6c8cff) 18%, transparent) !important;
+}
+
+/* Sync — a status-aware accent action. Anki's JS adds .normal-sync /
+   .full-sync when there are changes to push; keep that meaning, recolored. */
+a#sync,
+a#sync.normal-sync {
+  color: var(--accent, #6c8cff) !important;
+  font-weight: 600 !important;
+}
+a#sync:hover {
+  background: rgba(108, 140, 255, 0.14) !important;
+  background: color-mix(in srgb, var(--accent, #6c8cff) 14%, transparent) !important;
+}
+a#sync.full-sync {
+  color: var(--state-learn, #ff9e57) !important;
+}
+#sync-spinner {
+  height: 15px;
+  width: 0;
+  visibility: hidden;
+  margin: 0 0 -2px 0;
+}
+#sync-spinner.spin {
+  width: 15px !important;
+  visibility: visible !important;
+}
+
+/* Add-on tray items — keep them legible and in-theme. */
+.tray-item {
+  display: flex;
+  align-items: center;
+}
+.tray-item a,
+.tray-item button,
+.tray-item .hitem {
+  color: var(--fg-subtle, #aeb4c0) !important;
+  font-size: 12px !important;
 }


### PR DESCRIPTION
…, native settings

- Deck homepage: click-whole-card hero with big Due/New/Learn numbers, streak fire-pill + today/minutes/all-time meta, integrated heatmap, single-deck and multi-deck variants, hover state tuned per theme
- Left sidebar nav replaces Anki's top toolbar: wordmark, cross-deck totals (live), nav + quick actions, sync status indicator, settings
- Reviewer chrome: top progress strip, floating Decks back link with stable hover geometry, body-padding centering (Anki sets card class on <body>, breaking max-width tricks), ANSWER caption divider
- Reviewer bottom bar: minimal text-style Edit/Show Answer/More with ease-button key numbers and interval labels, no button chrome
- Heatmap: scroll-to-newest on resize, instant hover tooltip
- Native Qt settings dialog with serif headers, themed QSS, theme + accent + feature toggles + typography + heatmap config; merges Anki preferences/note-types/deck-options/addons inline
- Cmd+, (Ctrl+,) shortcut wired via QAction + global QShortcut
- Deck options gear surfaces full Rename/Options/Export/Delete menu
- Light + dark themes with system + explicit overrides; reviewer now loads theme.css so --rf-* tokens resolve in light mode