### PR TITLE
Rebuild BetterAnki settings as a full-width Preferences tab

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -54,6 +54,76 @@ def _config() -> Dict[str, Any]:
     return mw.addonManager.getConfig(__name__) or {}
 
 
+# Fixed-palette heatmaps. Four shades, low intensity → high.
+# Dark-mode set: eyeballed against the near-black canvas (#0b0c0f).
+# Light-mode set: eyeballed against the cream canvas (#f6f3ec) — the
+# dark sets render as harsh blobs in light mode, so each palette gets
+# its own light ramp running from pale-tinted to saturated.
+_HEATMAP_DARK: Dict[str, list] = {
+    "green":  ["#0e4429", "#006d32", "#26a641", "#39d353"],
+    "teal":   ["#0c4747", "#0d7d76", "#14b8a6", "#5eead4"],
+    "violet": ["#3b1670", "#6b2da3", "#9656ce", "#c896ec"],
+    "rose":   ["#5c1024", "#8c1338", "#cf2553", "#f43f5e"],
+    "amber":  ["#5a3a06", "#a87212", "#e09524", "#f7c149"],
+}
+_HEATMAP_LIGHT: Dict[str, list] = {
+    "green":  ["#cdebd4", "#84d18b", "#3aa552", "#1a6c2e"],
+    "teal":   ["#cdebe7", "#86d3c8", "#22a89a", "#0e6b62"],
+    "violet": ["#e5ddf6", "#bba6e2", "#7c52d6", "#3f1f8a"],
+    "rose":   ["#fbd9df", "#f29eaa", "#dc3a59", "#7a1230"],
+    "amber":  ["#fde6b6", "#f1c46c", "#cf8418", "#7a4708"],
+}
+
+
+def _shades_from_accent(accent: str, bg: tuple) -> list:
+    """Blend the accent toward a background color at four ratios.
+    Level 4 is the full accent; lower levels are progressively desaturated
+    toward the canvas tint."""
+    try:
+        r = int(accent[1:3], 16)
+        g = int(accent[3:5], 16)
+        b = int(accent[5:7], 16)
+    except Exception:
+        r, g, b = 108, 140, 255  # default accent
+    out = []
+    for ratio in (0.22, 0.45, 0.72, 1.0):
+        nr = int(bg[0] + (r - bg[0]) * ratio)
+        ng = int(bg[1] + (g - bg[1]) * ratio)
+        nb = int(bg[2] + (b - bg[2]) * ratio)
+        out.append(f"#{nr:02x}{ng:02x}{nb:02x}")
+    return out
+
+
+def _heatmap_palette_decl(choice: str, accent: str) -> str:
+    """CSS rule block (not a single declaration list) that paints the
+    heatmap cells per palette + theme. Emits two rule blocks — one for
+    each of dark and light — plus a @media block so the heatmap follows
+    the OS appearance when the theme is set to "system"."""
+    if choice in _HEATMAP_DARK:
+        dark = _HEATMAP_DARK[choice]
+        light = _HEATMAP_LIGHT[choice]
+    else:
+        dark = _shades_from_accent(accent, bg=(12, 14, 22))
+        light = _shades_from_accent(accent, bg=(246, 243, 236))
+    d1, d2, d3, d4 = dark
+    l1, l2, l3, l4 = light
+    # The !important wins over theme.css's per-theme defaults. We emit a
+    # CSS rule block here (separate from the page's main injection) so the
+    # selectors can target dark/light themes independently.
+    return (
+        f":root,:root[data-rf-theme=\"dark\"]"
+        f"{{--rf-hm-l1:{d1}!important;--rf-hm-l2:{d2}!important;"
+        f"--rf-hm-l3:{d3}!important;--rf-hm-l4:{d4}!important;}}"
+        f":root[data-rf-theme=\"light\"]"
+        f"{{--rf-hm-l1:{l1}!important;--rf-hm-l2:{l2}!important;"
+        f"--rf-hm-l3:{l3}!important;--rf-hm-l4:{l4}!important;}}"
+        f"@media (prefers-color-scheme:light)"
+        f"{{:root:not([data-rf-theme=\"dark\"])"
+        f"{{--rf-hm-l1:{l1}!important;--rf-hm-l2:{l2}!important;"
+        f"--rf-hm-l3:{l3}!important;--rf-hm-l4:{l4}!important;}}}}"
+    )
+
+
 def _is(context: Any, cls: Any) -> bool:
     return bool(cls) and isinstance(context, cls)
 
@@ -73,6 +143,10 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
     cfg = _config()
     accent = cfg.get("accent", "#6c8cff")
     theme_pref = cfg.get("theme", "system")  # "system" | "light" | "dark"
+    density = cfg.get("density", "comfortable")
+    palette_choice = cfg.get("heatmap_palette", "accent")
+    card_width_choice = cfg.get("reviewer_card_width", "medium")
+    font_size_choice = cfg.get("reviewer_font_size", "medium")
     # User-supplied display fonts are prepended to the existing stacks.
     serif_user = (cfg.get("font_serif") or "").strip()
     sans_user = (cfg.get("font_sans") or "").strip()
@@ -80,17 +154,37 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         if serif_user else ""
     sans_decl = f"--rf-sans:{sans_user}, ui-sans-serif, -apple-system, system-ui, sans-serif;" \
         if sans_user else ""
+
+    # Reviewer geometry — variables surface in reviewer.css.
+    width_map = {"narrow": "640px", "medium": "780px", "wide": "920px",
+                 "full": "100%"}
+    fontsize_map = {"small": "16px", "medium": "19px", "large": "22px",
+                    "x-large": "26px"}
+    card_width = width_map.get(card_width_choice, "780px")
+    card_font_size = fontsize_map.get(font_size_choice, "19px")
+    reviewer_decl = (
+        f"--rf-card-max-width:{card_width};"
+        f"--rf-card-font-size:{card_font_size};"
+    )
+
+    # Heatmap palette — emits its own rule block (light + dark variants),
+    # so its rules can stand outside the single-rule injection below.
+    hm_rules = _heatmap_palette_decl(palette_choice, accent)
+
     # tokens.css derives --accent from --rf-accent; inject the latter here.
     # `data-rf-theme` on <html> forces light/dark over the system @media.
-    extras = ""
+    # `data-rf-density` lets theme.css tighten or loosen spacing.
+    extras = "<script>(function(){var d=document.documentElement;"
     if theme_pref in ("light", "dark"):
-        extras = (
-            f"<script>document.documentElement.dataset.rfTheme="
-            f"'{theme_pref}';</script>"
-        )
+        extras += f"d.dataset.rfTheme='{theme_pref}';"
+    extras += f"d.dataset.rfDensity='{density}';"
+    extras += "})();</script>"
+
     web_content.head += (
         f"<style>:root,.night-mode,body{{"
-        f"--rf-accent:{accent};{serif_decl}{sans_decl}}}</style>"
+        f"--rf-accent:{accent};"
+        f"{serif_decl}{sans_decl}{reviewer_decl}"
+        f"}}{hm_rules}</style>"
         + extras
     )
     web_content.css.append(f"{WEB}/tokens.css")
@@ -622,7 +716,9 @@ def _start_studying(did: int) -> None:
 def _practice_header_html() -> str:
     """Streak + today/minutes/all-time as a header band above the heatmap.
     These stats used to live in the sidebar; they fit better here next to
-    the visual record of activity."""
+    the visual record of activity. The streak block is suppressed when
+    ``show_streak`` is False so users who don't track streaks aren't
+    pressured by a count they don't care about."""
     try:
         s = _standing()
     except Exception:
@@ -631,26 +727,30 @@ def _practice_header_html() -> str:
     today_n = int(s.get("today", 0) or 0)
     today_min = _minutes_today()
     total = int(s.get("total", 0) or 0)
-    # Phosphor-inspired flame: tall body + a small inner highlight that
-    # reads as the cool core of the fire.
-    flame = (
-        '<svg class="ba-flame" viewBox="0 0 24 24" '
-        'fill="currentColor" aria-hidden="true">'
-        '<path d="M12 2c.5 3 2 4.5 3.5 6.2C17 10 18.5 12 18.5 14.5'
-        '  c0 3.6-2.9 6.5-6.5 6.5s-6.5-2.9-6.5-6.5c0-1.6.6-2.9 1.5-3.8'
-        '  C8 11.6 9 12 10 12c0-2 0-4.5 2-10z"/>'
-        '<path d="M12.5 17.5c-1.4 0-2.5-1.1-2.5-2.5c0-.9.4-1.6 1.2-2'
-        '  c.7-.4 1.6-.8 1.9-1.7c.5 1 1.3 1.7 1.6 2.6c.1.4.2.8.2 1.2'
-        '  c0 1.4-1.1 2.4-2.4 2.4z" opacity=".55"/>'
-        '</svg>'
-    )
+    streak_html = ""
+    if _config().get("show_streak", True):
+        # Phosphor-inspired flame: tall body + a small inner highlight that
+        # reads as the cool core of the fire.
+        flame = (
+            '<svg class="ba-flame" viewBox="0 0 24 24" '
+            'fill="currentColor" aria-hidden="true">'
+            '<path d="M12 2c.5 3 2 4.5 3.5 6.2C17 10 18.5 12 18.5 14.5'
+            '  c0 3.6-2.9 6.5-6.5 6.5s-6.5-2.9-6.5-6.5c0-1.6.6-2.9 1.5-3.8'
+            '  C8 11.6 9 12 10 12c0-2 0-4.5 2-10z"/>'
+            '<path d="M12.5 17.5c-1.4 0-2.5-1.1-2.5-2.5c0-.9.4-1.6 1.2-2'
+            '  c.7-.4 1.6-.8 1.9-1.7c.5 1 1.3 1.7 1.6 2.6c.1.4.2.8.2 1.2'
+            '  c0 1.4-1.1 2.4-2.4 2.4z" opacity=".55"/>'
+            '</svg>'
+        )
+        streak_html = f"""
+        <div class="ba-practice-streak" title="Consecutive days reviewed">
+            {flame}
+            <span class="ba-practice-streak-n">{streak}</span>
+            <span class="ba-practice-streak-l">day streak</span>
+        </div>"""
     return f"""
     <header class="ba-practice-head">
-      <div class="ba-practice-streak" title="Consecutive days reviewed">
-        {flame}
-        <span class="ba-practice-streak-n">{streak}</span>
-        <span class="ba-practice-streak-l">day streak</span>
-      </div>
+      {streak_html}
       <div class="ba-practice-meta">
         <div class="ba-practice-stat">
           <span class="n">{today_n:,}</span>
@@ -938,7 +1038,17 @@ try:
 except Exception:
     pass
 
-# Anki add-on dialog "Config" → open our settings UI instead of raw JSON.
+# Inject a "BetterAnki" tab into Anki's native Preferences dialog so every
+# entry point — including the Tools-menu "Preferences…" / app-menu shortcut
+# the user already knows — surfaces our settings alongside Anki's own.
+try:
+    from .settings import install_into_preferences
+    install_into_preferences()
+except Exception:
+    pass
+
+# Anki add-on dialog "Config" → open Preferences on the BetterAnki tab
+# instead of dumping raw JSON in front of the user.
 try:
     mw.addonManager.setConfigAction(__name__, _open_settings)
 except Exception:

--- a/config.json
+++ b/config.json
@@ -1,12 +1,17 @@
 {
   "theme": "system",
   "accent": "#6c8cff",
+  "density": "comfortable",
   "sidebar_nav": true,
   "show_heatmap": true,
   "show_progress": true,
+  "show_streak": true,
   "hide_bottom_on_decks": true,
   "hide_bottom_on_overview": true,
   "heatmap_weeks": 53,
+  "heatmap_palette": "accent",
+  "reviewer_card_width": "medium",
+  "reviewer_font_size": "medium",
   "font_serif": "",
   "font_sans": ""
 }

--- a/settings.py
+++ b/settings.py
@@ -1,12 +1,18 @@
-"""BetterAnki — settings dialog.
+"""BetterAnki — settings, embedded as a tab in Anki's native Preferences.
 
-A native Qt dialog dressed in the same editorial system the rest of the
-add-on uses. Sections in a scrollable column (no tabs), serif headers,
-refined toggles, and a clean accent swatch. Saves to mw.addonManager
-config on every change; CSS/JS updates apply on next render.
+The whole UI lives in ``BetterAnkiSettingsPage`` (a plain ``QWidget``) so it
+can be dropped into ``aqt.preferences.Preferences``' ``QTabWidget``. We hook
+in via ``Preferences.setupOptions`` — Anki's documented (legacy) extension
+point — so every newly-opened Preferences dialog gains a "BetterAnki" tab.
+
+Every entry point that used to spawn a standalone dialog (sidebar cog, the
+Tools-menu action, Cmd+,, the add-on manager's "Config" button) now opens
+Anki Preferences and selects our tab. Config writes happen immediately on
+each change, separate from Anki's own Save/Cancel cycle.
 """
 
-from typing import Any, Dict, Optional, Tuple
+import os
+from typing import Any, Dict, List, Optional, Tuple
 
 from aqt import mw
 from aqt.qt import (
@@ -15,9 +21,14 @@ from aqt.qt import (
     QCheckBox,
     QColor,
     QColorDialog,
+    QComboBox,
     QDialog,
+    QDialogButtonBox,
+    QFont,
+    QFontDatabase,
     QFrame,
     QHBoxLayout,
+    QIcon,
     QLabel,
     QLineEdit,
     QPalette,
@@ -27,12 +38,42 @@ from aqt.qt import (
     QSize,
     QSpinBox,
     Qt,
+    QUrl,
     QVBoxLayout,
     QWidget,
 )
 
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+WEB_DIR = os.path.join(HERE, "web")
+
+
+def _icon_url(name: str) -> str:
+    """Plain absolute path to an icon in our web/ folder, slash-normalised
+    so Qt's QSS ``url(...)`` accepts it on every platform. Qt's QSS URL
+    parser silently drops data:image/svg+xml URLs in some builds, and a
+    file:// URL gets joined to the CWD when parsed — passing the raw
+    absolute path is what actually works."""
+    return os.path.join(WEB_DIR, name).replace(os.sep, "/")
+
+
 ADDON = __name__.split(".")[0]
+TAB_TITLE = "BetterAnki"
+PAGE_OBJECT_NAME = "baSettings"
+
+
+def _human_version() -> str:
+    """Best-effort read of manifest.json's human_version. Falls back to a
+    short string so the footer wordmark always renders something."""
+    import json
+    import os
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, "manifest.json")) as fh:
+            data = json.load(fh)
+        return str(data.get("human_version", "")) or "—"
+    except Exception:
+        return "—"
 
 
 # --------------------------------------------------------------------------- #
@@ -69,7 +110,6 @@ def _resolve_palette() -> Tuple[Dict[str, str], bool]:
         return PAL_DARK, True
     if pref == "light":
         return PAL_LIGHT, False
-    # "system" — inspect Qt's palette.
     try:
         c = QApplication.palette().color(QPalette.ColorRole.Window)
         is_dark = (c.red() + c.green() + c.blue()) < 384
@@ -78,192 +118,383 @@ def _resolve_palette() -> Tuple[Dict[str, str], bool]:
         return PAL_DARK, True
 
 
-SERIF = '"New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif'
-SANS = '"SF Pro Text", "Helvetica Neue", "Segoe UI", system-ui, sans-serif'
+# Lead with fonts Qt reliably resolves. macOS-bundled "Iowan Old Style"
+# and "New York" trip Qt's missing-family warning even though AppKit
+# resolves them; Georgia + Hoefler Text are picked up cleanly, so put
+# those first to avoid silently falling through to QFont's last-resort
+# (typically a sans-serif), which would defeat the editorial title.
+SERIF = 'Georgia, "Hoefler Text", "Times New Roman", serif'
+SANS = '"Helvetica Neue", "Segoe UI", system-ui, sans-serif'
 
 
+# Curated recommendations the font picker shows first. We intersect this
+# with the actually-installed fonts on the user's system so we never show
+# a font they can't choose. Order is "best aesthetic match" first.
+SERIF_RECOMMENDATIONS: List[str] = [
+    "Iowan Old Style",
+    "New York",
+    "Hoefler Text",
+    "Charter",
+    "Cochin",
+    "Baskerville",
+    "Garamond",
+    "Palatino",
+    "Georgia",
+    "Cambria",
+    "Times New Roman",
+    "Times",
+]
+SANS_RECOMMENDATIONS: List[str] = [
+    "Inter",
+    "SF Pro Text",
+    "SF Pro Display",
+    "Helvetica Neue",
+    "Helvetica",
+    "Avenir Next",
+    "Avenir",
+    "Lucida Grande",
+    "Segoe UI",
+    "Verdana",
+    "Tahoma",
+    "Calibri",
+    "Arial",
+]
+
+
+def _installed_fonts() -> List[str]:
+    """Family names of every font QFontDatabase reports installed."""
+    try:
+        return sorted(set(QFontDatabase.families()))
+    except Exception:
+        return []
+
+
+def _recommended_available(category: str) -> List[str]:
+    """Recommended fonts intersected with what's actually installed,
+    preserving the recommendation order."""
+    recs = SERIF_RECOMMENDATIONS if category == "serif" else SANS_RECOMMENDATIONS
+    installed = set(_installed_fonts())
+    return [f for f in recs if f in installed]
+
+
+# QSS is applied to the page widget itself; Qt scopes the rules to that
+# widget + its descendants, so sibling Preferences tabs are not affected.
 def _qss(p: Dict[str, str], accent: str) -> str:
     return f"""
-QDialog, QScrollArea, QWidget#root, QWidget#content {{
+QWidget#{PAGE_OBJECT_NAME}, QWidget#{PAGE_OBJECT_NAME} QScrollArea,
+QWidget#{PAGE_OBJECT_NAME} QWidget#viewport,
+QWidget#{PAGE_OBJECT_NAME} QWidget#content,
+QWidget#{PAGE_OBJECT_NAME} QWidget#footer {{
     background: {p['paper']};
     color: {p['ink']};
     font-family: {SANS};
 }}
-QScrollArea {{ border: 0; }}
-QScrollBar:vertical {{
+QWidget#{PAGE_OBJECT_NAME} QScrollArea {{ border: 0; }}
+QWidget#{PAGE_OBJECT_NAME} QScrollBar:vertical {{
     background: transparent;
     width: 10px;
     margin: 4px 0;
 }}
-QScrollBar::handle:vertical {{
+QWidget#{PAGE_OBJECT_NAME} QScrollBar::handle:vertical {{
     background: {p['line2']};
     border-radius: 5px;
     min-height: 30px;
 }}
-QScrollBar::handle:vertical:hover {{ background: {p['ink_faint']}; }}
-QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{ height: 0; }}
+QWidget#{PAGE_OBJECT_NAME} QScrollBar::handle:vertical:hover {{
+    background: {p['ink_faint']};
+}}
+QWidget#{PAGE_OBJECT_NAME} QScrollBar::add-line:vertical,
+QWidget#{PAGE_OBJECT_NAME} QScrollBar::sub-line:vertical {{ height: 0; }}
 
-QLabel {{
+QWidget#{PAGE_OBJECT_NAME} QLabel {{
     color: {p['ink']};
     font-family: {SANS};
-    font-size: 12pt;
+    font-size: 15pt;
     background: transparent;
 }}
-QLabel[role="title"] {{
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="title"] {{
     font-family: {SERIF};
-    font-size: 22pt;
+    font-size: 30pt;
     font-weight: 500;
     letter-spacing: -0.5px;
     padding: 0 0 4px 0;
     color: {p['ink']};
 }}
-QLabel[role="subtitle"] {{
-    font-size: 10pt;
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="page-title"] {{
+    font-family: {SERIF};
+    font-size: 28pt;
+    font-weight: 500;
+    letter-spacing: -0.4px;
+    padding: 0;
+    margin: 0;
+    color: {p['ink']};
+}}
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="subtitle"] {{
+    font-size: 14pt;
     color: {p['ink_dim']};
     padding-bottom: 6px;
 }}
-QLabel[role="section"] {{
-    font-family: {SANS};
-    font-size: 9pt;
-    font-weight: 600;
-    letter-spacing: 3px;
-    text-transform: uppercase;
-    color: {p['ink_faint']};
-    padding-top: 22px;
-    padding-bottom: 4px;
-}}
-QLabel[role="field"] {{
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="intro"] {{
+    font-size: 14pt;
     color: {p['ink_dim']};
-    font-size: 11pt;
+    /* Flush-left so the intro line x-aligns with the serif title above
+       (whose left-bearing is reset by margin/padding:0). */
+    padding: 0;
+    margin: 0;
 }}
-QLabel[role="hint"] {{
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="mono"] {{
+    font-family: "SF Mono", "Menlo", Consolas, monospace;
+    font-size: 14pt;
+    color: {p['ink_dim']};
+    letter-spacing: 0.2px;
+}}
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="section"] {{
+    font-family: {SANS};
+    font-size: 12pt;
+    font-weight: 700;
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+    color: {p['ink']};
+    padding: 0;
+}}
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="field"] {{
+    color: {p['ink']};
+    font-size: 15pt;
+    font-weight: 600;
+}}
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="hint"] {{
+    color: {p['ink_dim']};
+    font-size: 13pt;
+    font-family: {SANS};
+}}
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="subgroup"] {{
+    color: {p['ink_dim']};
+    font-size: 14pt;
+    font-weight: 500;
+    padding: 4px 0 4px 0;
+}}
+/* "optional" tag next to optional inputs — a quiet plain word, not a pill,
+   so it doesn't compete with the all-caps section labels. */
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="tag"] {{
     color: {p['ink_faint']};
-    font-size: 10pt;
+    font-size: 13pt;
     font-style: italic;
-    font-family: {SERIF};
+    background: transparent;
+    padding: 0;
 }}
-QFrame[role="rule"] {{
+/* Footer wordmark — small serif "BetterAnki vX.Y.Z" sitting opposite the
+   Restore link so the bottom of the page reads as a deliberate close. */
+QWidget#{PAGE_OBJECT_NAME} QLabel[role="wordmark"] {{
+    color: {p['ink_faint']};
+    font-family: {SERIF};
+    font-size: 13pt;
+    font-style: italic;
+}}
+QWidget#{PAGE_OBJECT_NAME} QFrame[role="rule"] {{
     background: {p['line']};
     max-height: 1px;
     min-height: 1px;
     border: 0;
 }}
 
-QCheckBox {{
+QWidget#{PAGE_OBJECT_NAME} QCheckBox {{
     color: {p['ink']};
-    spacing: 12px;
-    font-size: 11.5pt;
-    padding: 4px 0;
+    spacing: 14px;
+    font-size: 14pt;
+    padding: 6px 0;
 }}
-QCheckBox::indicator {{
-    width: 18px;
-    height: 18px;
-    border-radius: 5px;
+QWidget#{PAGE_OBJECT_NAME} QCheckBox::indicator {{
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
     border: 1px solid {p['line2']};
     background: {p['panel']};
 }}
-QCheckBox::indicator:hover {{
+QWidget#{PAGE_OBJECT_NAME} QCheckBox::indicator:hover {{
     border-color: {p['ink_faint']};
 }}
-QCheckBox::indicator:checked {{
+QWidget#{PAGE_OBJECT_NAME} QCheckBox::indicator:checked {{
     background: {accent};
     border-color: {accent};
-    /* white check via a data: SVG so the indicator is obviously "on" — a
-       plain accent fill alone reads as "indeterminate" to many users. */
-    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2.6' stroke-linecap='round' stroke-linejoin='round'><polyline points='3,8 7,12 13,4'/></svg>");
+    /* White check loaded from an on-disk SVG. Qt6's QSS parser silently
+       drops data:image/svg+xml URLs in some builds, leaving the indicator
+       as a flat accent square that reads as "indeterminate" — using a
+       real file works everywhere. */
+    image: url({_icon_url("check.svg")});
 }}
-QCheckBox::indicator:disabled {{
+QWidget#{PAGE_OBJECT_NAME} QCheckBox::indicator:disabled {{
     background: {p['hover']};
     border-color: {p['line']};
 }}
 
-QRadioButton {{
-    color: {p['ink']};
-    spacing: 10px;
-    font-size: 11.5pt;
-    padding: 3px 0;
+QWidget#{PAGE_OBJECT_NAME} QRadioButton {{
+    color: {p['ink_dim']};
+    spacing: 12px;
+    font-size: 14pt;
+    padding: 5px 0;
 }}
-QRadioButton::indicator {{
-    width: 16px;
-    height: 16px;
-    border-radius: 8px;
+/* Darken the currently-selected radio's text so the active option reads
+   even without the dot being in the user's focus. */
+QWidget#{PAGE_OBJECT_NAME} QRadioButton:checked {{
+    color: {p['ink']};
+}}
+QWidget#{PAGE_OBJECT_NAME} QRadioButton::indicator {{
+    width: 20px;
+    height: 20px;
+    border-radius: 10px;
     border: 1px solid {p['line2']};
     background: {p['panel']};
 }}
-QRadioButton::indicator:hover {{ border-color: {p['ink_faint']}; }}
-QRadioButton::indicator:checked {{
-    border: 5px solid {accent};
-    background: {p['paper']};
+QWidget#{PAGE_OBJECT_NAME} QRadioButton::indicator:hover {{
+    border-color: {p['ink_faint']};
+}}
+/* Radial gradient → proper radio dot (small accent fill on paper ring). */
+QWidget#{PAGE_OBJECT_NAME} QRadioButton::indicator:checked {{
+    background: qradialgradient(cx:0.5, cy:0.5, radius:0.5,
+        fx:0.5, fy:0.5, stop:0.32 {accent}, stop:0.38 {p['paper']});
+    border: 1px solid {accent};
 }}
 
-QPushButton {{
+QWidget#{PAGE_OBJECT_NAME} QPushButton {{
     background: transparent;
     color: {p['ink_dim']};
     border: 1px solid {p['line2']};
-    border-radius: 8px;
-    padding: 8px 16px;
-    font-size: 11pt;
+    border-radius: 9px;
+    padding: 12px 22px;
+    font-size: 14pt;
     font-weight: 500;
 }}
-QPushButton:hover {{
+QWidget#{PAGE_OBJECT_NAME} QPushButton:hover {{
     color: {p['ink']};
     background: {p['hover']};
     border-color: {p['ink_faint']};
 }}
-QPushButton#primary {{
-    color: white;
+/* The page's primary action — "Done" closes the dialog. Filled in the
+   accent color so the user can find it instantly at the bottom-right. */
+QWidget#{PAGE_OBJECT_NAME} QPushButton#primary {{
     background: {accent};
-    border: 1px solid {accent};
-}}
-QPushButton#primary:hover {{
-    /* darken accent a touch on hover so it actually reads as interactive */
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 {accent}, stop:1 {accent});
     color: white;
-    border-color: {accent};
+    border: 1px solid {accent};
+    padding: 12px 32px;
+    font-size: 14pt;
+    font-weight: 600;
 }}
-QPushButton#primary:pressed {{ background: {accent}; }}
+QWidget#{PAGE_OBJECT_NAME} QPushButton#primary:hover {{
+    background: {accent};
+    color: white;
+    /* Subtle darken via overlay shadow approximates an active state without
+       touching the swatch color the user picked. */
+    border-color: rgba(0,0,0,0.18);
+}}
+/* Jump-to-native-dialog links — read as quiet links, not form fields. */
+QWidget#{PAGE_OBJECT_NAME} QPushButton#jump {{
+    background: transparent;
+    border: 0;
+    color: {p['ink']};
+    padding: 6px 0;
+    text-align: left;
+    font-size: 15pt;
+    font-weight: 500;
+}}
+QWidget#{PAGE_OBJECT_NAME} QPushButton#jump:hover {{
+    color: {accent};
+    background: transparent;
+}}
+/* The "Restore defaults" rescue path — quiet ghost link; underlines only
+   on hover so it doesn't compete for attention. */
+QWidget#{PAGE_OBJECT_NAME} QPushButton#quiet {{
+    background: transparent;
+    border: 0;
+    color: {p['ink_faint']};
+    padding: 4px 0;
+    font-size: 10.5pt;
+    font-weight: 500;
+}}
+QWidget#{PAGE_OBJECT_NAME} QPushButton#quiet:hover {{
+    color: {p['ink']};
+    background: transparent;
+    text-decoration: underline;
+}}
 
-QSpinBox, QLineEdit {{
+QWidget#{PAGE_OBJECT_NAME} QSpinBox,
+QWidget#{PAGE_OBJECT_NAME} QLineEdit,
+QWidget#{PAGE_OBJECT_NAME} QComboBox {{
+    background: {p['panel']};
+    color: {p['ink']};
+    border: 1px solid {p['line2']};
+    border-radius: 9px;
+    padding: 11px 14px;
+    font-size: 14pt;
+    selection-background-color: {accent};
+}}
+QWidget#{PAGE_OBJECT_NAME} QSpinBox:focus,
+QWidget#{PAGE_OBJECT_NAME} QLineEdit:focus,
+QWidget#{PAGE_OBJECT_NAME} QComboBox:focus {{
+    border-color: {accent};
+    outline: none;
+}}
+
+QWidget#{PAGE_OBJECT_NAME} QComboBox {{ padding-right: 28px; }}
+QWidget#{PAGE_OBJECT_NAME} QComboBox::drop-down {{
+    subcontrol-origin: padding;
+    subcontrol-position: top right;
+    width: 24px;
+    border: 0;
+    background: transparent;
+}}
+QWidget#{PAGE_OBJECT_NAME} QComboBox::down-arrow {{
+    image: url({_icon_url("chevron-down.svg")});
+    width: 10px; height: 6px;
+}}
+/* The popup list — same paper palette, sharp selection in accent. */
+QComboBox QAbstractItemView {{
     background: {p['panel']};
     color: {p['ink']};
     border: 1px solid {p['line2']};
     border-radius: 7px;
-    padding: 7px 10px;
-    font-size: 11.5pt;
+    padding: 6px 0;
+    outline: 0;
     selection-background-color: {accent};
+    selection-color: white;
 }}
-QSpinBox:focus, QLineEdit:focus {{
-    border-color: {accent};
-    outline: none;
+QComboBox QAbstractItemView::item {{
+    padding: 8px 16px;
+    min-height: 26px;
+    font-size: 13pt;
+    border: 0;
 }}
-/* Compact, visible spin buttons — were hidden, which made the control feel
-   broken. Show small up/down chevrons in the dim ink color. */
-QSpinBox {{ padding-right: 22px; }}
-QSpinBox::up-button {{
+QComboBox QAbstractItemView::separator {{
+    height: 1px;
+    background: {p['line']};
+    margin: 6px 8px;
+}}
+/* Compact, visible spin buttons — Anki's default Qt theme renders them
+   nearly invisible against our panel color. */
+QWidget#{PAGE_OBJECT_NAME} QSpinBox {{ padding-right: 22px; }}
+QWidget#{PAGE_OBJECT_NAME} QSpinBox::up-button {{
     subcontrol-origin: border;
     subcontrol-position: top right;
     width: 18px;
     border: 0;
     background: transparent;
 }}
-QSpinBox::down-button {{
+QWidget#{PAGE_OBJECT_NAME} QSpinBox::down-button {{
     subcontrol-origin: border;
     subcontrol-position: bottom right;
     width: 18px;
     border: 0;
     background: transparent;
 }}
-QSpinBox::up-arrow {{
-    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239b978a' stroke-width='1.6' stroke-linecap='round'><polyline points='3,7 6,4 9,7'/></svg>");
+QWidget#{PAGE_OBJECT_NAME} QSpinBox::up-arrow {{
+    image: url({_icon_url("chevron-up.svg")});
     width: 10px; height: 6px;
 }}
-QSpinBox::down-arrow {{
-    image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239b978a' stroke-width='1.6' stroke-linecap='round'><polyline points='3,5 6,8 9,5'/></svg>");
+QWidget#{PAGE_OBJECT_NAME} QSpinBox::down-arrow {{
+    image: url({_icon_url("chevron-down.svg")});
     width: 10px; height: 6px;
 }}
 
-QLineEdit[placeholderText] {{ color: {p['ink_faint']}; }}
+QWidget#{PAGE_OBJECT_NAME} QLineEdit[placeholderText] {{ color: {p['ink_faint']}; }}
 """
 
 
@@ -271,13 +502,15 @@ QLineEdit[placeholderText] {{ color: {p['ink_faint']}; }}
 # Helpers
 # --------------------------------------------------------------------------- #
 class ColorSwatch(QPushButton):
-    """A 56×30 swatch button that opens the system color picker."""
+    """A 44×22 swatch button that opens the system color picker. Sized to
+    sit comfortably alongside a single line of body text — bigger swatches
+    overpower their hex label in a stacked row."""
 
     def __init__(self, color: str, on_change, parent=None):
         super().__init__(parent)
         self._color = color
         self._on_change = on_change
-        self.setFixedSize(QSize(56, 30))
+        self.setFixedSize(QSize(44, 22))
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self._restyle()
         self.clicked.connect(self._pick)
@@ -286,9 +519,14 @@ class ColorSwatch(QPushButton):
         return self._color
 
     def _restyle(self):
+        # Use a low-contrast border that works in both light and dark
+        # palettes — the previous fixed rgba(255,255,255,...) only read
+        # against dark backgrounds, leaving the swatch edgeless in light.
         self.setStyleSheet(
-            f"QPushButton {{ background: {self._color};"
-            f" border: 1px solid rgba(255,255,255,0.15); border-radius: 7px; }}"
+            "QPushButton {"
+            f" background: {self._color};"
+            " border: 1px solid rgba(0,0,0,0.18);"
+            " border-radius: 6px; }"
         )
 
     def _pick(self):
@@ -297,6 +535,143 @@ class ColorSwatch(QPushButton):
             self._color = c.name()
             self._restyle()
             self._on_change(self._color)
+
+
+class PaletteSwatchRow(QWidget):
+    """A row of small color swatches the user clicks to choose. The
+    currently-selected swatch grows a thin accent ring around it so the
+    state is unambiguous against any swatch background.
+
+    ``options`` is a list of ``(value, color_hex, label)`` triples. When
+    a swatch is clicked, ``on_change(value)`` fires."""
+
+    def __init__(self, options: List[Tuple[str, str, str]], current: str,
+                 ink_faint: str, accent: str, on_change, parent=None) -> None:
+        super().__init__(parent)
+        self._options = options
+        self._on_change = on_change
+        self._current = current
+        self._ink_faint = ink_faint
+        self._accent = accent
+        self._buttons: Dict[str, QPushButton] = {}
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for value, color, label in options:
+            btn = QPushButton()
+            btn.setFixedSize(QSize(38, 24))
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            btn.setToolTip(label)
+            btn.clicked.connect(lambda _, v=value: self._select(v))
+            self._buttons[value] = btn
+            layout.addWidget(btn)
+        layout.addStretch(1)
+        self._restyle()
+
+    def _select(self, value: str) -> None:
+        self._current = value
+        self._restyle()
+        self._on_change(value)
+
+    def _restyle(self) -> None:
+        check_path = os.path.join(WEB_DIR, "check.svg").replace(os.sep, "/")
+        check_icon = QIcon(check_path)
+        for value, color, _ in self._options:
+            btn = self._buttons[value]
+            picked = value == self._current
+            if picked:
+                # Selected swatch wears the same white check the checkboxes
+                # use, plus a contrasting white inner ring. Border colour
+                # alone is too easy to miss on top of a vivid swatch.
+                btn.setIcon(check_icon)
+                btn.setIconSize(QSize(14, 14))
+                style = (
+                    "QPushButton {"
+                    f" background: {color};"
+                    " border: 2px solid white;"
+                    " border-radius: 6px; }"
+                )
+            else:
+                btn.setIcon(QIcon())  # clear
+                style = (
+                    "QPushButton {"
+                    f" background: {color};"
+                    " border: 1px solid rgba(0,0,0,0.22);"
+                    " border-radius: 6px; }"
+                    "QPushButton:hover { border-color: rgba(0,0,0,0.45); }"
+                )
+            btn.setStyleSheet(style)
+
+
+class FontPicker(QComboBox):
+    """Editable combo of recommended + installed fonts for a category.
+
+    Layout: a blank "(use default)" item first, then the recommended list
+    filtered to what's installed, then a separator, then every other
+    family QFontDatabase reports. Each item is rendered in its own font
+    so users can see what they're picking. The combo is editable so a
+    user can still type a font Anki itself will pick up later, even if
+    Qt's database doesn't list it."""
+
+    DEFAULT_LABEL = "(use default)"
+
+    def __init__(self, category: str, current: str = "", parent=None) -> None:
+        super().__init__(parent)
+        self._category = category
+        self.setEditable(True)
+        self.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.setMaximumWidth(280)
+        self.setMinimumWidth(220)
+
+        # Blank → "use default fallback stack".
+        self.addItem(self.DEFAULT_LABEL, userData="")
+
+        recommended = _recommended_available(category)
+        self._fill(recommended)
+
+        # All-other-installed below a separator so the recommended block
+        # always stays at the top.
+        remaining = [
+            f for f in _installed_fonts()
+            if f not in recommended and not f.startswith(".")
+        ]
+        if remaining:
+            self.insertSeparator(self.count())
+            self._fill(remaining)
+
+        # Match the saved value to the corresponding combo entry; if no
+        # exact match, drop the literal text into the editable field so
+        # the user keeps their unknown-to-Qt choice.
+        self.set_value(current)
+
+    def _fill(self, fonts: List[str]) -> None:
+        for name in fonts:
+            self.addItem(name, userData=name)
+            self.setItemData(
+                self.count() - 1, QFont(name, 11), Qt.ItemDataRole.FontRole
+            )
+
+    def set_value(self, value: str) -> None:
+        value = (value or "").strip()
+        if not value:
+            self.setCurrentIndex(0)
+            self.setEditText("")
+            return
+        for i in range(self.count()):
+            if self.itemData(i) == value:
+                self.setCurrentIndex(i)
+                return
+        # Unknown — keep it in the editable text so the user can see
+        # and edit their custom choice.
+        self.setEditText(value)
+
+    def value(self) -> str:
+        """Current value with blank meaning "use default"."""
+        text = (self.currentText() or "").strip()
+        if text == self.DEFAULT_LABEL:
+            return ""
+        return text
 
 
 def _hrule(palette: Dict[str, str]) -> QFrame:
@@ -314,23 +689,42 @@ def _section_label(text: str) -> QLabel:
     return lbl
 
 
+def _section_block(palette: Dict[str, str], text: str) -> QWidget:
+    """Section label preceded by a thin rule, so the page has a clear visual
+    rhythm — title, rule, sections-with-rules. A wall of section labels
+    alone blurs together as the eye scans down."""
+    wrap = QWidget()
+    box = QVBoxLayout(wrap)
+    box.setContentsMargins(0, 26, 0, 0)
+    box.setSpacing(12)
+    rule = QFrame()
+    rule.setProperty("role", "rule")
+    rule.setFrameShape(QFrame.Shape.HLine)
+    rule.setStyleSheet(f"QFrame {{ background: {palette['line']}; }}")
+    rule.setFixedHeight(1)
+    box.addWidget(rule)
+    lbl = QLabel(text)
+    lbl.setProperty("role", "section")
+    box.addWidget(lbl)
+    return wrap
+
+
 def _field_row(label_text: str, widget: QWidget,
                hint: Optional[str] = None) -> QWidget:
-    """A `Label  ───  Control` row, vertically aligned, with optional hint."""
+    """Stacked field: label above, control below, optional hint under the
+    control. Stacked layout means every row in the page shares the same
+    horizontal rhythm — left-aligned at the page margin — instead of the
+    two-column "label / value" split, which left a wasteland of empty
+    pixels to the right of every short control."""
     container = QWidget()
     v = QVBoxLayout(container)
-    v.setContentsMargins(0, 4, 0, 4)
+    v.setContentsMargins(0, 6, 0, 8)
     v.setSpacing(4)
-    top = QHBoxLayout()
-    top.setContentsMargins(0, 0, 0, 0)
-    top.setSpacing(12)
-    lbl = QLabel(label_text)
-    lbl.setProperty("role", "field")
-    lbl.setMinimumWidth(160)
-    top.addWidget(lbl)
-    top.addStretch(1)
-    top.addWidget(widget, 0, Qt.AlignmentFlag.AlignRight)
-    v.addLayout(top)
+    if label_text:
+        lbl = QLabel(label_text)
+        lbl.setProperty("role", "field")
+        v.addWidget(lbl)
+    v.addWidget(widget)
     if hint:
         h = QLabel(hint)
         h.setProperty("role", "hint")
@@ -340,16 +734,19 @@ def _field_row(label_text: str, widget: QWidget,
 
 
 # --------------------------------------------------------------------------- #
-# Dialog
+# Tab page
 # --------------------------------------------------------------------------- #
-class SettingsDialog(QDialog):
+class BetterAnkiSettingsPage(QWidget):
+    """The BetterAnki settings UI, packaged as a tab for Anki's Preferences."""
+
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("BetterAnki — Settings")
-        self.setMinimumSize(QSize(560, 640))
-        self.setObjectName("root")
+        self.setObjectName(PAGE_OBJECT_NAME)
         self._cfg: Dict[str, Any] = mw.addonManager.getConfig(ADDON) or {}
         self._palette, _ = _resolve_palette()
+        # Strong refs to button groups created in _build; Qt will drop
+        # exclusivity if the group goes out of scope.
+        self._radio_groups: List[QButtonGroup] = []
         self._build()
         self._apply_styles()
 
@@ -378,48 +775,80 @@ class SettingsDialog(QDialog):
         accent = self._g("accent", "#6c8cff")
         self.setStyleSheet(_qss(self._palette, accent))
 
+    # Close the enclosing Preferences dialog so a follow-on native dialog can
+    # open without modal stacking. Walks up the parent chain because the tab
+    # is several layers deep inside a QTabWidget → QStackedWidget → QDialog.
+    def _close_enclosing_dialog(self) -> None:
+        w: Optional[QWidget] = self.parentWidget()
+        while w is not None:
+            if isinstance(w, QDialog):
+                try:
+                    w.accept()
+                except Exception:
+                    pass
+                return
+            w = w.parentWidget()
+
     # ----- ui ----- #
     def _build(self) -> None:
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
         outer.setSpacing(0)
 
-        # Scrollable content
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
         outer.addWidget(scroll, 1)
 
+        # Inside the scroll viewport: the content widget fills the full
+        # width of the dialog tab. We use generous internal padding to
+        # keep text from running right to the edge, but skip the previous
+        # centered narrow-column approach — the user wanted the page to
+        # actually use the dialog's horizontal space.
+        viewport = QWidget()
+        viewport.setObjectName("viewport")
+        scroll.setWidget(viewport)
+
+        vp = QHBoxLayout(viewport)
+        vp.setContentsMargins(0, 0, 0, 0)
+        vp.setSpacing(0)
+
         content = QWidget()
         content.setObjectName("content")
-        scroll.setWidget(content)
+        vp.addWidget(content, 1)
 
         v = QVBoxLayout(content)
-        v.setContentsMargins(36, 30, 36, 22)
+        # Wide internal padding so controls breathe but the column still
+        # spans the dialog width. (44px left/right matches the footer
+        # padding so the columns visually line up.)
+        v.setContentsMargins(44, 36, 44, 36)
         v.setSpacing(6)
 
-        # Title
-        title = QLabel("Settings")
-        title.setProperty("role", "title")
-        v.addWidget(title)
-        subtitle = QLabel("BetterAnki preferences — saved as you change them.")
-        subtitle.setProperty("role", "subtitle")
-        v.addWidget(subtitle)
-        v.addSpacing(10)
-        v.addWidget(_hrule(self._palette))
+        # Header — a small "Settings" wordmark so the column has a clear
+        # start. The tab itself says "BetterAnki", so the header doesn't
+        # need to repeat that.
+        header = QLabel("Settings")
+        header.setProperty("role", "page-title")
+        v.addWidget(header)
+        intro = QLabel("Changes apply immediately.")
+        intro.setProperty("role", "intro")
+        intro.setWordWrap(True)
+        v.addWidget(intro)
 
         # ----- Appearance ----- #
-        v.addWidget(_section_label("Appearance"))
+        v.addWidget(_section_block(self._palette, "Appearance"))
 
-        # Theme radio group
         self._theme_group = QButtonGroup(self)
+        # Strong ref so QButtonGroup isn't dropped on the next event loop tick.
+        self._radio_groups.append(self._theme_group)
         theme_box = QWidget()
-        tb = QVBoxLayout(theme_box)
+        tb = QHBoxLayout(theme_box)
         tb.setContentsMargins(0, 0, 0, 0)
-        tb.setSpacing(2)
+        tb.setSpacing(14)
         current = self._g("theme", "system")
         for value, label in [
-            ("system", "System (follow OS appearance)"),
+            ("system", "System"),
             ("light", "Light"),
             ("dark", "Dark"),
         ]:
@@ -430,59 +859,125 @@ class SettingsDialog(QDialog):
                 lambda checked, val=value: checked and self._theme_changed(val)
             )
             tb.addWidget(rb)
+        tb.addStretch(1)
+        # Theme is self-explanatory — three labels named for what they do.
+        # A hint just restating "System follows the OS" adds noise.
         v.addWidget(_field_row("Theme", theme_box))
 
-        # Accent
+        accent_box = QWidget()
+        ab = QHBoxLayout(accent_box)
+        ab.setContentsMargins(0, 0, 0, 0)
+        ab.setSpacing(12)
         self._accent_btn = ColorSwatch(
             self._g("accent", "#6c8cff"),
-            lambda c: (self._set("accent", c), self._apply_styles()),
+            self._on_accent_changed,
         )
+        self._accent_value = QLabel(self._g("accent", "#6c8cff").upper())
+        self._accent_value.setProperty("role", "mono")
+        # Vertically center the hex label against the 30px swatch so the
+        # text baseline doesn't sit awkwardly low.
+        ab.addWidget(self._accent_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+        ab.addWidget(self._accent_value, 0, Qt.AlignmentFlag.AlignVCenter)
+        ab.addStretch(1)
         v.addWidget(_field_row(
-            "Accent",
-            self._accent_btn,
-            "Recolors links, the streak number, current-deck rule, and the "
-            "primary Study button.",
+            "Accent", accent_box,
+            "Used for links and the primary Study button.",
+        ))
+
+        v.addWidget(self._radio_row(
+            "density", "comfortable",
+            [("compact", "Compact"),
+             ("cozy", "Cozy"),
+             ("comfortable", "Comfortable")],
+            "Density",
+            "Compact fits more on screen; Comfortable gives each row more air.",
         ))
 
         # ----- Features ----- #
-        v.addWidget(_hrule(self._palette))
-        v.addWidget(_section_label("Features"))
+        # Order matters here: the two "Hide bottom strip" toggles sit at the
+        # end as a deliberate pair (deck list / deck overview). They share
+        # a visual subgroup so the eye doesn't read them as four separate
+        # unrelated toggles.
+        v.addWidget(_section_block(self._palette, "Features"))
+        v.addSpacing(2)
 
-        for key, label, default, hint in [
-            ("sidebar_nav", "Left sidebar navigation", True,
-             "Replaces Anki's top toolbar with the BetterAnki rail."),
-            ("show_heatmap", "Review-activity heatmap", True,
-             "GitHub-style grid of your reviews on the deck homepage."),
-            ("show_progress", "Reviewer progress bar", True,
-             "Thin progress strip at the top of the reviewer."),
-            ("hide_bottom_on_decks", "Hide bottom strip on deck list", True,
-             "Frees the homepage from Anki's legacy bottom bar."),
-            ("hide_bottom_on_overview", "Hide bottom strip on deck overview",
-             True,
-             "Removes the Options / Custom Study / Description row."),
-        ]:
+        def feature_row(key: str, label: str, default: bool, hint: str) -> QWidget:
             cb = QCheckBox(label)
             cb.setChecked(bool(self._g(key, default)))
             cb.toggled.connect(
                 lambda checked, k=key: self._set(k, bool(checked))
             )
-            row = QVBoxLayout()
-            row.setContentsMargins(0, 0, 0, 0)
-            row.setSpacing(0)
             wrap = QWidget()
-            wrap.setLayout(row)
+            row = QVBoxLayout(wrap)
+            row.setContentsMargins(0, 2, 0, 4)
+            row.setSpacing(2)
             row.addWidget(cb)
-            h = QLabel("    " + hint)
+            h = QLabel(hint)
             h.setProperty("role", "hint")
             h.setWordWrap(True)
-            h.setContentsMargins(28, 0, 0, 6)
+            h.setContentsMargins(30, 0, 0, 0)
             row.addWidget(h)
-            v.addWidget(wrap)
+            return wrap
+
+        v.addWidget(feature_row(
+            "sidebar_nav", "Left sidebar navigation", True,
+            "Replaces Anki's top toolbar with the BetterAnki rail.",
+        ))
+        v.addWidget(feature_row(
+            "show_streak", "Show streak counter", True,
+            "Flame + day count above the heatmap and in the sidebar.",
+        ))
+        v.addWidget(feature_row(
+            "show_progress", "Reviewer progress bar", True,
+            "Thin progress strip across the top of the reviewer.",
+        ))
+        v.addWidget(feature_row(
+            "hide_bottom_on_decks",
+            "Hide bottom strip on the deck list", True,
+            "Those actions move inline into the homepage.",
+        ))
+        v.addWidget(feature_row(
+            "hide_bottom_on_overview",
+            "Hide bottom strip on the deck overview", True,
+            "Removes the Options / Custom Study / Description row.",
+        ))
+
+        # ----- Reviewer ----- #
+        v.addWidget(_section_block(self._palette, "Reviewer"))
+
+        v.addWidget(self._radio_row(
+            "reviewer_card_width", "medium",
+            [("narrow", "Narrow"),
+             ("medium", "Medium"),
+             ("wide", "Wide"),
+             ("full", "Full")],
+            "Card width",
+            "Maximum width of the card body during review.",
+        ))
+
+        v.addWidget(self._radio_row(
+            "reviewer_font_size", "medium",
+            [("small", "Small"),
+             ("medium", "Medium"),
+             ("large", "Large"),
+             ("x-large", "XL")],
+            "Font size",
+            "Base size used to render the card front and back.",
+        ))
 
         # ----- Heatmap ----- #
-        v.addWidget(_hrule(self._palette))
-        v.addWidget(_section_label("Heatmap"))
+        # Heatmap-related settings live together: the toggle to enable it,
+        # plus the minimum-weeks slider that controls its width. Used to be
+        # split across Features + its own one-field section, which felt
+        # arbitrary.
+        v.addWidget(_section_block(self._palette, "Heatmap"))
+        v.addSpacing(2)
 
+        # Track the heatmap toggle so we can gray out the minimum-weeks
+        # field when the heatmap is off — leaving it active suggests the
+        # value still matters, which it doesn't.
+        heatmap_cb = QCheckBox("Show review-activity heatmap")
+        heatmap_cb.setChecked(bool(self._g("show_heatmap", True)))
         weeks = QSpinBox()
         weeks.setRange(8, 260)
         weeks.setSingleStep(1)
@@ -491,136 +986,252 @@ class SettingsDialog(QDialog):
         weeks.valueChanged.connect(
             lambda val: self._set("heatmap_weeks", int(val))
         )
-        v.addWidget(_field_row(
-            "Minimum weeks shown",
-            weeks,
-            "The heatmap always extends back to your first review; never "
-            "renders fewer than this many columns.",
+        weeks_wrap = QWidget()
+        ww = QHBoxLayout(weeks_wrap)
+        ww.setContentsMargins(0, 0, 0, 0)
+        ww.addWidget(weeks)
+        ww.addStretch(1)
+        weeks_row = _field_row(
+            "Minimum weeks shown", weeks_wrap,
+            "For new collections; older ones extend back to your first review.",
+        )
+
+        def _toggle_heatmap(checked: bool) -> None:
+            self._set("show_heatmap", bool(checked))
+            weeks_row.setEnabled(bool(checked))
+
+        heatmap_cb.toggled.connect(_toggle_heatmap)
+        weeks_row.setEnabled(heatmap_cb.isChecked())
+
+        heatmap_wrap = QWidget()
+        hrow = QVBoxLayout(heatmap_wrap)
+        hrow.setContentsMargins(0, 2, 0, 4)
+        hrow.setSpacing(2)
+        hrow.addWidget(heatmap_cb)
+        hint = QLabel("A daily-review grid on the deck homepage.")
+        hint.setProperty("role", "hint")
+        hint.setWordWrap(True)
+        hint.setContentsMargins(30, 0, 0, 0)
+        hrow.addWidget(hint)
+        v.addWidget(heatmap_wrap)
+        # Indent the weeks row so it visually nests under the toggle —
+        # the spinbox is meaningful only when the toggle above is on.
+        weeks_indent = QWidget()
+        wi = QHBoxLayout(weeks_indent)
+        wi.setContentsMargins(30, 0, 0, 0)
+        wi.addWidget(weeks_row)
+        v.addWidget(weeks_indent)
+
+        # Heatmap palette swatches.
+        current_accent = self._g("accent", "#6c8cff")
+        palette_options: List[Tuple[str, str, str]] = [
+            ("accent", current_accent, "Match the accent color"),
+            ("green", "#2ea043", "GitHub green"),
+            ("teal", "#14b8a6", "Teal"),
+            ("violet", "#8b5cf6", "Violet"),
+            ("rose", "#f43f5e", "Rose"),
+            ("amber", "#f59e0b", "Amber"),
+        ]
+        palette_widget = PaletteSwatchRow(
+            palette_options,
+            current=self._g("heatmap_palette", "accent"),
+            ink_faint=self._palette["ink_faint"],
+            accent=current_accent,
+            on_change=lambda v: self._set("heatmap_palette", v),
+        )
+        self._heatmap_palette_widget = palette_widget
+        palette_indent = QWidget()
+        pi = QHBoxLayout(palette_indent)
+        pi.setContentsMargins(30, 4, 0, 0)
+        pi.addWidget(_field_row(
+            "Palette", palette_widget,
+            "Color used for the heatmap cells. “Accent” follows your accent above.",
         ))
+        v.addWidget(palette_indent)
 
         # ----- Typography ----- #
-        v.addWidget(_hrule(self._palette))
-        v.addWidget(_section_label("Typography"))
+        v.addWidget(_section_block(self._palette, "Typography"))
 
-        serif = QLineEdit(self._g("font_serif", ""))
-        serif.setPlaceholderText('e.g. "Iowan Old Style", Georgia')
-        serif.setMinimumWidth(220)
-        serif.editingFinished.connect(
-            lambda: self._set("font_serif", serif.text().strip())
+        # Cap font-name inputs at a comfortable single-line width so they
+        # don't stretch into a 700px form field on a wide page.
+        serif = FontPicker("serif", self._g("font_serif", ""))
+        serif.currentTextChanged.connect(
+            lambda _t: self._set("font_serif", serif.value())
         )
         v.addWidget(_field_row(
-            "Display serif", serif,
-            "Prepended to the existing serif stack. Headings, deck names. "
-            "Leave blank for the system default.",
+            "Display serif",
+            self._font_wrap(serif),
+            "Used for headings and deck names. Falls back to Georgia.",
         ))
 
-        sans = QLineEdit(self._g("font_sans", ""))
-        sans.setPlaceholderText('e.g. "Inter", "SF Pro Text"')
-        sans.setMinimumWidth(220)
-        sans.editingFinished.connect(
-            lambda: self._set("font_sans", sans.text().strip())
+        sans = FontPicker("sans", self._g("font_sans", ""))
+        sans.currentTextChanged.connect(
+            lambda _t: self._set("font_sans", sans.value())
         )
         v.addWidget(_field_row(
-            "Body sans", sans,
-            "Prepended to the existing sans stack. Labels, counts, UI.",
+            "Body sans",
+            self._font_wrap(sans),
+            "Used for labels, counts, and UI text. Falls back to the system "
+            "sans.",
         ))
 
-        # ----- Anki — surfaces native Anki dialogs we couldn't merge inline ----- #
-        v.addWidget(_hrule(self._palette))
-        v.addWidget(_section_label("Anki"))
+        # ----- Open in Anki ----- #
+        # Quick jumps to native Anki dialogs the standard Preferences tabs
+        # don't surface. "Open Anki Preferences" is absent — the user is
+        # already inside it.
+        v.addWidget(_section_block(self._palette, "Open in Anki"))
 
-        def _open(fn, *args):
-            """Close our dialog then call fn(*args). Anki dialogs can't be
-            modal-stacked nicely; close-then-open keeps focus sane."""
+        def _jump(fn, *args):
             def go():
-                try:
-                    self.accept()
-                except Exception:
-                    pass
+                self._close_enclosing_dialog()
                 try:
                     fn(*args)
                 except Exception:
                     pass
             return go
 
-        def native_btn(label: str, hint: str, callback) -> QWidget:
-            wrap = QWidget()
-            row = QVBoxLayout(wrap)
-            row.setContentsMargins(0, 0, 0, 0)
-            row.setSpacing(2)
-            b = QPushButton(label + "  →")
-            b.setCursor(Qt.CursorShape.PointingHandCursor)
-            b.clicked.connect(callback)
-            b.setStyleSheet("text-align: left;")
-            row.addWidget(b)
-            h = QLabel("    " + hint)
-            h.setProperty("role", "hint")
-            h.setWordWrap(True)
-            row.addWidget(h)
-            return wrap
-
-        v.addWidget(native_btn(
-            "Open Anki Preferences",
-            "The standard Anki preferences dialog (review settings, sync, "
-            "appearance, etc.).",
-            _open(mw.onPrefs),
-        ))
-
         def _open_current_deck_opts():
             try:
                 from aqt.deckoptions import display_options_for_deck_id
                 from anki.decks import DeckId
                 did = DeckId(int(mw.col.decks.get_current_id()))
-                self.accept()
+                self._close_enclosing_dialog()
                 display_options_for_deck_id(did)
             except Exception:
                 pass
 
-        v.addWidget(native_btn(
+        def jump_item(label: str, hint: str, callback) -> QWidget:
+            wrap = QWidget()
+            box = QVBoxLayout(wrap)
+            box.setContentsMargins(0, 4, 0, 6)
+            box.setSpacing(2)
+            btn = QPushButton(label + "  ↗")
+            btn.setObjectName("jump")
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            btn.clicked.connect(callback)
+            box.addWidget(btn, 0, Qt.AlignmentFlag.AlignLeft)
+            h = QLabel(hint)
+            h.setProperty("role", "hint")
+            h.setWordWrap(True)
+            box.addWidget(h)
+            return wrap
+
+        v.addWidget(jump_item(
             "Open deck options",
-            "Configure the current deck's review settings, new-card limits, "
-            "FSRS parameters, etc.",
+            "Review settings, new-card limits, FSRS parameters for the "
+            "current deck.",
             _open_current_deck_opts,
         ))
-
-        v.addWidget(native_btn(
+        v.addWidget(jump_item(
             "Manage note types",
-            "Add, edit, and delete note types (card templates).",
-            _open(mw.onNoteTypes),
+            "Add, edit, and delete note types and card templates.",
+            _jump(mw.onNoteTypes),
         ))
-
-        v.addWidget(native_btn(
+        v.addWidget(jump_item(
             "Open add-ons",
             "Manage installed add-ons.",
-            _open(mw.addonManager.onAddonsDialog),
+            _jump(mw.addonManager.onAddonsDialog),
         ))
 
-        v.addSpacing(20)
+        # The footer used to live inside the scrollable column, which meant
+        # it floated wherever the content ended. Now it's a sibling of the
+        # scroll area in the outer layout — pinned to the bottom of the
+        # dialog, always visible, always reachable.
         v.addStretch(1)
 
-        # ----- Footer (sticky) ----- #
         footer = QWidget()
-        footer.setObjectName("root")
-        f = QHBoxLayout(footer)
-        f.setContentsMargins(36, 14, 36, 18)
-        f.setSpacing(10)
-        restore = QPushButton("Restore defaults")
-        restore.clicked.connect(self._restore_defaults)
-        close_btn = QPushButton("Close")
-        close_btn.setObjectName("primary")
-        close_btn.clicked.connect(self.accept)
-        f.addWidget(restore)
-        f.addStretch(1)
-        f.addWidget(close_btn)
+        footer.setObjectName("footer")
+        f = QVBoxLayout(footer)
+        f.setContentsMargins(0, 0, 0, 0)
+        f.setSpacing(0)
+        rule = QFrame()
+        rule.setProperty("role", "rule")
+        rule.setFrameShape(QFrame.Shape.HLine)
+        rule.setStyleSheet(f"QFrame {{ background: {self._palette['line']}; }}")
+        rule.setFixedHeight(1)
+        f.addWidget(rule)
 
-        outer.addWidget(_hrule(self._palette))
+        footer_inner = QWidget()
+        fi = QHBoxLayout(footer_inner)
+        fi.setContentsMargins(44, 16, 44, 16)
+        fi.setSpacing(16)
+        restore = QPushButton("Restore BetterAnki defaults")
+        restore.setObjectName("quiet")
+        restore.setCursor(Qt.CursorShape.PointingHandCursor)
+        restore.clicked.connect(self._restore_defaults)
+        fi.addWidget(restore, 0, Qt.AlignmentFlag.AlignLeft)
+        fi.addStretch(1)
+        version = QLabel(f"BetterAnki v{_human_version()}")
+        version.setProperty("role", "wordmark")
+        fi.addWidget(version, 0, Qt.AlignmentFlag.AlignVCenter)
+        done = QPushButton("Done")
+        done.setObjectName("primary")
+        done.setCursor(Qt.CursorShape.PointingHandCursor)
+        done.clicked.connect(self._close_enclosing_dialog)
+        fi.addWidget(done, 0, Qt.AlignmentFlag.AlignRight)
+        f.addWidget(footer_inner)
+
         outer.addWidget(footer)
 
+    # ----- builders ----- #
+    def _radio_row(self, key: str, default: str,
+                   options: List[Tuple[str, str]],
+                   label: str, hint: Optional[str] = None) -> QWidget:
+        """Horizontal radio group as a stacked field row. options is
+        ``[(config_value, display_label), …]``."""
+        group = QButtonGroup(self)
+        # Keep a reference so the group isn't garbage-collected and the
+        # exclusivity stops working — Qt notoriously drops un-referenced
+        # QButtonGroups created inside methods.
+        self._radio_groups.append(group)
+        box = QWidget()
+        h = QHBoxLayout(box)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(14)
+        current = self._g(key, default)
+        for value, opt_label in options:
+            rb = QRadioButton(opt_label)
+            rb.setChecked(current == value)
+            group.addButton(rb)
+            rb.toggled.connect(
+                lambda checked, k=key, v=value: checked and self._set(k, v)
+            )
+            h.addWidget(rb)
+        h.addStretch(1)
+        return _field_row(label, box, hint)
+
+    def _font_wrap(self, picker: "FontPicker") -> QWidget:
+        """A FontPicker + a quiet italic "optional" to its right; the tag
+        hides as soon as the user picks (or types) a real value. Once
+        there is a value, "optional" stops being information."""
+        wrap = QWidget()
+        h = QHBoxLayout(wrap)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(12)
+        h.addWidget(picker)
+        tag = QLabel("optional")
+        tag.setProperty("role", "tag")
+        tag.setVisible(not picker.value())
+        picker.currentTextChanged.connect(
+            lambda _t: tag.setVisible(not picker.value())
+        )
+        h.addWidget(tag, 0, Qt.AlignmentFlag.AlignVCenter)
+        h.addStretch(1)
+        return wrap
+
     # ----- handlers ----- #
+    def _on_accent_changed(self, color: str) -> None:
+        self._set("accent", color)
+        try:
+            self._accent_value.setText(color.upper())
+        except Exception:
+            pass
+        self._apply_styles()
+
     def _theme_changed(self, value: str) -> None:
         self._set("theme", value)
-        # Re-resolve the dialog palette so the dialog itself reflects the
-        # new choice immediately (Light ↔ Dark switch is live).
+        # Re-resolve the page palette so the tab itself reflects the new
+        # choice immediately (Light ↔ Dark switch is live).
         self._palette, _ = _resolve_palette()
         self._apply_styles()
 
@@ -628,12 +1239,17 @@ class SettingsDialog(QDialog):
         defaults = {
             "theme": "system",
             "accent": "#6c8cff",
+            "density": "comfortable",
             "sidebar_nav": True,
             "show_heatmap": True,
             "show_progress": True,
+            "show_streak": True,
             "hide_bottom_on_decks": True,
             "hide_bottom_on_overview": True,
             "heatmap_weeks": 53,
+            "heatmap_palette": "accent",
+            "reviewer_card_width": "medium",
+            "reviewer_font_size": "medium",
             "font_serif": "",
             "font_sans": "",
         }
@@ -642,17 +1258,14 @@ class SettingsDialog(QDialog):
             mw.addonManager.writeConfig(ADDON, defaults)
         except Exception:
             pass
-        # Re-render the deck browser with defaults; rebuild the dialog so the
-        # widgets reflect the new state. The dialog stays open.
         try:
             state = getattr(mw, "state", "")
             if state == "deckBrowser":
                 mw.deckBrowser.refresh()
         except Exception:
             pass
-        # Rebuild the dialog in-place so radio/checkbox/swatch states reset.
+        # Rebuild in-place so each widget reflects the reset state.
         try:
-            # Clear all children from the dialog
             for child in self.findChildren(QWidget):
                 child.deleteLater()
             old_layout = self.layout()
@@ -661,10 +1274,125 @@ class SettingsDialog(QDialog):
         except Exception:
             pass
         self._palette, _ = _resolve_palette()
+        self._radio_groups.clear()
         self._build()
         self._apply_styles()
 
 
+# --------------------------------------------------------------------------- #
+# Integration with Anki's Preferences dialog
+# --------------------------------------------------------------------------- #
+_PATCHED = False
+
+
+def install_into_preferences() -> None:
+    """Make every newly-opened Preferences dialog gain a "BetterAnki" tab.
+
+    Anki exposes ``Preferences.setupOptions`` as an explicit (legacy)
+    extension point: the parent ``__init__`` calls it after ``setupUi`` has
+    populated ``self.form.tabWidget``. We wrap it so the original (and any
+    other add-on's wrap) still runs. Idempotent across re-imports.
+
+    The wrap also hides Anki's native bottom chrome (the "Some settings
+    will take effect…" warning + the Help/Close buttonBox) whenever the
+    BetterAnki tab is current — those controls don't apply to our settings
+    and the page should own the whole dialog.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return
+    try:
+        from aqt.preferences import Preferences
+    except Exception:
+        return
+    original = getattr(Preferences, "setupOptions", None)
+
+    def patched(self) -> None:
+        if callable(original):
+            try:
+                original(self)
+            except Exception:
+                pass
+        try:
+            tw = self.form.tabWidget
+        except Exception:
+            return
+        # Guard against being added twice if Anki ever re-runs setupOptions
+        # on the same instance (a different add-on doing something odd).
+        for i in range(tw.count()):
+            if tw.tabText(i) == TAB_TITLE:
+                return
+        try:
+            page = BetterAnkiSettingsPage(parent=tw)
+            tw.addTab(page, TAB_TITLE)
+        except Exception:
+            return
+
+        # Take over the bottom of the dialog when our tab is current.
+        # Native widgets: the QDialogButtonBox (Help/Close) and the
+        # "Some settings will take effect…" warning label. Stash the
+        # references so we can show/hide them per tab.
+        chrome: List[QWidget] = []
+        for w in self.findChildren(QDialogButtonBox):
+            chrome.append(w)
+        for w in self.findChildren(QLabel):
+            text = (w.text() or "").lower()
+            if "take effect" in text or "restart" in text:
+                chrome.append(w)
+
+        def update_chrome(idx: int) -> None:
+            try:
+                is_ours = tw.tabText(idx) == TAB_TITLE
+            except Exception:
+                is_ours = False
+            for cw in chrome:
+                try:
+                    cw.setVisible(not is_ours)
+                except Exception:
+                    pass
+
+        try:
+            tw.currentChanged.connect(update_chrome)
+            update_chrome(tw.currentIndex())
+        except Exception:
+            pass
+
+    try:
+        Preferences.setupOptions = patched  # type: ignore[assignment]
+        _PATCHED = True
+    except Exception:
+        pass
+
+
+def _select_betteranki_tab(dlg: Any) -> None:
+    try:
+        tw = dlg.form.tabWidget
+    except Exception:
+        return
+    for i in range(tw.count()):
+        if tw.tabText(i) == TAB_TITLE:
+            try:
+                tw.setCurrentIndex(i)
+            except Exception:
+                pass
+            return
+
+
 def open_settings(parent: Any = None) -> None:
-    dlg = SettingsDialog(parent or mw)
-    dlg.exec()
+    """Open Anki's Preferences dialog with the BetterAnki tab selected.
+
+    Used by every BetterAnki entry point (Cmd+, shortcut, sidebar cog,
+    Tools menu, add-on manager Config button)."""
+    install_into_preferences()
+    dlg = None
+    try:
+        import aqt
+        dlg = aqt.dialogs.open("Preferences", mw)
+    except Exception:
+        try:
+            from aqt.preferences import Preferences
+            dlg = Preferences(mw)
+        except Exception:
+            return
+    if dlg is not None:
+        _select_betteranki_tab(dlg)

--- a/web/check.svg
+++ b/web/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="white" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3.2,8.4 6.8,12 12.8,4.4"/>
+</svg>

--- a/web/chevron-down.svg
+++ b/web/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none" stroke="#7a7468" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3,4.6 6,7.6 9,4.6"/>
+</svg>

--- a/web/chevron-up.svg
+++ b/web/chevron-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none" stroke="#7a7468" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3,7.4 6,4.4 9,7.4"/>
+</svg>

--- a/web/heatmap.css
+++ b/web/heatmap.css
@@ -91,11 +91,11 @@
 .rf-hm-col .rf-hm-cell:last-child { margin-bottom: 0; }
 .rf-hm-empty { background: transparent; }
 
-.rf-hm-l0 { background: #20242e; }
-.rf-hm-l1 { background: #1f3d5c; }
-.rf-hm-l2 { background: #2f6aa8; }
-.rf-hm-l3 { background: #4f9ae0; }
-.rf-hm-l4 { background: #7fc4ff; }
+.rf-hm-l0 { background: var(--rf-hm-l0, #20242e); }
+.rf-hm-l1 { background: var(--rf-hm-l1, #1f3d5c); }
+.rf-hm-l2 { background: var(--rf-hm-l2, #2f6aa8); }
+.rf-hm-l3 { background: var(--rf-hm-l3, #4f9ae0); }
+.rf-hm-l4 { background: var(--rf-hm-l4, #7fc4ff); }
 
 .rf-hm-col .rf-hm-cell:not(.rf-hm-empty) { cursor: pointer; }
 .rf-hm-col .rf-hm-cell:not(.rf-hm-empty):hover {

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -8,21 +8,21 @@ html, body {
   color: var(--rf-ink, #eceae2) !important;
 }
 /* Anki sets `<body class="card cardN">` on the reviewer. We center the
-   reading column by giving body symmetric padding via calc — viewports
-   ≥ 784px get an auto-centered 720px column; narrower viewports collapse
-   to a 32px gutter. Doing this on body (instead of a wrapper) means we
-   don't need to modify Anki's reviewer DOM, and the back-button (fixed)
-   and progress strip (fixed) aren't affected. */
+   reading column by giving body symmetric padding via calc — wider
+   viewports get an auto-centered column at --rf-card-max-width, narrower
+   ones collapse to a 32px gutter. Doing this on body (instead of a
+   wrapper) means we don't need to modify Anki's reviewer DOM, and the
+   back-button (fixed) and progress strip (fixed) aren't affected. */
 body {
   font-family: var(--rf-sans, ui-sans-serif, -apple-system, system-ui, sans-serif);
   padding-top: 56px !important;
   padding-bottom: 84px !important;
-  padding-left: max(32px, calc((100% - 720px) / 2)) !important;
-  padding-right: max(32px, calc((100% - 720px) / 2)) !important;
+  padding-left: max(32px, calc((100% - var(--rf-card-max-width, 720px)) / 2)) !important;
+  padding-right: max(32px, calc((100% - var(--rf-card-max-width, 720px)) / 2)) !important;
   margin: 0 !important;
   line-height: 1.55;
   text-align: center;
-  font-size: 18px;
+  font-size: var(--rf-card-font-size, 18px);
 }
 
 /* `<body class="card">` would otherwise inherit our generic `.card` rule
@@ -34,9 +34,9 @@ body.card {
 /* Generic .card rules — apply to a card wrapper if the user's template uses
    one, but NOT to body (handled above). */
 :not(body).card {
-  max-width: 720px;
+  max-width: var(--rf-card-max-width, 720px);
   margin: 0 auto;
-  font-size: 18px;
+  font-size: var(--rf-card-font-size, 18px);
   line-height: 1.55;
   color: var(--rf-ink, #eceae2);
 }
@@ -51,7 +51,7 @@ body.card {
   height: 1px;
   background: var(--rf-line, rgba(127, 127, 127, 0.18));
   margin: 38px auto 28px;
-  max-width: 720px;
+  max-width: var(--rf-card-max-width, 720px);
   overflow: visible;
 }
 #answer::after {

--- a/web/theme.css
+++ b/web/theme.css
@@ -11,6 +11,29 @@
 
 /* ============================ THEME TOKENS ============================ */
 /* dark = default */
+/* Page-level density scales — driven by data-rf-density on <html>. The
+   values are picked up by the .ba-home spacing block further down, and
+   by the row-padding on deck rows. Default is "comfortable". */
+:root[data-rf-density="compact"] {
+  --rf-pad-page: 26px;
+  --rf-pad-page-bottom: 20px;
+  --rf-pad-row: 12px;
+  --rf-gap-section: 26px;
+}
+:root[data-rf-density="cozy"] {
+  --rf-pad-page: 32px;
+  --rf-pad-page-bottom: 26px;
+  --rf-pad-row: 16px;
+  --rf-gap-section: 32px;
+}
+:root[data-rf-density="comfortable"],
+:root:not([data-rf-density]) {
+  --rf-pad-page: 40px;
+  --rf-pad-page-bottom: 32px;
+  --rf-pad-row: 20px;
+  --rf-gap-section: 40px;
+}
+
 :root {
   --rf-paper: #0b0c0f;
   --rf-panel: #121319;
@@ -107,19 +130,26 @@
   --rf-bg: #060708;
 }
 
-/* heatmap cells get a light-mode scale (the dark scale is in heatmap.css) */
+/* Heatmap palette — set as CSS variables so the user's "heatmap_palette"
+   setting in BetterAnki preferences can override these via a higher-
+   specificity injection. heatmap.css consumes the vars; we just provide
+   defaults appropriate to the active theme. */
 @media (prefers-color-scheme: light) {
-  :root:not([data-rf-theme="dark"]) .rf-hm-l0 { background: rgba(31,29,24,.07); }
-  :root:not([data-rf-theme="dark"]) .rf-hm-l1 { background: #cfe0f5; }
-  :root:not([data-rf-theme="dark"]) .rf-hm-l2 { background: #8eb1de; }
-  :root:not([data-rf-theme="dark"]) .rf-hm-l3 { background: #4d7fc4; }
-  :root:not([data-rf-theme="dark"]) .rf-hm-l4 { background: #1f5cae; }
+  :root:not([data-rf-theme="dark"]) {
+    --rf-hm-l0: rgba(31,29,24,.07);
+    --rf-hm-l1: #cfe0f5;
+    --rf-hm-l2: #8eb1de;
+    --rf-hm-l3: #4d7fc4;
+    --rf-hm-l4: #1f5cae;
+  }
 }
-:root[data-rf-theme="light"] .rf-hm-l0 { background: rgba(31,29,24,.07); }
-:root[data-rf-theme="light"] .rf-hm-l1 { background: #cfe0f5; }
-:root[data-rf-theme="light"] .rf-hm-l2 { background: #8eb1de; }
-:root[data-rf-theme="light"] .rf-hm-l3 { background: #4d7fc4; }
-:root[data-rf-theme="light"] .rf-hm-l4 { background: #1f5cae; }
+:root[data-rf-theme="light"] {
+  --rf-hm-l0: rgba(31,29,24,.07);
+  --rf-hm-l1: #cfe0f5;
+  --rf-hm-l2: #8eb1de;
+  --rf-hm-l3: #4d7fc4;
+  --rf-hm-l4: #1f5cae;
+}
 
 /* ============================== BASE ============================== */
 html, body {
@@ -163,7 +193,9 @@ body::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 40px 40px 32px;
+  padding: var(--rf-pad-page, 40px)
+           var(--rf-pad-page, 40px)
+           var(--rf-pad-page-bottom, 32px);
   min-height: 100vh;
   box-sizing: border-box;
 }
@@ -253,12 +285,12 @@ body::before {
   border: 0 !important;
   border-bottom: 1px solid var(--rf-line) !important;
   border-radius: 0 !important;
-  padding: 16px 10px !important;
+  padding: var(--rf-pad-row, 16px) 10px !important;
   vertical-align: middle;
   transition: background 120ms ease;
 }
 .ba-home tr.deck td.decktd { padding-left: 4px !important; }
-.ba-home tr.deck td[align="end"] { padding: 16px 6px !important; }
+.ba-home tr.deck td[align="end"] { padding: var(--rf-pad-row, 16px) 6px !important; }
 .ba-home tr.deck:hover:not(.top-level-drag-row) td {
   background: var(--rf-row-hover) !important;
   border-radius: 0 !important;


### PR DESCRIPTION
## Summary

- Settings now live as their own tab inside Anki's native Preferences dialog. The patch on `Preferences.setupOptions` injects the tab and, on tab change, hides Anki's "Some settings will take effect…" warning and the Help/Close button-box so the BetterAnki page owns the whole dialog area; a pinned footer at the bottom of the page provides the Restore-defaults link and a primary **Done** button.
- New settings wired end-to-end: density (compact/cozy/comfortable → `data-rf-density` consumed by `theme.css`), show streak counter (gates the practice header flame), heatmap palette (six palettes with separate light/dark shade ramps + accent-derived shades blended toward the active canvas), reviewer card width and font size (CSS vars consumed by `reviewer.css`).
- Font picker rebuilt as a `QComboBox` of curated serif/sans recommendations filtered to what `QFontDatabase` reports installed, with every other installed family below a separator; each entry renders in its own face. Real checkboxes/spinbox chevrons via on-disk SVGs in `web/` (Qt6 silently drops data: URLs in QSS).
- Typography bumped substantially (serif title 28pt, field labels 15pt 600, hints 13pt, controls 14pt) and the page now spans the full dialog width with comfortable internal padding instead of a centred narrow column.

## Test plan
- [ ] Open Preferences (Cmd+,, sidebar cog, Tools → BetterAnki Settings…, or the addon-manager Config button) — verify the BetterAnki tab is selected and Anki's bottom warning + Help/Close are hidden
- [ ] Switch to another Preferences tab — verify the native warning and Help/Close reappear
- [ ] Toggle every setting in light, dark, and system theme; verify each one has a visible effect (sidebar, streak, heatmap, density, reviewer width/size, accent, font picker)
- [ ] Try every heatmap palette in both light and dark mode — colours should read against the active canvas
- [ ] Click Done — dialog closes; reopen and confirm settings persisted