### PR TITLE
Rebuild Add Card page: editorial chrome, inline pickers, main-window embed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1197,6 +1197,23 @@ def _dev_screenshot(request_path: str) -> None:
                 pass
         if click_cog:
             QTimer.singleShot(700, _click_cog)
+        # Optionally trigger the in-page note-type picker so the dropdown is
+        # visible in the screenshot.
+        click_type = bool(req.get("click_type"))
+        def _click_type() -> None:
+            try:
+                from aqt import dialogs
+                from PyQt6.QtWidgets import QPushButton as _QPB
+                ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+                if ac is None:
+                    return
+                btns = ac.form.modelArea.findChildren(_QPB)
+                if btns:
+                    btns[0].click()
+            except Exception:
+                pass
+        if click_type:
+            QTimer.singleShot(800, _click_type)
 
         # Give the WebEngine view time to render (templates load async).
         # 1500ms is conservative; the editor.html bundle plus Svelte hydration

--- a/__init__.py
+++ b/__init__.py
@@ -555,9 +555,23 @@ def _on_js_message(handled, message, context):
     cmd = message[3:]
     try:
         if cmd == "decks":
+            # If we're in the embedded Add view, close it first so the deck
+            # browser becomes visible again.
+            try:
+                from . import addcard_embed
+                addcard_embed.close_inline()
+            except Exception:
+                pass
             mw.moveToState("deckBrowser")
         elif cmd == "add":
-            mw.onAddCard()
+            # Open AddCards inside the main window (over the deck area, to
+            # the right of the sidebar). Falls back to the standard window
+            # if the embed setup fails.
+            try:
+                from . import addcard_embed
+                addcard_embed.open_inline(mw)
+            except Exception:
+                mw.onAddCard()
         elif cmd == "browse":
             mw.onBrowse()
         elif cmd == "stats":
@@ -1106,9 +1120,14 @@ def _dev_screenshot(request_path: str) -> None:
         return
     try:
         from aqt.qt import QApplication, QTimer
+        embed_add = bool(req.get("embed_add"))
         if open_addcards:
             try:
-                mw.onAddCard()
+                if embed_add:
+                    from . import addcard_embed
+                    addcard_embed.open_inline(mw)
+                else:
+                    mw.onAddCard()
             except Exception:
                 pass
         # Optional: pre-fill the fields with sample text so we can validate

--- a/__init__.py
+++ b/__init__.py
@@ -1197,33 +1197,6 @@ def _dev_screenshot(request_path: str) -> None:
                 pass
         if click_cog:
             QTimer.singleShot(700, _click_cog)
-        # Optionally force the Add card button into its hover state so the
-        # shortcut chip is visible in the screenshot (we can't simulate a
-        # real mouse hover during grab()).
-        force_add_hover = bool(req.get("force_add_hover"))
-        def _force_hover() -> None:
-            try:
-                from aqt import dialogs
-                ac = dialogs._dialogs.get("AddCards", [None, None])[1]
-                if ac is None:
-                    return
-                root = ac.centralWidget()
-                if root is None:
-                    return
-                for child in root.findChildren(type(ac)):
-                    pass  # no-op; the chip widget is on the Add button
-                # Walk children to find the _AddCardButton instance.
-                from PyQt6.QtWidgets import QPushButton as _QPB  # type: ignore
-                for b in root.findChildren(_QPB):
-                    if b.objectName() == "ba-add":
-                        chip = getattr(b, "chip", None)
-                        if chip is not None:
-                            chip.show()
-                        break
-            except Exception:
-                pass
-        if force_add_hover:
-            QTimer.singleShot(800, _force_hover)
 
         # Give the WebEngine view time to render (templates load async).
         # 1500ms is conservative; the editor.html bundle plus Svelte hydration

--- a/__init__.py
+++ b/__init__.py
@@ -1180,6 +1180,23 @@ def _dev_screenshot(request_path: str) -> None:
                 pass
         if fill_sample:
             QTimer.singleShot(400, _fill)
+        # Optionally click the toolbar cog to verify the dropdown renders.
+        click_cog = bool(req.get("click_cog"))
+        def _click_cog() -> None:
+            try:
+                from aqt import dialogs
+                ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+                if ac is None:
+                    return
+                web = ac.editor.web
+                web.eval(
+                    "(function(){var b=document.querySelector('#settings button');"
+                    "if(b)b.click();})();"
+                )
+            except Exception:
+                pass
+        if click_cog:
+            QTimer.singleShot(700, _click_cog)
 
         # Give the WebEngine view time to render (templates load async).
         # 1500ms is conservative; the editor.html bundle plus Svelte hydration

--- a/__init__.py
+++ b/__init__.py
@@ -1197,6 +1197,33 @@ def _dev_screenshot(request_path: str) -> None:
                 pass
         if click_cog:
             QTimer.singleShot(700, _click_cog)
+        # Optionally force the Add card button into its hover state so the
+        # shortcut chip is visible in the screenshot (we can't simulate a
+        # real mouse hover during grab()).
+        force_add_hover = bool(req.get("force_add_hover"))
+        def _force_hover() -> None:
+            try:
+                from aqt import dialogs
+                ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+                if ac is None:
+                    return
+                root = ac.centralWidget()
+                if root is None:
+                    return
+                for child in root.findChildren(type(ac)):
+                    pass  # no-op; the chip widget is on the Add button
+                # Walk children to find the _AddCardButton instance.
+                from PyQt6.QtWidgets import QPushButton as _QPB  # type: ignore
+                for b in root.findChildren(_QPB):
+                    if b.objectName() == "ba-add":
+                        chip = getattr(b, "chip", None)
+                        if chip is not None:
+                            chip.show()
+                        break
+            except Exception:
+                pass
+        if force_add_hover:
+            QTimer.singleShot(800, _force_hover)
 
         # Give the WebEngine view time to render (templates load async).
         # 1500ms is conservative; the editor.html bundle plus Svelte hydration

--- a/__init__.py
+++ b/__init__.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Optional
 
 from aqt import gui_hooks, mw
 from aqt.deckbrowser import DeckBrowser, DeckBrowserContent
+from aqt.editor import Editor, EditorMode
 from aqt.overview import Overview
 from aqt.reviewer import Reviewer
 from aqt.webview import WebContent
@@ -62,10 +63,12 @@ def _is(context: Any, cls: Any) -> bool:
 # Theme + asset injection
 # --------------------------------------------------------------------------- #
 def on_webview_will_set_content(web_content: WebContent, context: Optional[Any]) -> None:
+    is_editor = isinstance(context, Editor)
     themed = (
         isinstance(context, (DeckBrowser, Overview, Reviewer))
         or _is(context, _ToolbarCtx)
         or _is(context, _BottomCtx)
+        or is_editor
     )
     if not themed:
         return
@@ -178,6 +181,21 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         web_content.css.append(f"{WEB}/reviewer.css")
         if cfg.get("show_progress", True):
             web_content.js.append(f"{WEB}/reviewer.js")
+    if is_editor:
+        # Only style the editor in ADD_CARDS mode — the same Editor is used
+        # by Browser and Edit-Current; we don't want to overwrite their
+        # chrome here. Anki's CSP blocks inline <script> in the editor page,
+        # so the mode AND theme are communicated via a meta tag in the head
+        # that addcard.js reads (avoiding inline-script CSP).
+        em = getattr(context, "editorMode", None)
+        if em == EditorMode.ADD_CARDS:
+            theme_safe = theme_pref if theme_pref in ("light", "dark") else ""
+            web_content.head += (
+                f'<meta name="ba-editor-mode" content="add">'
+                f'<meta name="ba-theme" content="{theme_safe}">'
+            )
+            web_content.css.append(f"{WEB}/addcard.css")
+            web_content.js.append(f"{WEB}/addcard.js")
 
 
 # --------------------------------------------------------------------------- #
@@ -975,6 +993,17 @@ def _add_tools_menu_action() -> None:
 gui_hooks.main_window_did_init.append(_add_tools_menu_action)
 
 
+# Add Card window redesign — separate module so the file stays focused.
+try:
+    from . import addcard as _addcard
+    _addcard.register()
+except Exception as _e:
+    try:
+        print(f"[betteranki] addcard register failed: {_e}", flush=True)
+    except Exception:
+        pass
+
+
 # --------------------------------------------------------------------------- #
 # Dev hot-reload — web/ assets only, enabled by `make dev` (a .devmode file).
 #
@@ -1051,6 +1080,186 @@ def _dev_reload_views() -> None:
         pass
 
 
+def _dev_screenshot(request_path: str) -> None:
+    """Runs on the Qt main thread. Reads the JSON request file, finds the
+    target Qt widget (by window-title substring or "main"), grabs it as a
+    PNG and writes to the requested output path. Always removes the request
+    file. Used by the iterative-design screenshot loop."""
+    import json
+    try:
+        with open(request_path) as fh:
+            req = json.load(fh)
+    except Exception:
+        try:
+            os.remove(request_path)
+        except Exception:
+            pass
+        return
+    try:
+        os.remove(request_path)
+    except Exception:
+        pass
+    out = req.get("out")
+    target_title = (req.get("title") or "").lower()
+    open_addcards = bool(req.get("open_addcards"))
+    if not out:
+        return
+    try:
+        from aqt.qt import QApplication, QTimer
+        if open_addcards:
+            try:
+                mw.onAddCard()
+            except Exception:
+                pass
+        # Optional: pre-fill the fields with sample text so we can validate
+        # how the design looks with content (vs the empty/placeholder state).
+        fill_sample = bool(req.get("fill_sample"))
+        try:
+            QApplication.processEvents()
+        except Exception:
+            pass
+
+        def _grab() -> None:
+            widget = None
+            if target_title in ("main", "mw"):
+                widget = mw
+            else:
+                for w in QApplication.topLevelWidgets():
+                    try:
+                        if not w.isVisible():
+                            continue
+                        title = (w.windowTitle() or "").lower()
+                        if target_title and target_title in title:
+                            widget = w
+                            break
+                    except Exception:
+                        continue
+            if widget is None:
+                try:
+                    with open(out + ".err", "w") as fh:
+                        fh.write(f"no widget for title={target_title!r}\n")
+                except Exception:
+                    pass
+                return
+            try:
+                widget.raise_()
+                widget.activateWindow()
+                QApplication.processEvents()
+            except Exception:
+                pass
+            try:
+                pix = widget.grab()
+                pix.save(out, "PNG")
+            except Exception as e:
+                try:
+                    with open(out + ".err", "w") as fh:
+                        fh.write(f"grab failed: {e}\n")
+                except Exception:
+                    pass
+
+        # Optionally inject sample text into editor fields so we can preview
+        # the design with content. We schedule this *before* the grab delay.
+        def _fill() -> None:
+            try:
+                from aqt import dialogs
+                ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+                if ac is None or not getattr(ac, "editor", None):
+                    return
+                ed = ac.editor
+                if not getattr(ed, "note", None):
+                    return
+                samples = [
+                    "What is the capital of France?",
+                    "Paris — capital and most populous city.",
+                    "Located on the Seine river.",
+                ]
+                for i in range(min(len(ed.note.fields), len(samples))):
+                    ed.note.fields[i] = samples[i]
+                ed.loadNote()
+            except Exception:
+                pass
+        if fill_sample:
+            QTimer.singleShot(400, _fill)
+
+        # Give the WebEngine view time to render (templates load async).
+        # 1500ms is conservative; the editor.html bundle plus Svelte hydration
+        # can take a beat after window construction.
+        delay_ms = int(req.get("delay_ms", 1500))
+        QTimer.singleShot(delay_ms, _grab)
+    except Exception as e:
+        try:
+            with open(out + ".err", "w") as fh:
+                fh.write(f"screenshot fatal: {e}\n")
+        except Exception:
+            pass
+
+
+_SCREENSHOT_DIR = os.path.join(ADDON_SRC, ".context", "screenshot-requests")
+_DUMP_DIR = os.path.join(ADDON_SRC, ".context", "dump-requests")
+
+
+def _dev_dump(request_path: str) -> None:
+    """Runs on the Qt main thread. Reads a {out, title} JSON request and
+    dumps that window's web HTML to `out`. Used for design inspection."""
+    import json
+    try:
+        with open(request_path) as fh:
+            req = json.load(fh)
+    except Exception:
+        try:
+            os.remove(request_path)
+        except Exception:
+            pass
+        return
+    try:
+        os.remove(request_path)
+    except Exception:
+        pass
+    out = req.get("out")
+    target_title = (req.get("title") or "").lower()
+    if not out:
+        return
+    try:
+        from aqt.qt import QApplication
+        widget = None
+        for w in QApplication.topLevelWidgets():
+            try:
+                if not w.isVisible():
+                    continue
+                title = (w.windowTitle() or "").lower()
+                if target_title and target_title in title:
+                    widget = w
+                    break
+            except Exception:
+                continue
+        if widget is None:
+            with open(out, "w") as fh:
+                fh.write(f"<!-- no widget for title={target_title!r} -->")
+            return
+        try:
+            from aqt.qt import QWebEngineView  # type: ignore
+        except Exception:
+            from PyQt6.QtWebEngineWidgets import QWebEngineView  # type: ignore
+        web = widget.findChild(QWebEngineView)
+        if web is None:
+            with open(out, "w") as fh:
+                fh.write("<!-- no QWebEngineView found -->")
+            return
+        def _write(html: str, out: str = out) -> None:
+            try:
+                with open(out, "w") as fh:
+                    fh.write(html or "")
+            except Exception:
+                pass
+        web.page().toHtml(_write)
+    except Exception as e:
+        try:
+            with open(out, "w") as fh:
+                fh.write(f"<!-- dump error: {e} -->")
+        except Exception:
+            pass
+
+
 def _dev_watch() -> None:
     web_dir = os.path.join(ADDON_SRC, "web")
     seen: Dict[str, float] = {}
@@ -1076,6 +1285,34 @@ def _dev_watch() -> None:
                 mw.taskman.run_on_main(_dev_reload_views)
             except Exception:
                 pass
+        # Process pending screenshot requests (one per file in the dir).
+        try:
+            if os.path.isdir(_SCREENSHOT_DIR):
+                for name in sorted(os.listdir(_SCREENSHOT_DIR)):
+                    if not name.endswith(".json"):
+                        continue
+                    req = os.path.join(_SCREENSHOT_DIR, name)
+                    try:
+                        mw.taskman.run_on_main(
+                            lambda p=req: _dev_screenshot(p)
+                        )
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+        # Process pending DOM-dump requests.
+        try:
+            if os.path.isdir(_DUMP_DIR):
+                for name in sorted(os.listdir(_DUMP_DIR)):
+                    if not name.endswith(".json"):
+                        continue
+                    req = os.path.join(_DUMP_DIR, name)
+                    try:
+                        mw.taskman.run_on_main(lambda p=req: _dev_dump(p))
+                    except Exception:
+                        pass
+        except Exception:
+            pass
         _dev_stop.wait(0.5)
 
 

--- a/addcard.py
+++ b/addcard.py
@@ -10,15 +10,23 @@ the rest of BetterAnki (settings dialog, deck home, sidebar). The editor
 webview itself gets a CSS overlay in `web/addcard.css` (injected via
 `webview_will_set_content` when the context is an Editor in ADD_CARDS mode).
 
-Add-on compatibility: all the original buttons (Add / Close / Help / History)
-keep their original click handlers and shortcuts — we just hide the stock
-buttonBox and proxy clicks to it. Hooks (`add_cards_did_*`, etc.) fire from
-the underlying AddCards instance, so any add-on that listens still works.
+Layout philosophy:
+  - No "Add card" page-title — the window's title bar already says that.
+  - Top: inline editorial sentence "New [Basic ▾] card in [Anki ▾]" — the
+    chooser values are styled italic-serif links, opening the same picker
+    as Anki's native chooser when clicked.
+  - Bottom: a single primary Add-card button on the right with a
+    hover-revealed shortcut pill; a Recent menu on the left.
+
+Add-on compatibility: the original Add / History buttons keep their
+handlers, shortcuts and `gui_hooks.add_cards_*` firing. We hide the stock
+QDialogButtonBox and proxy clicks. The history menu is rebuilt under our
+own button so it anchors to the visible button (the proxied click would
+otherwise open the menu at the hidden button's position).
 """
 
 from __future__ import annotations
 
-import time
 from typing import Any, Dict, Optional, Tuple
 
 from aqt import gui_hooks, mw
@@ -30,7 +38,9 @@ from aqt.qt import (
     QHBoxLayout,
     QKeySequence,
     QLabel,
+    QMenu,
     QPalette,
+    QPoint,
     QPushButton,
     QShortcut,
     QSize,
@@ -94,57 +104,10 @@ def _qss(p: Dict[str, str], accent: str) -> str:
     """QSS for the Add Card window chrome (everything outside the webview).
     The editor itself is restyled by web/addcard.css."""
     return f"""
-QMainWindow, #ba-root, #ba-header, #ba-footer, #ba-fields-wrap {{
+QDialog, QMainWindow, #ba-root, #ba-context, #ba-footer, #ba-fields-wrap {{
     background: {p['paper']};
     color: {p['ink']};
     font-family: {SANS};
-}}
-
-/* Title font/size come from setFont() in addcard.py for reliable metrics.
-   Don't restate font-family here or QSS will rebuild a multi-family font
-   whose space-glyph differs from its letter-glyphs (giant whitespace gap
-   between "Add" and "card"). */
-#ba-title {{
-    color: {p['ink']};
-    padding: 0;
-    background: transparent;
-}}
-
-#ba-meta {{
-    font-size: 10pt;
-    color: {p['ink_faint']};
-    letter-spacing: 1.6px;
-    text-transform: uppercase;
-    font-weight: 600;
-}}
-
-/* Chooser pill — small text + bold value, looks like an editorial caption. */
-QPushButton#ba-chooser {{
-    background: transparent;
-    border: 1px solid {p['line2']};
-    border-radius: 999px;
-    padding: 7px 14px 7px 14px;
-    color: {p['ink']};
-    font-size: 11pt;
-    font-family: {SANS};
-    text-align: left;
-}}
-QPushButton#ba-chooser:hover {{
-    background: {p['hover']};
-    border-color: {p['ink_faint']};
-}}
-QPushButton#ba-chooser:focus {{
-    border-color: {accent};
-    outline: none;
-}}
-
-QLabel[role="chooser-key"] {{
-    color: {p['ink_faint']};
-    font-size: 9pt;
-    letter-spacing: 1.4px;
-    text-transform: uppercase;
-    font-weight: 600;
-    padding-right: 6px;
 }}
 
 QFrame[role="rule"] {{
@@ -154,45 +117,47 @@ QFrame[role="rule"] {{
     border: 0;
 }}
 
-/* Chooser pills — selected look: filled with the panel color, thin tinted
-   border, weighty value text. */
-QPushButton#ba-chooser,
+/* Inline context: "New  [Basic ▾]  card in  [Anki ▾]"
+   Clean sans throughout for readability. Connective text is faint; the
+   chooser values are weighted so they read as the clickable parts. */
+#ba-context QLabel {{
+    color: {p['ink_faint']};
+    font-family: {SANS};
+    font-size: 11.5pt;
+    font-weight: 400;
+    background: transparent;
+}}
 #modelArea QPushButton, #deckArea QPushButton {{
-    background: {p['panel']};
-    border: 1px solid {p['line2']};
-    border-radius: 14px;
-    padding: 6px 18px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
     color: {p['ink']};
-    font-size: 11pt;
+    font-family: {SANS};
+    font-size: 11.5pt;
     font-weight: 600;
-    min-height: 22px;
+    padding: 1px 4px;
+    min-height: 16px;
+    text-decoration: none;
 }}
-QPushButton#ba-chooser:hover,
 #modelArea QPushButton:hover, #deckArea QPushButton:hover {{
-    background: {p['hover']};
-    border-color: {p['ink_faint']};
-    color: {p['ink']};
+    color: {accent};
+    background: transparent;
 }}
-QPushButton#ba-chooser:focus,
 #modelArea QPushButton:focus, #deckArea QPushButton:focus {{
-    border-color: {accent};
     outline: none;
+    color: {accent};
 }}
 #modelArea QLabel, #deckArea QLabel {{
-    color: {p['ink_faint']};
-    font-size: 9pt;
-    letter-spacing: 1.4px;
-    text-transform: uppercase;
-    font-weight: 600;
+    background: transparent;
 }}
 
-/* Footer */
+/* Footer — Recent and other secondary buttons. */
 #ba-footer QPushButton {{
     background: transparent;
     color: {p['ink_dim']};
     border: 1px solid {p['line2']};
     border-radius: 8px;
-    padding: 9px 18px;
+    padding: 8px 14px;
     font-size: 11pt;
     font-weight: 500;
 }}
@@ -201,100 +166,51 @@ QPushButton#ba-chooser:focus,
     background: {p['hover']};
     border-color: {p['ink_faint']};
 }}
-#ba-footer QPushButton#ba-primary {{
+
+/* Add card primary button — large pill with hover-revealed shortcut.
+   Override the generic #ba-footer QPushButton selector by using both IDs
+   so the cascade picks our accent fill. */
+#ba-footer QPushButton#ba-add {{
     color: white;
     background: {accent};
     border: 1px solid {accent};
-    padding: 10px 24px;
+    border-radius: 22px;
+    padding: 11px 22px;
+    font-size: 12pt;
     font-weight: 600;
+    min-height: 22px;
+    min-width: 140px;
+    text-align: center;
 }}
-#ba-footer QPushButton#ba-primary:hover {{
+#ba-footer QPushButton#ba-add:hover {{
     background: {accent};
+    color: white;
+    border-color: {accent};
 }}
-#ba-footer QPushButton#ba-ghost {{
-    border: 1px solid transparent;
-    color: {p['ink_faint']};
-    font-size: 10pt;
-    letter-spacing: 1.2px;
-    text-transform: uppercase;
-    padding: 8px 14px;
-}}
-#ba-footer QPushButton#ba-ghost:hover {{
-    color: {p['ink']};
-    background: {p['hover']};
-    border-color: {p['line2']};
-}}
-#ba-footer QPushButton#ba-ghost:focus {{
-    border-color: {p['line2']};
-    outline: none;
-}}
-#ba-footer QPushButton#ba-icon {{
-    min-width: 34px;
-    max-width: 34px;
-    min-height: 34px;
-    max-height: 34px;
-    padding: 0;
-    border-radius: 17px;
-    color: {p['ink_faint']};
-    font-size: 13pt;
-    font-weight: 600;
-    font-family: {SERIF};
-    font-style: italic;
-}}
-#ba-footer QPushButton#ba-icon:hover {{
-    color: {p['ink']};
-    border-color: {p['ink_faint']};
-    background: {p['hover']};
+#ba-footer QPushButton#ba-add:pressed {{
+    padding-top: 12px;
+    padding-bottom: 10px;
 }}
 
-#ba-shortcut {{
-    color: {p['ink_faint']};
-    font-size: 10pt;
+/* The shortcut chip is a child QLabel positioned in Python on hover. */
+QLabel#ba-add-chip {{
+    background: rgba(255, 255, 255, 0.22);
+    color: white;
+    border-radius: 9px;
+    padding: 2px 8px;
+    font-size: 9.5pt;
+    font-weight: 600;
     font-family: {SANS};
-    padding-left: 6px;
 }}
 """
 
 
 # --------------------------------------------------------------------------- #
-# Rebuild AddCards chrome on init
+# Helpers
 # --------------------------------------------------------------------------- #
-def _shortcut_caption(seq: str) -> str:
-    """Return platform-appropriate visual representation of a key seq."""
-    import sys
-    if sys.platform == "darwin":
-        return seq.replace("Ctrl+", "⌘").replace("Shift+", "⇧").replace("Alt+", "⌥")
-    return seq
-
-
-def _cards_added_today() -> int:
-    """Count notes added since the user's day rollover. Best-effort; returns
-    0 on any error so the title can never break."""
-    try:
-        col = mw.col
-        if col is None:
-            return 0
-        try:
-            rollover = int(col.get_preferences().scheduling.rollover)
-        except Exception:
-            rollover = 4
-        if time.localtime().tm_isdst and time.daylight:
-            tz_offset = -time.altzone
-        else:
-            tz_offset = -time.timezone
-        shift = tz_offset - rollover * 3600
-        today_idx = int((time.time() + shift) // 86400)
-        # Anki note IDs are millisecond timestamps at creation.
-        start_ms = (today_idx * 86400 - shift) * 1000
-        row = col.db.first("select count() from notes where id >= ?", start_ms)
-        return int(row[0]) if row and row[0] else 0
-    except Exception:
-        return 0
-
-
 def _proxy_click(source: QPushButton, target: QPushButton) -> None:
-    """Wire a new button to click the underlying native one (which carries
-    the real handlers, shortcuts and gui_hooks)."""
+    """Wire a new button to click the underlying native one (preserves
+    shortcuts and gui_hooks)."""
     source.clicked.connect(target.click)
 
 
@@ -307,15 +223,54 @@ def _hrule(palette: Dict[str, str]) -> QFrame:
     return f
 
 
+# --------------------------------------------------------------------------- #
+# Primary "Add card" button with hover-revealed shortcut pill.
+# --------------------------------------------------------------------------- #
+class _AddCardButton(QPushButton):
+    """QPushButton with a small shortcut chip ("⌘↩") in its right edge that
+    fades in on hover. The chip is a child QLabel positioned manually so it
+    doesn't interfere with the button's text alignment."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__("Add card", parent)
+        self.setObjectName("ba-add")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.chip = QLabel("⌘↩", self)
+        self.chip.setObjectName("ba-add-chip")
+        self.chip.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.chip.hide()
+
+    def resizeEvent(self, e: Any) -> None:
+        super().resizeEvent(e)
+        try:
+            cw = self.chip.sizeHint().width()
+            ch = self.chip.sizeHint().height()
+            self.chip.setGeometry(
+                self.width() - cw - 12,
+                (self.height() - ch) // 2,
+                cw,
+                ch,
+            )
+        except Exception:
+            pass
+
+    def enterEvent(self, e: Any) -> None:
+        super().enterEvent(e)
+        self.chip.show()
+
+    def leaveEvent(self, e: Any) -> None:
+        super().leaveEvent(e)
+        self.chip.hide()
+
+
+# --------------------------------------------------------------------------- #
+# Rebuild AddCards chrome on init
+# --------------------------------------------------------------------------- #
 def _redress(addcards: AddCards) -> None:
-    """Wrap the existing centralWidget in our own layout. We keep all native
-    widgets alive (so handlers and hooks continue to fire) but rehome them
-    inside our chrome and hide the stock button box."""
     palette, _ = _resolve_palette()
     cfg = _config()
     accent = cfg.get("accent", "#6c8cff")
 
-    # Apply window-level theming
     try:
         addcards.setWindowTitle("Add card")
     except Exception:
@@ -328,147 +283,66 @@ def _redress(addcards: AddCards) -> None:
     root_layout.setContentsMargins(0, 0, 0, 0)
     root_layout.setSpacing(0)
 
-    # --- Header --- #
-    header = QWidget()
-    header.setObjectName("ba-header")
-    h = QVBoxLayout(header)
-    h.setContentsMargins(32, 22, 32, 16)
-    h.setSpacing(10)
-
-    # Eyebrow + title row
-    top = QHBoxLayout()
-    top.setSpacing(14)
-    top.setContentsMargins(0, 0, 0, 0)
-
-    added = _cards_added_today()
-    if added <= 0:
-        meta_text = "FIRST OF TODAY"
-    elif added == 1:
-        meta_text = "1 ADDED TODAY"
-    else:
-        meta_text = f"{added} ADDED TODAY"
-    meta = QLabel(meta_text)
-    meta.setObjectName("ba-meta")
-    # The ASCII space rendered with a giant gap because Qts QSS multi-family
-    # font selection picked the space-glyph from a different fallback than
-    # the letters. A NBSP (\xa0) bypasses that substitution.
-    title = QLabel("Add card")
-    title.setTextFormat(Qt.TextFormat.PlainText)
-    title.setObjectName("ba-title")
-    title.setWordWrap(False)
-    title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
-    from aqt.qt import QFont, QFontDatabase, QSizePolicy
-    # Pick the first serif that QFontDatabase reports as actually installed.
-    # exactMatch() lies on macOS Qt6 — a non-existent serif still "matches"
-    # but then renders its space glyph from a fallback with very different
-    # metrics ("Add" + huge gap + "card"). QFontDatabase.families() never
-    # lies.
-    families = set(QFontDatabase.families())
-    serif = None
-    # NOTE: Hoefler Text is installed on macOS but its space glyph renders
-    # at ~2x expected width in Qt6, producing "Add" + huge gap + "card".
-    # Skip it. New York / Iowan Old Style / Charter render correctly.
-    for fam in ("New York", "Iowan Old Style", "Charter",
-                "Georgia", "Times New Roman", "Times"):
-        if fam in families:
-            serif = fam
-            break
-    if serif:
-        tf = QFont(serif, 22)
-        tf.setStyleHint(QFont.StyleHint.Serif)
-        tf.setWeight(QFont.Weight.Medium)
-        title.setFont(tf)
-    else:
-        tf = QFont("Helvetica Neue", 22)
-        tf.setWeight(QFont.Weight.DemiBold)
-        title.setFont(tf)
-    title.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
-
-    title_col = QVBoxLayout()
-    title_col.setContentsMargins(0, 0, 0, 0)
-    title_col.setSpacing(2)
-    title_col.addWidget(meta)
-    title_col.addWidget(title)
-    title_col_wrap = QWidget()
-    title_col_wrap.setLayout(title_col)
-    top.addWidget(title_col_wrap, 1)
-    h.addLayout(top)
-
-    # Chooser strip: the native DeckChooser / NotetypeChooser live inside
-    # `addcards.form.modelArea` and `deckArea`. We rehome those widgets so
-    # the controls themselves still work — only the position changes.
-    choosers = QHBoxLayout()
-    choosers.setContentsMargins(0, 4, 0, 0)
-    choosers.setSpacing(18)
-
-    nt_label = QLabel("TYPE")
-    nt_label.setProperty("role", "chooser-key")
-    nt_label.setToolTip("Note type (⌘N to change)")
-    dk_label = QLabel("DECK")
-    dk_label.setProperty("role", "chooser-key")
-    dk_label.setToolTip("Target deck (⌘D to change)")
+    # --- Context strip: "New [Basic ▾] card in [Anki ▾]" --- #
+    context = QWidget()
+    context.setObjectName("ba-context")
+    ctx_layout = QHBoxLayout(context)
+    ctx_layout.setContentsMargins(28, 14, 28, 12)
+    ctx_layout.setSpacing(2)
 
     nt_area: QWidget = addcards.form.modelArea
     dk_area: QWidget = addcards.form.deckArea
-    # Strip any minimum size so they shrink to content.
     try:
         nt_area.setMinimumSize(QSize(0, 0))
         dk_area.setMinimumSize(QSize(0, 0))
     except Exception:
         pass
 
-    # NotetypeChooser / DeckChooser each construct their own QLabel as the
-    # first child of the area widget (text: "Type" / "Deck"). We already have
-    # our own all-caps eyebrow label, so hide theirs to avoid the duplicate
-    # "NOTE TYPE TYPE Basic" effect.
+    # NotetypeChooser / DeckChooser auto-add a QLabel ("Type" / "Deck") — hide
+    # it so the inline sentence has its own narration.
     def _hide_first_label(host: QWidget) -> None:
         try:
             for child in host.findChildren(QLabel):
                 child.hide()
-                # one is enough; the chooser only adds one label per area
                 break
         except Exception:
             pass
     _hide_first_label(nt_area)
     _hide_first_label(dk_area)
 
-    # Force flat style on the chooser buttons — macOS's native QStyle keeps
-    # the Aqua chrome around QPushButton even with a stylesheet, so we
-    # explicitly setStyleSheet on each child push button. This puts the
-    # painted pill back even when the global QSS gets out-prioritized.
-    def _flatten_buttons(host: QWidget) -> None:
+    # Style each chooser's QPushButton as an inline text link, and append a
+    # tiny ▾ so it reads as openable.
+    def _stylize(host: QWidget) -> None:
         try:
             for b in host.findChildren(QPushButton):
                 b.setObjectName("ba-chooser")
-                b.setCursor(Qt.CursorShape.PointingHandCursor)
                 b.setFlat(True)
+                b.setCursor(Qt.CursorShape.PointingHandCursor)
+                # Append the chevron once. Anki later may update the label
+                # via the chooser when the user picks a different type/deck
+                # — we re-append on a timer so the chevron always tags along.
+                txt = b.text()
+                if not txt.endswith(" ▾"):
+                    b.setText(f"{txt} ▾")
         except Exception:
             pass
-    _flatten_buttons(nt_area)
-    _flatten_buttons(dk_area)
+    _stylize(nt_area)
+    _stylize(dk_area)
 
-    nt_group = QHBoxLayout()
-    nt_group.setContentsMargins(0, 0, 0, 0)
-    nt_group.setSpacing(6)
-    nt_group.addWidget(nt_label)
-    nt_group.addWidget(nt_area)
-    nt_wrap = QWidget()
-    nt_wrap.setLayout(nt_group)
+    # Build the sentence. Each fragment is a thin QLabel; chooser pushbuttons
+    # sit between them.
+    pre = QLabel("New ")
+    mid = QLabel(" card in ")
+    post = QLabel("")
 
-    dk_group = QHBoxLayout()
-    dk_group.setContentsMargins(0, 0, 0, 0)
-    dk_group.setSpacing(6)
-    dk_group.addWidget(dk_label)
-    dk_group.addWidget(dk_area)
-    dk_wrap = QWidget()
-    dk_wrap.setLayout(dk_group)
+    ctx_layout.addWidget(pre)
+    ctx_layout.addWidget(nt_area)
+    ctx_layout.addWidget(mid)
+    ctx_layout.addWidget(dk_area)
+    ctx_layout.addWidget(post)
+    ctx_layout.addStretch(1)
 
-    choosers.addWidget(nt_wrap)
-    choosers.addWidget(dk_wrap)
-    choosers.addStretch(1)
-
-    h.addLayout(choosers)
-    root_layout.addWidget(header)
+    root_layout.addWidget(context)
     root_layout.addWidget(_hrule(palette))
 
     # --- Fields (editor webview lives inside addcards.form.fieldsArea) --- #
@@ -485,126 +359,138 @@ def _redress(addcards: AddCards) -> None:
     root_layout.addWidget(_hrule(palette))
     footer = QWidget()
     footer.setObjectName("ba-footer")
-    f = QHBoxLayout(footer)
-    f.setContentsMargins(28, 16, 28, 18)
-    f.setSpacing(10)
+    fl = QHBoxLayout(footer)
+    fl.setContentsMargins(28, 14, 28, 16)
+    fl.setSpacing(10)
 
-    history_btn = QPushButton("Recent ▾")
-    history_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-    history_btn.setToolTip("Re-open a recently added note (Cmd+Shift+H)")
-    help_btn = QPushButton("?")
-    help_btn.setObjectName("ba-icon")
-    help_btn.setToolTip("Help")
-    help_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-    close_btn = QPushButton("Esc")
-    close_btn.setObjectName("ba-ghost")
-    close_btn.setToolTip("Close (Esc)")
-    close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-    add_btn = QPushButton("Add card")
-    add_btn.setObjectName("ba-primary")
-    add_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    recent_btn = QPushButton("Recent  ▾")
+    recent_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    recent_btn.setToolTip("Re-open a recently added note  (⌘⇧H)")
+    add_btn = _AddCardButton()
 
-    # Wire to original buttons (preserves shortcuts and add-on hooks).
+    # Wire Add to the native add button so all Anki logic / shortcuts /
+    # hooks still fire.
     try:
         _proxy_click(add_btn, addcards.addButton)
-        _proxy_click(history_btn, addcards.historyButton)
-        _proxy_click(help_btn, addcards.helpButton)
-        _proxy_click(close_btn, addcards.closeButton)
     except Exception:
         pass
 
-    # Disable our copy of history when the native one is disabled (no history).
-    try:
-        history_btn.setEnabled(addcards.historyButton.isEnabled())
-        addcards.historyButton.changeEvent  # noqa - just touch
-        # Mirror enabled-state changes from the native button.
-        def _mirror_history() -> None:
+    # Recent: we build our own QMenu anchored to OUR button (the proxied
+    # click on the hidden historyButton would open the menu at its hidden
+    # position). Reuses the same nid -> editHistory logic Anki ships.
+    def _show_recent_menu() -> None:
+        try:
+            from anki.collection import SearchNode
+            from anki.utils import html_to_text_line
+            from aqt.utils import tr as ttr
+            m = QMenu(addcards)
+            history = list(getattr(addcards, "history", []))
+            if not history:
+                a = m.addAction("No recently added notes")
+                a.setEnabled(False)
+            else:
+                for nid in history:
+                    try:
+                        if addcards.col.find_notes(
+                            addcards.col.build_search_string(SearchNode(nid=nid))
+                        ):
+                            note = addcards.col.get_note(nid)
+                            txt = html_to_text_line(", ".join(note.fields))
+                            if len(txt) > 40:
+                                txt = txt[:40] + "…"
+                            try:
+                                label = ttr.adding_edit(val=txt)
+                            except Exception:
+                                label = f"Edit: {txt}"
+                            label = gui_hooks.addcards_will_add_history_entry(
+                                label, note
+                            )
+                            label = label.replace("&", "&&")
+                            a = m.addAction(label)
+                            a.triggered.connect(
+                                lambda _, nid=nid: addcards.editHistory(nid)
+                            )
+                        else:
+                            try:
+                                label = ttr.adding_note_deleted()
+                            except Exception:
+                                label = "(deleted)"
+                            a = m.addAction(label)
+                            a.setEnabled(False)
+                    except Exception:
+                        continue
             try:
-                history_btn.setEnabled(addcards.historyButton.isEnabled())
+                gui_hooks.add_cards_will_show_history_menu(addcards, m)
             except Exception:
                 pass
-        # Hook via paintEvent: cheap, fires often enough.
-        addcards._ba_mirror_history = _mirror_history  # type: ignore[attr-defined]
-    except Exception:
-        pass
+            # Anchor at the bottom-left of our visible Recent button so the
+            # menu drops down from it (not from the hidden native button).
+            pos = recent_btn.mapToGlobal(QPoint(0, recent_btn.height()))
+            m.exec(pos)
+        except Exception as e:
+            try:
+                from aqt.utils import showWarning
+                showWarning(f"Recent menu failed: {e}")
+            except Exception:
+                pass
+    recent_btn.clicked.connect(_show_recent_menu)
 
-    # Build an "Add card  ⌘↩" composite — shortcut hint sits inside the
-    # primary button as a quiet caption (Apple-style), not a detached label.
-    add_btn.setText(
-        f"Add card     {_shortcut_caption('Ctrl+Enter')}"
-    )
-
-    f.addWidget(help_btn)
-    f.addWidget(history_btn)
-    f.addStretch(1)
-    f.addWidget(close_btn)
-    f.addSpacing(6)
-    f.addWidget(add_btn)
+    fl.addWidget(recent_btn)
+    fl.addStretch(1)
+    fl.addWidget(add_btn)
     root_layout.addWidget(footer)
 
-    # Hide the original button box (its buttons remain alive for proxying).
+    # Hide the stock buttonBox (its buttons stay alive for proxying).
     try:
         addcards.form.buttonBox.hide()
     except Exception:
         pass
 
-    # Apply QSS to the window.
+    # Apply QSS and install our root as the central widget.
     try:
         addcards.setStyleSheet(_qss(palette, accent))
     except Exception:
         pass
-    # Install root as the central widget (replaces the stock centralwidget).
     try:
         addcards.setCentralWidget(root)
     except Exception:
         pass
 
-    # Re-poll the native history button's enabled state every 800ms so our
-    # mirror stays in sync. Cheap and bulletproof.
+    # Mirror Recent's enabled state from the native history button. Cheap
+    # 800ms tick (native is enabled after the first note is added).
     try:
         from aqt.qt import QTimer
+        recent_btn.setEnabled(addcards.historyButton.isEnabled())
         t = QTimer(addcards)
         t.setInterval(800)
         def _tick() -> None:
             try:
-                history_btn.setEnabled(addcards.historyButton.isEnabled())
+                recent_btn.setEnabled(addcards.historyButton.isEnabled())
             except Exception:
                 pass
+            # Re-apply chevron in case Anki updated the chooser label text.
+            _stylize(nt_area)
+            _stylize(dk_area)
         t.timeout.connect(_tick)
         t.start()
         addcards._ba_history_timer = t  # keep ref
     except Exception:
         pass
 
-    # Larger default window — the new chrome breathes.
+    # Larger default window.
     try:
         if addcards.width() < 880 or addcards.height() < 720:
-            addcards.resize(max(addcards.width(), 880), max(addcards.height(), 720))
+            addcards.resize(
+                max(addcards.width(), 880), max(addcards.height(), 720)
+            )
     except Exception:
         pass
-
-    # Update the "N ADDED TODAY" eyebrow every time a note is added.
-    def _refresh_meta() -> None:
-        try:
-            n = _cards_added_today()
-            if n <= 0:
-                t = "FIRST OF TODAY"
-            elif n == 1:
-                t = "1 ADDED TODAY"
-            else:
-                t = f"{n} ADDED TODAY"
-            meta.setText(t)
-        except Exception:
-            pass
-    addcards._ba_refresh_meta = _refresh_meta  # type: ignore[attr-defined]
 
 
 def on_add_cards_did_init(addcards: AddCards) -> None:
     try:
         _redress(addcards)
     except Exception as e:
-        # Log only — popping up a modal here blocks Qt's event loop and
-        # cascades into hung-screenshot timeouts during dev iteration.
         import traceback
         try:
             print(
@@ -616,23 +502,5 @@ def on_add_cards_did_init(addcards: AddCards) -> None:
             pass
 
 
-def _on_note_added(note: Any) -> None:
-    """Refresh the eyebrow count in any open Add Card window."""
-    try:
-        from aqt import dialogs
-        ac = dialogs._dialogs.get("AddCards", [None, None])[1]
-        if ac is None:
-            return
-        cb = getattr(ac, "_ba_refresh_meta", None)
-        if callable(cb):
-            cb()
-    except Exception:
-        pass
-
-
 def register() -> None:
     gui_hooks.add_cards_did_init.append(on_add_cards_did_init)
-    try:
-        gui_hooks.add_cards_did_add_note.append(_on_note_added)
-    except Exception:
-        pass

--- a/addcard.py
+++ b/addcard.py
@@ -167,20 +167,22 @@ QFrame[role="rule"] {{
     border-color: {p['ink_faint']};
 }}
 
-/* Add card primary button — large pill with hover-revealed shortcut.
-   Override the generic #ba-footer QPushButton selector by using both IDs
-   so the cascade picks our accent fill. */
+/* Add card primary button — solid dark ink with the shortcut shown inline
+   at low opacity. No animated chip; the chip overlaid the opaque pill and
+   read as broken when it appeared. Compact corner radius (the previous
+   pill shape felt out of place next to the rest of the editorial chrome). */
 #ba-footer QPushButton#ba-add {{
     color: white;
-    background: {accent};
-    border: 1px solid {accent};
-    border-radius: 22px;
-    padding: 11px 22px;
-    font-size: 12pt;
+    background: {p['ink']};
+    border: 1px solid {p['ink']};
+    border-radius: 8px;
+    padding: 10px 18px;
+    font-size: 11.5pt;
     font-weight: 600;
     min-height: 22px;
-    min-width: 140px;
+    min-width: 160px;
     text-align: center;
+    letter-spacing: 0.2px;
 }}
 #ba-footer QPushButton#ba-add:hover {{
     background: {accent};
@@ -188,19 +190,17 @@ QFrame[role="rule"] {{
     border-color: {accent};
 }}
 #ba-footer QPushButton#ba-add:pressed {{
-    padding-top: 12px;
-    padding-bottom: 10px;
+    padding-top: 11px;
+    padding-bottom: 9px;
 }}
 
-/* The shortcut chip is a child QLabel positioned in Python on hover. */
-QLabel#ba-add-chip {{
-    background: rgba(255, 255, 255, 0.22);
-    color: white;
-    border-radius: 9px;
-    padding: 2px 8px;
-    font-size: 9.5pt;
-    font-weight: 600;
-    font-family: {SANS};
+/* Keyboard hint living next to the Add button. Quiet sans, mono-ish. */
+QLabel#ba-add-shortcut {{
+    color: {p['ink_faint']};
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11pt;
+    background: transparent;
+    padding: 0 4px;
 }}
 """
 
@@ -224,43 +224,97 @@ def _hrule(palette: Dict[str, str]) -> QFrame:
 
 
 # --------------------------------------------------------------------------- #
-# Primary "Add card" button with hover-revealed shortcut pill.
+# Inline pickers for note type / deck (replace the StudyDeck popup window).
 # --------------------------------------------------------------------------- #
-class _AddCardButton(QPushButton):
-    """QPushButton with a small shortcut chip ("⌘↩") in its right edge that
-    fades in on hover. The chip is a child QLabel positioned manually so it
-    doesn't interfere with the button's text alignment."""
+def _wire_inline_notetype_picker(
+    addcards: AddCards, btn: QPushButton
+) -> None:
+    """Replace the chooser's button click with a dropdown menu listing all
+    note types. Picking one calls the chooser's setter — same effect as the
+    original popup, no new window."""
+    try:
+        btn.clicked.disconnect()
+    except Exception:
+        pass
 
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
-        super().__init__("Add card", parent)
-        self.setObjectName("ba-add")
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.chip = QLabel("⌘↩", self)
-        self.chip.setObjectName("ba-add-chip")
-        self.chip.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
-        self.chip.hide()
-
-    def resizeEvent(self, e: Any) -> None:
-        super().resizeEvent(e)
+    def _open_menu() -> None:
         try:
-            cw = self.chip.sizeHint().width()
-            ch = self.chip.sizeHint().height()
-            self.chip.setGeometry(
-                self.width() - cw - 12,
-                (self.height() - ch) // 2,
-                cw,
-                ch,
+            m = QMenu(addcards)
+            current_id = int(addcards.notetype_chooser.selected_notetype_id)
+            for nid in sorted(
+                addcards.col.models.all_names_and_ids(),
+                key=lambda n: n.name.lower(),
+            ):
+                act = m.addAction(nid.name)
+                if int(nid.id) == current_id:
+                    f = act.font()
+                    f.setBold(True)
+                    act.setFont(f)
+                act.triggered.connect(
+                    lambda _, i=int(nid.id):
+                        setattr(addcards.notetype_chooser,
+                                "selected_notetype_id", i)
+                )
+            m.addSeparator()
+            edit = m.addAction("Manage note types…")
+            edit.triggered.connect(
+                lambda _: addcards.notetype_chooser.onEdit()
             )
+            pos = btn.mapToGlobal(QPoint(0, btn.height()))
+            m.exec(pos)
         except Exception:
             pass
+    btn.clicked.connect(_open_menu)
 
-    def enterEvent(self, e: Any) -> None:
-        super().enterEvent(e)
-        self.chip.show()
 
-    def leaveEvent(self, e: Any) -> None:
-        super().leaveEvent(e)
-        self.chip.hide()
+def _wire_inline_deck_picker(addcards: AddCards, btn: QPushButton) -> None:
+    """Same as above for decks. all_names_and_ids returns the hierarchical
+    names (Parent::Child); show them as-is so the structure is visible."""
+    try:
+        btn.clicked.disconnect()
+    except Exception:
+        pass
+
+    def _open_menu() -> None:
+        try:
+            m = QMenu(addcards)
+            current_id = int(addcards.deck_chooser.selected_deck_id)
+            decks = sorted(
+                addcards.col.decks.all_names_and_ids(skip_empty_default=False),
+                key=lambda d: d.name.lower(),
+            )
+            for dk in decks:
+                # Skip filtered decks — the add window can't target them.
+                try:
+                    dd = addcards.col.decks.get(dk.id, default=False)
+                    if dd and dd.get("dyn"):
+                        continue
+                except Exception:
+                    pass
+                act = m.addAction(dk.name)
+                if int(dk.id) == current_id:
+                    f = act.font()
+                    f.setBold(True)
+                    act.setFont(f)
+                act.triggered.connect(
+                    lambda _, i=int(dk.id):
+                        setattr(addcards.deck_chooser,
+                                "selected_deck_id", i)
+                )
+            m.addSeparator()
+            new = m.addAction("New deck…")
+            def _new_deck() -> None:
+                try:
+                    from aqt.operations.deck import add_deck_dialog
+                    add_deck_dialog(parent=addcards)
+                except Exception:
+                    pass
+            new.triggered.connect(lambda _: _new_deck())
+            pos = btn.mapToGlobal(QPoint(0, btn.height()))
+            m.exec(pos)
+        except Exception:
+            pass
+    btn.clicked.connect(_open_menu)
 
 
 # --------------------------------------------------------------------------- #
@@ -311,23 +365,25 @@ def _redress(addcards: AddCards) -> None:
     _hide_first_label(dk_area)
 
     # Style each chooser's QPushButton as an inline text link, and append a
-    # tiny ▾ so it reads as openable.
-    def _stylize(host: QWidget) -> None:
+    # tiny ▾ so it reads as openable. Also intercept the click to show a
+    # dropdown menu in-page instead of opening Anki's StudyDeck popup.
+    def _stylize(host: QWidget, kind: str) -> None:
         try:
             for b in host.findChildren(QPushButton):
                 b.setObjectName("ba-chooser")
                 b.setFlat(True)
                 b.setCursor(Qt.CursorShape.PointingHandCursor)
-                # Append the chevron once. Anki later may update the label
-                # via the chooser when the user picks a different type/deck
-                # — we re-append on a timer so the chevron always tags along.
                 txt = b.text()
                 if not txt.endswith(" ▾"):
                     b.setText(f"{txt} ▾")
+                if kind == "notetype":
+                    _wire_inline_notetype_picker(addcards, b)
+                elif kind == "deck":
+                    _wire_inline_deck_picker(addcards, b)
         except Exception:
             pass
-    _stylize(nt_area)
-    _stylize(dk_area)
+    _stylize(nt_area, "notetype")
+    _stylize(dk_area, "deck")
 
     # Build the sentence. Each fragment is a thin QLabel; chooser pushbuttons
     # sit between them.
@@ -366,7 +422,18 @@ def _redress(addcards: AddCards) -> None:
     recent_btn = QPushButton("Recent  ▾")
     recent_btn.setCursor(Qt.CursorShape.PointingHandCursor)
     recent_btn.setToolTip("Re-open a recently added note  (⌘⇧H)")
-    add_btn = _AddCardButton()
+    # Add card: clean dark button, just "Add card". The keyboard shortcut
+    # lives in a small dim label to its right (always visible, no animated
+    # chip — the hover chip overlaid the opaque pill which read as broken).
+    add_btn = QPushButton("Add card")
+    add_btn.setObjectName("ba-add")
+    add_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    add_btn.setToolTip("Add card  (⌘↩)")
+    add_shortcut = QLabel("⌘↩")
+    add_shortcut.setObjectName("ba-add-shortcut")
+    add_shortcut.setAlignment(
+        Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+    )
 
     # Wire Add to the native add button so all Anki logic / shortcuts /
     # hooks still fire.
@@ -437,6 +504,8 @@ def _redress(addcards: AddCards) -> None:
 
     fl.addWidget(recent_btn)
     fl.addStretch(1)
+    fl.addWidget(add_shortcut)
+    fl.addSpacing(8)
     fl.addWidget(add_btn)
     root_layout.addWidget(footer)
 

--- a/addcard.py
+++ b/addcard.py
@@ -1,0 +1,638 @@
+"""BetterAnki — Add Card window redesign.
+
+The native AddCards dialog (`aqt.addcards.AddCards`) is a QMainWindow with:
+  - top row: notetype + deck chooser
+  - middle: editor webview (Svelte app)
+  - bottom: QDialogButtonBox (Add / Close / Help / History)
+
+We rebuild all the Qt chrome around the editor in the same editorial style as
+the rest of BetterAnki (settings dialog, deck home, sidebar). The editor
+webview itself gets a CSS overlay in `web/addcard.css` (injected via
+`webview_will_set_content` when the context is an Editor in ADD_CARDS mode).
+
+Add-on compatibility: all the original buttons (Add / Close / Help / History)
+keep their original click handlers and shortcuts — we just hide the stock
+buttonBox and proxy clicks to it. Hooks (`add_cards_did_*`, etc.) fire from
+the underlying AddCards instance, so any add-on that listens still works.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from aqt import gui_hooks, mw
+from aqt.addcards import AddCards
+from aqt.qt import (
+    QApplication,
+    QColor,
+    QFrame,
+    QHBoxLayout,
+    QKeySequence,
+    QLabel,
+    QPalette,
+    QPushButton,
+    QShortcut,
+    QSize,
+    Qt,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+ADDON = __name__.split(".")[0]
+
+
+# Palettes mirror settings.py so light/dark stays coherent across dialogs.
+PAL_DARK: Dict[str, str] = {
+    "paper": "#0b0c0f",
+    "panel": "#15171c",
+    "ink": "#eceae2",
+    "ink_dim": "#9b978a",
+    "ink_faint": "#5d5a51",
+    "line": "rgba(236,234,226,0.10)",
+    "line2": "rgba(236,234,226,0.20)",
+    "hover": "rgba(236,234,226,0.05)",
+    "field_bg": "#0f1116",
+}
+PAL_LIGHT: Dict[str, str] = {
+    "paper": "#f6f3ec",
+    "panel": "#fbf9f3",
+    "ink": "#1f1d18",
+    "ink_dim": "#6a6557",
+    "ink_faint": "#a39d8b",
+    "line": "rgba(31,29,24,0.10)",
+    "line2": "rgba(31,29,24,0.22)",
+    "hover": "rgba(31,29,24,0.04)",
+    "field_bg": "#ffffff",
+}
+
+SERIF = '"New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif'
+SANS = '"SF Pro Text", "Helvetica Neue", "Segoe UI", system-ui, sans-serif'
+
+
+def _config() -> Dict[str, Any]:
+    return mw.addonManager.getConfig(ADDON) or {}
+
+
+def _resolve_palette() -> Tuple[Dict[str, str], bool]:
+    cfg = _config()
+    pref = cfg.get("theme", "system")
+    if pref == "dark":
+        return PAL_DARK, True
+    if pref == "light":
+        return PAL_LIGHT, False
+    try:
+        c = QApplication.palette().color(QPalette.ColorRole.Window)
+        is_dark = (c.red() + c.green() + c.blue()) < 384
+        return (PAL_DARK if is_dark else PAL_LIGHT), is_dark
+    except Exception:
+        return PAL_DARK, True
+
+
+def _qss(p: Dict[str, str], accent: str) -> str:
+    """QSS for the Add Card window chrome (everything outside the webview).
+    The editor itself is restyled by web/addcard.css."""
+    return f"""
+QMainWindow, #ba-root, #ba-header, #ba-footer, #ba-fields-wrap {{
+    background: {p['paper']};
+    color: {p['ink']};
+    font-family: {SANS};
+}}
+
+/* Title font/size come from setFont() in addcard.py for reliable metrics.
+   Don't restate font-family here or QSS will rebuild a multi-family font
+   whose space-glyph differs from its letter-glyphs (giant whitespace gap
+   between "Add" and "card"). */
+#ba-title {{
+    color: {p['ink']};
+    padding: 0;
+    background: transparent;
+}}
+
+#ba-meta {{
+    font-size: 10pt;
+    color: {p['ink_faint']};
+    letter-spacing: 1.6px;
+    text-transform: uppercase;
+    font-weight: 600;
+}}
+
+/* Chooser pill — small text + bold value, looks like an editorial caption. */
+QPushButton#ba-chooser {{
+    background: transparent;
+    border: 1px solid {p['line2']};
+    border-radius: 999px;
+    padding: 7px 14px 7px 14px;
+    color: {p['ink']};
+    font-size: 11pt;
+    font-family: {SANS};
+    text-align: left;
+}}
+QPushButton#ba-chooser:hover {{
+    background: {p['hover']};
+    border-color: {p['ink_faint']};
+}}
+QPushButton#ba-chooser:focus {{
+    border-color: {accent};
+    outline: none;
+}}
+
+QLabel[role="chooser-key"] {{
+    color: {p['ink_faint']};
+    font-size: 9pt;
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+    font-weight: 600;
+    padding-right: 6px;
+}}
+
+QFrame[role="rule"] {{
+    background: {p['line']};
+    max-height: 1px;
+    min-height: 1px;
+    border: 0;
+}}
+
+/* Chooser pills — selected look: filled with the panel color, thin tinted
+   border, weighty value text. */
+QPushButton#ba-chooser,
+#modelArea QPushButton, #deckArea QPushButton {{
+    background: {p['panel']};
+    border: 1px solid {p['line2']};
+    border-radius: 14px;
+    padding: 6px 18px;
+    color: {p['ink']};
+    font-size: 11pt;
+    font-weight: 600;
+    min-height: 22px;
+}}
+QPushButton#ba-chooser:hover,
+#modelArea QPushButton:hover, #deckArea QPushButton:hover {{
+    background: {p['hover']};
+    border-color: {p['ink_faint']};
+    color: {p['ink']};
+}}
+QPushButton#ba-chooser:focus,
+#modelArea QPushButton:focus, #deckArea QPushButton:focus {{
+    border-color: {accent};
+    outline: none;
+}}
+#modelArea QLabel, #deckArea QLabel {{
+    color: {p['ink_faint']};
+    font-size: 9pt;
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+    font-weight: 600;
+}}
+
+/* Footer */
+#ba-footer QPushButton {{
+    background: transparent;
+    color: {p['ink_dim']};
+    border: 1px solid {p['line2']};
+    border-radius: 8px;
+    padding: 9px 18px;
+    font-size: 11pt;
+    font-weight: 500;
+}}
+#ba-footer QPushButton:hover {{
+    color: {p['ink']};
+    background: {p['hover']};
+    border-color: {p['ink_faint']};
+}}
+#ba-footer QPushButton#ba-primary {{
+    color: white;
+    background: {accent};
+    border: 1px solid {accent};
+    padding: 10px 24px;
+    font-weight: 600;
+}}
+#ba-footer QPushButton#ba-primary:hover {{
+    background: {accent};
+}}
+#ba-footer QPushButton#ba-ghost {{
+    border: 1px solid transparent;
+    color: {p['ink_faint']};
+    font-size: 10pt;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    padding: 8px 14px;
+}}
+#ba-footer QPushButton#ba-ghost:hover {{
+    color: {p['ink']};
+    background: {p['hover']};
+    border-color: {p['line2']};
+}}
+#ba-footer QPushButton#ba-ghost:focus {{
+    border-color: {p['line2']};
+    outline: none;
+}}
+#ba-footer QPushButton#ba-icon {{
+    min-width: 34px;
+    max-width: 34px;
+    min-height: 34px;
+    max-height: 34px;
+    padding: 0;
+    border-radius: 17px;
+    color: {p['ink_faint']};
+    font-size: 13pt;
+    font-weight: 600;
+    font-family: {SERIF};
+    font-style: italic;
+}}
+#ba-footer QPushButton#ba-icon:hover {{
+    color: {p['ink']};
+    border-color: {p['ink_faint']};
+    background: {p['hover']};
+}}
+
+#ba-shortcut {{
+    color: {p['ink_faint']};
+    font-size: 10pt;
+    font-family: {SANS};
+    padding-left: 6px;
+}}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Rebuild AddCards chrome on init
+# --------------------------------------------------------------------------- #
+def _shortcut_caption(seq: str) -> str:
+    """Return platform-appropriate visual representation of a key seq."""
+    import sys
+    if sys.platform == "darwin":
+        return seq.replace("Ctrl+", "⌘").replace("Shift+", "⇧").replace("Alt+", "⌥")
+    return seq
+
+
+def _cards_added_today() -> int:
+    """Count notes added since the user's day rollover. Best-effort; returns
+    0 on any error so the title can never break."""
+    try:
+        col = mw.col
+        if col is None:
+            return 0
+        try:
+            rollover = int(col.get_preferences().scheduling.rollover)
+        except Exception:
+            rollover = 4
+        if time.localtime().tm_isdst and time.daylight:
+            tz_offset = -time.altzone
+        else:
+            tz_offset = -time.timezone
+        shift = tz_offset - rollover * 3600
+        today_idx = int((time.time() + shift) // 86400)
+        # Anki note IDs are millisecond timestamps at creation.
+        start_ms = (today_idx * 86400 - shift) * 1000
+        row = col.db.first("select count() from notes where id >= ?", start_ms)
+        return int(row[0]) if row and row[0] else 0
+    except Exception:
+        return 0
+
+
+def _proxy_click(source: QPushButton, target: QPushButton) -> None:
+    """Wire a new button to click the underlying native one (which carries
+    the real handlers, shortcuts and gui_hooks)."""
+    source.clicked.connect(target.click)
+
+
+def _hrule(palette: Dict[str, str]) -> QFrame:
+    f = QFrame()
+    f.setProperty("role", "rule")
+    f.setFrameShape(QFrame.Shape.HLine)
+    f.setStyleSheet(f"QFrame {{ background: {palette['line']}; }}")
+    f.setFixedHeight(1)
+    return f
+
+
+def _redress(addcards: AddCards) -> None:
+    """Wrap the existing centralWidget in our own layout. We keep all native
+    widgets alive (so handlers and hooks continue to fire) but rehome them
+    inside our chrome and hide the stock button box."""
+    palette, _ = _resolve_palette()
+    cfg = _config()
+    accent = cfg.get("accent", "#6c8cff")
+
+    # Apply window-level theming
+    try:
+        addcards.setWindowTitle("Add card")
+    except Exception:
+        pass
+
+    # Build our root container.
+    root = QWidget()
+    root.setObjectName("ba-root")
+    root_layout = QVBoxLayout(root)
+    root_layout.setContentsMargins(0, 0, 0, 0)
+    root_layout.setSpacing(0)
+
+    # --- Header --- #
+    header = QWidget()
+    header.setObjectName("ba-header")
+    h = QVBoxLayout(header)
+    h.setContentsMargins(32, 22, 32, 16)
+    h.setSpacing(10)
+
+    # Eyebrow + title row
+    top = QHBoxLayout()
+    top.setSpacing(14)
+    top.setContentsMargins(0, 0, 0, 0)
+
+    added = _cards_added_today()
+    if added <= 0:
+        meta_text = "FIRST OF TODAY"
+    elif added == 1:
+        meta_text = "1 ADDED TODAY"
+    else:
+        meta_text = f"{added} ADDED TODAY"
+    meta = QLabel(meta_text)
+    meta.setObjectName("ba-meta")
+    # The ASCII space rendered with a giant gap because Qts QSS multi-family
+    # font selection picked the space-glyph from a different fallback than
+    # the letters. A NBSP (\xa0) bypasses that substitution.
+    title = QLabel("Add card")
+    title.setTextFormat(Qt.TextFormat.PlainText)
+    title.setObjectName("ba-title")
+    title.setWordWrap(False)
+    title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+    from aqt.qt import QFont, QFontDatabase, QSizePolicy
+    # Pick the first serif that QFontDatabase reports as actually installed.
+    # exactMatch() lies on macOS Qt6 — a non-existent serif still "matches"
+    # but then renders its space glyph from a fallback with very different
+    # metrics ("Add" + huge gap + "card"). QFontDatabase.families() never
+    # lies.
+    families = set(QFontDatabase.families())
+    serif = None
+    # NOTE: Hoefler Text is installed on macOS but its space glyph renders
+    # at ~2x expected width in Qt6, producing "Add" + huge gap + "card".
+    # Skip it. New York / Iowan Old Style / Charter render correctly.
+    for fam in ("New York", "Iowan Old Style", "Charter",
+                "Georgia", "Times New Roman", "Times"):
+        if fam in families:
+            serif = fam
+            break
+    if serif:
+        tf = QFont(serif, 22)
+        tf.setStyleHint(QFont.StyleHint.Serif)
+        tf.setWeight(QFont.Weight.Medium)
+        title.setFont(tf)
+    else:
+        tf = QFont("Helvetica Neue", 22)
+        tf.setWeight(QFont.Weight.DemiBold)
+        title.setFont(tf)
+    title.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+
+    title_col = QVBoxLayout()
+    title_col.setContentsMargins(0, 0, 0, 0)
+    title_col.setSpacing(2)
+    title_col.addWidget(meta)
+    title_col.addWidget(title)
+    title_col_wrap = QWidget()
+    title_col_wrap.setLayout(title_col)
+    top.addWidget(title_col_wrap, 1)
+    h.addLayout(top)
+
+    # Chooser strip: the native DeckChooser / NotetypeChooser live inside
+    # `addcards.form.modelArea` and `deckArea`. We rehome those widgets so
+    # the controls themselves still work — only the position changes.
+    choosers = QHBoxLayout()
+    choosers.setContentsMargins(0, 4, 0, 0)
+    choosers.setSpacing(18)
+
+    nt_label = QLabel("TYPE")
+    nt_label.setProperty("role", "chooser-key")
+    nt_label.setToolTip("Note type (⌘N to change)")
+    dk_label = QLabel("DECK")
+    dk_label.setProperty("role", "chooser-key")
+    dk_label.setToolTip("Target deck (⌘D to change)")
+
+    nt_area: QWidget = addcards.form.modelArea
+    dk_area: QWidget = addcards.form.deckArea
+    # Strip any minimum size so they shrink to content.
+    try:
+        nt_area.setMinimumSize(QSize(0, 0))
+        dk_area.setMinimumSize(QSize(0, 0))
+    except Exception:
+        pass
+
+    # NotetypeChooser / DeckChooser each construct their own QLabel as the
+    # first child of the area widget (text: "Type" / "Deck"). We already have
+    # our own all-caps eyebrow label, so hide theirs to avoid the duplicate
+    # "NOTE TYPE TYPE Basic" effect.
+    def _hide_first_label(host: QWidget) -> None:
+        try:
+            for child in host.findChildren(QLabel):
+                child.hide()
+                # one is enough; the chooser only adds one label per area
+                break
+        except Exception:
+            pass
+    _hide_first_label(nt_area)
+    _hide_first_label(dk_area)
+
+    # Force flat style on the chooser buttons — macOS's native QStyle keeps
+    # the Aqua chrome around QPushButton even with a stylesheet, so we
+    # explicitly setStyleSheet on each child push button. This puts the
+    # painted pill back even when the global QSS gets out-prioritized.
+    def _flatten_buttons(host: QWidget) -> None:
+        try:
+            for b in host.findChildren(QPushButton):
+                b.setObjectName("ba-chooser")
+                b.setCursor(Qt.CursorShape.PointingHandCursor)
+                b.setFlat(True)
+        except Exception:
+            pass
+    _flatten_buttons(nt_area)
+    _flatten_buttons(dk_area)
+
+    nt_group = QHBoxLayout()
+    nt_group.setContentsMargins(0, 0, 0, 0)
+    nt_group.setSpacing(6)
+    nt_group.addWidget(nt_label)
+    nt_group.addWidget(nt_area)
+    nt_wrap = QWidget()
+    nt_wrap.setLayout(nt_group)
+
+    dk_group = QHBoxLayout()
+    dk_group.setContentsMargins(0, 0, 0, 0)
+    dk_group.setSpacing(6)
+    dk_group.addWidget(dk_label)
+    dk_group.addWidget(dk_area)
+    dk_wrap = QWidget()
+    dk_wrap.setLayout(dk_group)
+
+    choosers.addWidget(nt_wrap)
+    choosers.addWidget(dk_wrap)
+    choosers.addStretch(1)
+
+    h.addLayout(choosers)
+    root_layout.addWidget(header)
+    root_layout.addWidget(_hrule(palette))
+
+    # --- Fields (editor webview lives inside addcards.form.fieldsArea) --- #
+    fields_wrap = QWidget()
+    fields_wrap.setObjectName("ba-fields-wrap")
+    fw = QVBoxLayout(fields_wrap)
+    fw.setContentsMargins(0, 0, 0, 0)
+    fw.setSpacing(0)
+    fields_area: QWidget = addcards.form.fieldsArea
+    fw.addWidget(fields_area)
+    root_layout.addWidget(fields_wrap, 1)
+
+    # --- Footer --- #
+    root_layout.addWidget(_hrule(palette))
+    footer = QWidget()
+    footer.setObjectName("ba-footer")
+    f = QHBoxLayout(footer)
+    f.setContentsMargins(28, 16, 28, 18)
+    f.setSpacing(10)
+
+    history_btn = QPushButton("Recent ▾")
+    history_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    history_btn.setToolTip("Re-open a recently added note (Cmd+Shift+H)")
+    help_btn = QPushButton("?")
+    help_btn.setObjectName("ba-icon")
+    help_btn.setToolTip("Help")
+    help_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    close_btn = QPushButton("Esc")
+    close_btn.setObjectName("ba-ghost")
+    close_btn.setToolTip("Close (Esc)")
+    close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    add_btn = QPushButton("Add card")
+    add_btn.setObjectName("ba-primary")
+    add_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    # Wire to original buttons (preserves shortcuts and add-on hooks).
+    try:
+        _proxy_click(add_btn, addcards.addButton)
+        _proxy_click(history_btn, addcards.historyButton)
+        _proxy_click(help_btn, addcards.helpButton)
+        _proxy_click(close_btn, addcards.closeButton)
+    except Exception:
+        pass
+
+    # Disable our copy of history when the native one is disabled (no history).
+    try:
+        history_btn.setEnabled(addcards.historyButton.isEnabled())
+        addcards.historyButton.changeEvent  # noqa - just touch
+        # Mirror enabled-state changes from the native button.
+        def _mirror_history() -> None:
+            try:
+                history_btn.setEnabled(addcards.historyButton.isEnabled())
+            except Exception:
+                pass
+        # Hook via paintEvent: cheap, fires often enough.
+        addcards._ba_mirror_history = _mirror_history  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    # Build an "Add card  ⌘↩" composite — shortcut hint sits inside the
+    # primary button as a quiet caption (Apple-style), not a detached label.
+    add_btn.setText(
+        f"Add card     {_shortcut_caption('Ctrl+Enter')}"
+    )
+
+    f.addWidget(help_btn)
+    f.addWidget(history_btn)
+    f.addStretch(1)
+    f.addWidget(close_btn)
+    f.addSpacing(6)
+    f.addWidget(add_btn)
+    root_layout.addWidget(footer)
+
+    # Hide the original button box (its buttons remain alive for proxying).
+    try:
+        addcards.form.buttonBox.hide()
+    except Exception:
+        pass
+
+    # Apply QSS to the window.
+    try:
+        addcards.setStyleSheet(_qss(palette, accent))
+    except Exception:
+        pass
+    # Install root as the central widget (replaces the stock centralwidget).
+    try:
+        addcards.setCentralWidget(root)
+    except Exception:
+        pass
+
+    # Re-poll the native history button's enabled state every 800ms so our
+    # mirror stays in sync. Cheap and bulletproof.
+    try:
+        from aqt.qt import QTimer
+        t = QTimer(addcards)
+        t.setInterval(800)
+        def _tick() -> None:
+            try:
+                history_btn.setEnabled(addcards.historyButton.isEnabled())
+            except Exception:
+                pass
+        t.timeout.connect(_tick)
+        t.start()
+        addcards._ba_history_timer = t  # keep ref
+    except Exception:
+        pass
+
+    # Larger default window — the new chrome breathes.
+    try:
+        if addcards.width() < 880 or addcards.height() < 720:
+            addcards.resize(max(addcards.width(), 880), max(addcards.height(), 720))
+    except Exception:
+        pass
+
+    # Update the "N ADDED TODAY" eyebrow every time a note is added.
+    def _refresh_meta() -> None:
+        try:
+            n = _cards_added_today()
+            if n <= 0:
+                t = "FIRST OF TODAY"
+            elif n == 1:
+                t = "1 ADDED TODAY"
+            else:
+                t = f"{n} ADDED TODAY"
+            meta.setText(t)
+        except Exception:
+            pass
+    addcards._ba_refresh_meta = _refresh_meta  # type: ignore[attr-defined]
+
+
+def on_add_cards_did_init(addcards: AddCards) -> None:
+    try:
+        _redress(addcards)
+    except Exception as e:
+        # Log only — popping up a modal here blocks Qt's event loop and
+        # cascades into hung-screenshot timeouts during dev iteration.
+        import traceback
+        try:
+            print(
+                f"[betteranki.addcard] redress failed: {e}\n"
+                f"{traceback.format_exc()}",
+                flush=True,
+            )
+        except Exception:
+            pass
+
+
+def _on_note_added(note: Any) -> None:
+    """Refresh the eyebrow count in any open Add Card window."""
+    try:
+        from aqt import dialogs
+        ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+        if ac is None:
+            return
+        cb = getattr(ac, "_ba_refresh_meta", None)
+        if callable(cb):
+            cb()
+    except Exception:
+        pass
+
+
+def register() -> None:
+    gui_hooks.add_cards_did_init.append(on_add_cards_did_init)
+    try:
+        gui_hooks.add_cards_did_add_note.append(_on_note_added)
+    except Exception:
+        pass

--- a/addcard.py
+++ b/addcard.py
@@ -538,8 +538,8 @@ def _redress(addcards: AddCards) -> None:
             except Exception:
                 pass
             # Re-apply chevron in case Anki updated the chooser label text.
-            _stylize(nt_area)
-            _stylize(dk_area)
+            _stylize(nt_area, "notetype")
+            _stylize(dk_area, "deck")
         t.timeout.connect(_tick)
         t.start()
         addcards._ba_history_timer = t  # keep ref

--- a/addcard_embed.py
+++ b/addcard_embed.py
@@ -1,0 +1,239 @@
+"""BetterAnki — embed AddCards inside the main window as a "tab".
+
+Anki opens AddCards as a separate QMainWindow. The user wants it to behave
+like a tab in the main window: the sidebar (rendered inside `mw.web` by the
+deck browser HTML) stays visible, and the editor occupies the rest.
+
+How this works:
+  - We intercept the sidebar's `ba:add` pycmd in `__init__.py` to call
+    `open_inline(mw)` instead of `mw.onAddCard()`.
+  - `open_inline` constructs an AddCards instance (which fires our normal
+    `_redress` via `add_cards_did_init`).
+  - We grab its `centralWidget` and reparent it onto a thin overlay frame
+    placed on top of `mw.form.centralwidget`, offset by the sidebar's
+    width so the sidebar in mw.web stays visible through the gap.
+  - The AddCards window itself is hidden (its widgets are alive, so all
+    handlers, shortcuts, and add-on hooks continue to fire).
+  - A small "← Back to decks" affordance in the top-left of the overlay
+    closes AddCards and removes the overlay.
+  - The overlay resizes with the main window via an installed event filter.
+
+Caveats:
+  - Sidebar width is hard-coded to 250px to match `web/sidebar.css`. If
+    the sidebar changes width, this needs to be updated.
+  - Qt widgets stacking above QWebEngineView on macOS Qt6 has been stable
+    for a long time but is technically a known-fragile combination — if
+    rendering glitches appear, fall back to the standard windowed flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from aqt import mw
+from aqt.qt import (
+    QEvent,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QObject,
+    QPushButton,
+    QSize,
+    Qt,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+SIDEBAR_W = 250  # px — matches web/sidebar.css .ba-sidebar width
+
+
+def _palette_styles() -> str:
+    """QSS for the embed wrapper and (importantly) re-applies the AddCards
+    chrome QSS so the styles continue to match after we reparent. Without
+    this the Add button comes through as a default white QPushButton."""
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    cfg = _addcard._config()
+    accent = cfg.get("accent", "#6c8cff")
+    chrome = _addcard._qss(palette, accent)
+    return chrome + """
+QFrame#ba-embed {
+    background: """ + palette["paper"] + """;
+    border-left: 1px solid """ + palette["line"] + """;
+}
+QPushButton#ba-back {
+    background: transparent;
+    color: """ + palette["ink_dim"] + """;
+    border: 1px solid """ + palette["line2"] + """;
+    border-radius: 8px;
+    padding: 6px 12px;
+    font-size: 10.5pt;
+    font-weight: 500;
+}
+QPushButton#ba-back:hover {
+    color: """ + palette["ink"] + """;
+    background: """ + palette["hover"] + """;
+    border-color: """ + palette["ink_faint"] + """;
+}
+"""
+
+
+class _EmbedFilter(QObject):
+    """Re-positions the embed overlay whenever the main window is resized."""
+
+    def __init__(self, overlay: QFrame) -> None:
+        super().__init__(overlay)
+        self._overlay = overlay
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize:
+            try:
+                cw = mw.form.centralwidget
+                self._overlay.setGeometry(
+                    SIDEBAR_W,
+                    0,
+                    cw.width() - SIDEBAR_W,
+                    cw.height(),
+                )
+            except Exception:
+                pass
+        return False
+
+
+_state: dict = {"addcards": None, "overlay": None, "filter": None}
+
+
+def close_inline() -> None:
+    """Tear down the embedded view and restore the deck browser."""
+    overlay = _state.get("overlay")
+    ac = _state.get("addcards")
+    flt = _state.get("filter")
+    if overlay is not None:
+        try:
+            if flt is not None:
+                mw.form.centralwidget.removeEventFilter(flt)
+        except Exception:
+            pass
+        try:
+            overlay.deleteLater()
+        except Exception:
+            pass
+    if ac is not None:
+        try:
+            ac.close()
+        except Exception:
+            pass
+    _state["addcards"] = None
+    _state["overlay"] = None
+    _state["filter"] = None
+    # Restore the sidebar's active tab.
+    try:
+        w = getattr(mw, "web", None)
+        if w is not None:
+            w.eval("window.__baSetActive && window.__baSetActive('decks');")
+    except Exception:
+        pass
+
+
+def open_inline(parent_mw: Any = None) -> None:
+    """Open AddCards embedded in the main window's content area.
+
+    Falls back to the normal AddCards window if the embed setup fails for
+    any reason."""
+    parent_mw = parent_mw or mw
+    if _state.get("overlay") is not None:
+        # Already open — bring it forward.
+        try:
+            _state["overlay"].raise_()
+        except Exception:
+            pass
+        return
+
+    try:
+        from aqt.addcards import AddCards
+        ac = AddCards(parent_mw)
+    except Exception:
+        # Anki's normal flow as a last resort.
+        try:
+            parent_mw.onAddCard()
+        except Exception:
+            pass
+        return
+
+    try:
+        central = ac.centralWidget()
+        # Build an overlay frame holding the redressed AddCards centralWidget.
+        # No back button — the sidebar already has a "Decks" item, and we
+        # mark "Add" as active there so the user knows what tab they're on.
+        overlay = QFrame(parent_mw.form.centralwidget)
+        overlay.setObjectName("ba-embed")
+        overlay.setStyleSheet(_palette_styles())
+
+        v = QVBoxLayout(overlay)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
+
+        # Reparent the redressed AddCards centralWidget into the overlay.
+        # Use Qt.Widget so it acts like a normal child, not a window.
+        central.setParent(overlay)
+        central.setWindowFlags(Qt.WindowType.Widget)
+        v.addWidget(central, 1)
+
+        # Hide the original AddCards QMainWindow chrome.
+        ac.setVisible(False)
+
+        # Position over the right of the central area.
+        cw = parent_mw.form.centralwidget
+        overlay.setGeometry(
+            SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height()
+        )
+        overlay.show()
+        overlay.raise_()
+
+        # Resize the overlay with the main window.
+        flt = _EmbedFilter(overlay)
+        cw.installEventFilter(flt)
+
+        _state["addcards"] = ac
+        _state["overlay"] = overlay
+        _state["filter"] = flt
+
+        # Tell the sidebar (rendered inside mw.web) to highlight "Add"
+        # instead of "Decks", so the active tab is correct visually.
+        try:
+            w = getattr(parent_mw, "web", None)
+            if w is not None:
+                w.eval("window.__baSetActive && window.__baSetActive('add');")
+        except Exception:
+            pass
+
+        # If AddCards closes from inside (Esc, internal close button), tear
+        # down the overlay too. We monkey-patch _close — the legitimate
+        # cleanup path — to call our close_inline after.
+        try:
+            orig_close = ac._close
+            def _wrapped_close(orig=orig_close) -> None:
+                try:
+                    orig()
+                finally:
+                    if _state.get("addcards") is ac:
+                        close_inline()
+            ac._close = _wrapped_close  # type: ignore[assignment]
+        except Exception:
+            pass
+    except Exception as e:
+        import traceback
+        print(
+            f"[betteranki.embed] failed: {e}\n{traceback.format_exc()}",
+            flush=True,
+        )
+        # Best-effort cleanup, then fall back to the standalone window.
+        try:
+            close_inline()
+        except Exception:
+            pass
+        try:
+            ac.show()
+        except Exception:
+            pass

--- a/scripts/dump.sh
+++ b/scripts/dump.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Dump the HTML of the web view in a Qt window matching the title substring.
+set -euo pipefail
+OUT="${1:?missing out.html}"
+TITLE="${2:?missing title substring}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DIR="$REPO/.context/dump-requests"
+mkdir -p "$DIR" "$(dirname "$OUT")"
+ABS_OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
+REQ="$DIR/req-$(date +%s%N).json"
+cat > "$REQ" <<JSON
+{"out":"${ABS_OUT}","title":"${TITLE}"}
+JSON
+for _ in $(seq 1 200); do
+  if [[ -f "$ABS_OUT" ]] && [[ ! -f "$REQ" ]]; then
+    echo "wrote $ABS_OUT"; exit 0
+  fi
+  sleep 0.1
+done
+echo "timeout" >&2; exit 1

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -16,6 +16,7 @@ FILL_FLAG="false"
 COG_FLAG="false"
 HOVER_FLAG="false"
 TYPE_FLAG="false"
+EMBED_FLAG="false"
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
@@ -23,6 +24,7 @@ for arg in "$@"; do
     --click-cog) COG_FLAG="true" ;;
     --hover-add) HOVER_FLAG="true" ;;
     --click-type) TYPE_FLAG="true" ;;
+    --embed-add) OPEN_FLAG="true"; EMBED_FLAG="true" ;;
   esac
 done
 
@@ -41,6 +43,7 @@ cat > "$REQ" <<JSON
   "fill_sample": ${FILL_FLAG},
   "click_cog": ${COG_FLAG},
   "click_type": ${TYPE_FLAG},
+  "embed_add": ${EMBED_FLAG},
   "delay_ms": 2000
 }
 JSON

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -15,12 +15,14 @@ OPEN_FLAG="false"
 FILL_FLAG="false"
 COG_FLAG="false"
 HOVER_FLAG="false"
+TYPE_FLAG="false"
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
     --fill-sample) FILL_FLAG="true" ;;
     --click-cog) COG_FLAG="true" ;;
     --hover-add) HOVER_FLAG="true" ;;
+    --click-type) TYPE_FLAG="true" ;;
   esac
 done
 
@@ -38,7 +40,7 @@ cat > "$REQ" <<JSON
   "open_addcards": ${OPEN_FLAG},
   "fill_sample": ${FILL_FLAG},
   "click_cog": ${COG_FLAG},
-  "force_add_hover": ${HOVER_FLAG},
+  "click_type": ${TYPE_FLAG},
   "delay_ms": 2000
 }
 JSON

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -14,11 +14,13 @@ shift 2 || true
 OPEN_FLAG="false"
 FILL_FLAG="false"
 COG_FLAG="false"
+HOVER_FLAG="false"
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
     --fill-sample) FILL_FLAG="true" ;;
     --click-cog) COG_FLAG="true" ;;
+    --hover-add) HOVER_FLAG="true" ;;
   esac
 done
 
@@ -36,6 +38,7 @@ cat > "$REQ" <<JSON
   "open_addcards": ${OPEN_FLAG},
   "fill_sample": ${FILL_FLAG},
   "click_cog": ${COG_FLAG},
+  "force_add_hover": ${HOVER_FLAG},
   "delay_ms": 2000
 }
 JSON

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# snap.sh - request a Qt grab() screenshot from the running dev Anki.
+#
+# Usage:
+#   scripts/snap.sh <out.png> <title-substring|"main"> [--open-addcards] [--fill-sample]
+#
+# Writes a JSON request into .context/screenshot-requests/; the BetterAnki
+# dev-watch thread picks it up, grabs the matching top-level widget on the
+# Qt main thread, saves the PNG, then deletes the request file.
+set -euo pipefail
+OUT="${1:?missing out.png path}"
+TITLE="${2:?missing title substring (or \"main\")}"
+shift 2 || true
+OPEN_FLAG="false"
+FILL_FLAG="false"
+for arg in "$@"; do
+  case "$arg" in
+    --open-addcards) OPEN_FLAG="true" ;;
+    --fill-sample) FILL_FLAG="true" ;;
+  esac
+done
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DIR="$REPO/.context/screenshot-requests"
+mkdir -p "$DIR" "$(dirname "$OUT")"
+ABS_OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
+
+# Stable filename ⇒ unique stamp per request
+REQ="$DIR/req-$(date +%s%N).json"
+cat > "$REQ" <<JSON
+{
+  "out": "${ABS_OUT}",
+  "title": "${TITLE}",
+  "open_addcards": ${OPEN_FLAG},
+  "fill_sample": ${FILL_FLAG}
+}
+JSON
+
+# Wait up to 30s for the addon to write the PNG (and delete the request).
+# Editor.html loads async via WebEngine so we allow ~1s render delay inside.
+for _ in $(seq 1 300); do
+  if [[ -f "$ABS_OUT" ]] && [[ ! -f "$REQ" ]]; then
+    echo "wrote $ABS_OUT"
+    exit 0
+  fi
+  if [[ -f "$ABS_OUT.err" ]]; then
+    echo "screenshot error: $(cat "$ABS_OUT.err")" >&2
+    rm -f "$ABS_OUT.err"
+    exit 1
+  fi
+  sleep 0.1
+done
+echo "timeout waiting for screenshot (req=$REQ)" >&2
+exit 1

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -13,10 +13,12 @@ TITLE="${2:?missing title substring (or \"main\")}"
 shift 2 || true
 OPEN_FLAG="false"
 FILL_FLAG="false"
+COG_FLAG="false"
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
     --fill-sample) FILL_FLAG="true" ;;
+    --click-cog) COG_FLAG="true" ;;
   esac
 done
 
@@ -32,7 +34,9 @@ cat > "$REQ" <<JSON
   "out": "${ABS_OUT}",
   "title": "${TITLE}",
   "open_addcards": ${OPEN_FLAG},
-  "fill_sample": ${FILL_FLAG}
+  "fill_sample": ${FILL_FLAG},
+  "click_cog": ${COG_FLAG},
+  "delay_ms": 2000
 }
 JSON
 

--- a/web/addcard.css
+++ b/web/addcard.css
@@ -4,14 +4,13 @@
  * window (data-ba-editor="add"). Anki's own editor.css uses Bootstrap-ish
  * tokens; we override the visible surface to match the editorial chrome.
  *
- * Anki's Svelte components carry hashed class suffixes (e.g.
- * `.editor-toolbar.svelte-1jmvn33`), but the unhashed base class is stable
- * across Anki versions, so we target by base class alone.
+ * Svelte components carry hashed class suffixes (.editor-toolbar.svelte-1jmvn33);
+ * the unhashed base class is stable across Anki versions, so we target by
+ * base class alone.
  */
 
-/* Design tokens scoped to the editor in add mode. */
+/* ---------- Design tokens ---------- */
 html[data-ba-editor="add"] {
-  /* light defaults */
   --ba-paper: #f6f3ec;
   --ba-panel: #fbf9f3;
   --ba-field: #ffffff;
@@ -24,6 +23,7 @@ html[data-ba-editor="add"] {
   --ba-accent: var(--rf-accent, #6c8cff);
   --ba-serif: var(--rf-serif, "New York", "Hoefler Text", Charter, Georgia, serif);
   --ba-sans: var(--rf-sans, "SF Pro Text", "Helvetica Neue", system-ui, sans-serif);
+  --ba-radius: 8px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -42,10 +42,6 @@ html[data-ba-editor="add"] {
 html[data-ba-editor="add"][data-rf-theme="dark"] {
   --ba-paper: #0b0c0f;
   --ba-panel: #15171c;
-  /* The field input keeps a paper-light background even in dark mode so
-     the card content renders the same as it will on the review screen
-     (where the note type stylesheet sets a dark-on-light look by default).
-     This is consistent with native Anki's add-card field behavior. */
   --ba-field: #f6f3ec;
   --ba-ink: #eceae2;
   --ba-ink-dim: #9b978a;
@@ -61,93 +57,58 @@ html[data-ba-editor="add"], html[data-ba-editor="add"] body {
   font-family: var(--ba-sans) !important;
 }
 
-/* --- The note editor frame --- */
 html[data-ba-editor="add"] .note-editor {
   background: var(--ba-paper) !important;
   color: var(--ba-ink) !important;
 }
-/* The mathjax & image overlays are positioned inside the fields scroll
-   area but have no business taking layout space when empty. */
+
 html[data-ba-editor="add"] .mathjax-overlay:empty,
 html[data-ba-editor="add"] .image-overlay:empty {
   display: none !important;
 }
 
-/* --- Top format toolbar --- */
+/* ---------- Format toolbar ----------
+ * We CANNOT use overflow:hidden on the toolbar or its parent — that clips
+ * the gear's dropdown menu (which is absolutely positioned but rendered
+ * inside the toolbar's DOM tree). The toolbar lives in a fixed-height row
+ * already, so we just allow overflow:visible and trust the icon row to fit.
+ */
 html[data-ba-editor="add"] .editor-toolbar {
   background: var(--ba-panel) !important;
   border-bottom: 1px solid var(--ba-line) !important;
-  padding: 8px 22px !important;
+  padding: 6px 24px !important;
+  overflow: visible !important;
   box-shadow: none !important;
 }
 html[data-ba-editor="add"] .button-toolbar.btn-toolbar {
   gap: 2px !important;
-  /* Anki gates the toolbar wrap via this CSS var, not by flex-wrap. */
   --buttons-size: 1.55rem !important;
   --buttons-wrap: nowrap !important;
-  overflow-x: auto !important;
-  overflow-y: hidden !important;
-  padding-right: 8px;
-  scrollbar-width: none; /* Firefox */
+  overflow: visible !important;
   align-items: center !important;
 }
-/* Move the gear/options group to the very end of the toolbar — it's a
-   "more" menu, not a formatting tool, and looked orphaned between the
-   notetype links and B/I/U. The .item lives inside .dynamically-slottable,
-   which IS a flex container, so the order applies there. */
-html[data-ba-editor="add"] .dynamically-slottable {
-  display: flex !important;
-  align-items: center !important;
-  flex-wrap: nowrap !important;
-}
-html[data-ba-editor="add"] .item#settings {
-  order: 99 !important;
-  margin-left: 6px !important;
-}
-html[data-ba-editor="add"] .item#notetype {
-  order: -1 !important;
-}
-html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar {
-  height: 0 !important;
-  display: none !important;
-}
-html[data-ba-editor="add"] .editor-toolbar {
-  overflow: hidden !important;
-}
-/* Kill the boxy borders/radii Bootstrap stamps onto every button-group and
-   button-group-item — we want a clean horizontal row of pill icons. */
 html[data-ba-editor="add"] .button-group,
 html[data-ba-editor="add"] .button-group.btn-group,
 html[data-ba-editor="add"] .button-group-item,
 html[data-ba-editor="add"] .dynamically-slottable {
   background: transparent !important;
   border: 0 !important;
-  border-radius: 8px !important;
+  border-radius: 6px !important;
   padding: 0 !important;
-  gap: 2px !important;
+  gap: 1px !important;
   box-shadow: none !important;
 }
-/* Vertical divider between adjacent toolbar groups. */
-html[data-ba-editor="add"] .button-toolbar.btn-toolbar > .item + .item {
-  position: relative;
-  padding-left: 12px !important;
-  margin-left: 0 !important;
-}
-html[data-ba-editor="add"] .button-toolbar.btn-toolbar > .item + .item::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 8px;
-  bottom: 8px;
-  width: 1px;
-  background: var(--ba-line);
+html[data-ba-editor="add"] .dynamically-slottable {
+  display: flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
 }
 html[data-ba-editor="add"] .icon-button,
 html[data-ba-editor="add"] .label-button {
   color: var(--ba-ink-dim) !important;
   background: transparent !important;
   border: 0 !important;
-  border-radius: 7px !important;
+  border-radius: 6px !important;
   font-family: var(--ba-sans) !important;
   font-size: 10.5pt !important;
   padding: 5px 7px !important;
@@ -172,65 +133,86 @@ html[data-ba-editor="add"] .label-button svg {
   width: 18px !important;
   height: 18px !important;
 }
-/* "Fields..." / "Cards..." should read as quiet meta links, not buttons. */
+/* "Fields..." / "Cards..." styled as quiet metadata links in sans. */
 html[data-ba-editor="add"] #notetype .label-button {
-  font-style: italic !important;
-  font-family: var(--ba-serif) !important;
+  font-style: normal !important;
+  font-family: var(--ba-sans) !important;
   color: var(--ba-ink-faint) !important;
-  font-size: 10.5pt !important;
-  padding: 6px 8px !important;
+  font-size: 10pt !important;
+  font-weight: 500 !important;
 }
 html[data-ba-editor="add"] #notetype .label-button:hover {
   color: var(--ba-ink) !important;
   background: var(--ba-hover) !important;
 }
+/* Gear: push to the very end via flex order. */
+html[data-ba-editor="add"] .item#settings { order: 99 !important; }
+html[data-ba-editor="add"] .item#notetype { order: -1 !important; }
+/* Dropdown panels (Popper-based "floating" elements) live inside the
+   toolbar's DOM tree. Their default visibility is toggled by Anki; we just
+   ensure they stack above other content when shown and don't get clipped.
+   IMPORTANT: don't add a background/border unconditionally — when the panel
+   is closed it's still in the DOM and our styles would draw a visible
+   "circle" around every chevron-button in the toolbar. */
+html[data-ba-editor="add"] .floating {
+  z-index: 50 !important;
+}
+html[data-ba-editor="add"] .floating[data-show],
+html[data-ba-editor="add"] .floating[style*="display: block"],
+html[data-ba-editor="add"] .floating[style*="display:flex"] {
+  background: var(--ba-panel) !important;
+  border: 1px solid var(--ba-line-strong) !important;
+  border-radius: 10px !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18) !important;
+  padding: 6px !important;
+}
 
-/* --- Fields list --- */
+/* ---------- Fields ---------- */
 html[data-ba-editor="add"] .fields {
   background: var(--ba-paper) !important;
-  padding: 14px 24px 2px 24px !important;
+  padding: 18px 28px 4px 28px !important;
 }
 html[data-ba-editor="add"] .field-container {
   background: transparent !important;
   border: 0 !important;
-  margin-bottom: 2px !important;
+  margin-bottom: 14px !important;
   padding: 0 !important;
 }
-/* Highlight the focused field — the one the next keystroke writes to. */
-html[data-ba-editor="add"] .field-container:focus-within .label-name {
-  color: var(--ba-accent) !important;
-}
 
-/* Field label row — touch only what we need. */
+/* Field label — small uppercase sans, like a section subhead. Quiet at
+   rest, accent on focus. Sans-serif at this small size reads better than
+   italic-serif (which felt unreadable). */
+html[data-ba-editor="add"] .label-container {
+  padding: 0 4px 5px 4px !important;
+  border: 0 !important;
+  background: transparent !important;
+}
 html[data-ba-editor="add"] .label-container .label-name {
   font-family: var(--ba-sans) !important;
-  font-size: 9pt !important;
-  font-weight: 700 !important;
-  letter-spacing: 1.4px !important;
+  font-style: normal !important;
+  font-size: 9.5pt !important;
+  font-weight: 600 !important;
+  letter-spacing: 1.2px !important;
   text-transform: uppercase !important;
   color: var(--ba-ink-faint) !important;
+  transition: color 160ms ease;
 }
 html[data-ba-editor="add"] .field-container:focus-within .label-name {
   color: var(--ba-accent) !important;
 }
-
-/* Hide just the chevron badge — the .collapse-label wraps the label NAME
-   so we mustn't display:none it. */
+/* Hide the chevron — fields aren't collapsible in the add window. */
 html[data-ba-editor="add"] .collapse-badge {
   display: none !important;
 }
 
-/* Field state icons (sticky pin, HTML edit, plain-text badge):
-   reveal only on hover so the field row stays calm at rest. The Svelte
-   templates also stamp them in by default for focused fields — we override
-   that so they're consistent. */
+/* Field state icons (sticky pin, HTML edit) — hover only. */
 html[data-ba-editor="add"] .field-state {
   opacity: 0;
   transition: opacity 180ms ease;
   pointer-events: none;
 }
 html[data-ba-editor="add"] .field-container:hover .field-state {
-  opacity: 0.6;
+  opacity: 0.55;
   pointer-events: auto;
 }
 html[data-ba-editor="add"] .field-container:hover .field-state:hover,
@@ -253,41 +235,46 @@ html[data-ba-editor="add"] .field-state .badge:hover {
   border-radius: 6px !important;
 }
 
-/* The actual editable box. Override both the outer .editing-area and the
-   inner .rich-text-input — Anki's editor.css sets backgrounds on both, and
-   without overriding the inner one the dark-mode bg shows through. */
+/* Field input box. Anki nests:
+       editor-field > editing-area > collapsible > rich-text-input >
+       rich-text-relative > rich-text-editable
+   Several of these ship with their own border/radius from editor.css,
+   which stack into a visible double-border. Strip them all and paint a
+   single border on .editor-field (the outermost wrapper). Focus inside
+   the rich-text-editable propagates :focus-within all the way up. */
+html[data-ba-editor="add"] .editor-field,
 html[data-ba-editor="add"] .editing-area,
-html[data-ba-editor="add"] .editing-area .rich-text-input,
-html[data-ba-editor="add"] .editing-area .plain-text-input {
+html[data-ba-editor="add"] .rich-text-input,
+html[data-ba-editor="add"] .rich-text-relative,
+html[data-ba-editor="add"] .rich-text-editable,
+html[data-ba-editor="add"] .plain-text-input {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+html[data-ba-editor="add"] .editor-field {
   background: var(--ba-field) !important;
-  color: #1f1d18 !important; /* readable on the cream/white field bg */
-  border-radius: 10px !important;
-}
-html[data-ba-editor="add"] .editing-area {
   border: 1px solid var(--ba-line) !important;
-  padding: 0 !important;
-  transition: border-color 160ms ease, box-shadow 160ms ease,
-              background 160ms ease;
-  overflow: hidden;  /* clip the inner bg to the rounded corners */
+  border-radius: var(--ba-radius) !important;
+  overflow: hidden !important;
+  transition: border-color 160ms ease, background 160ms ease;
 }
-html[data-ba-editor="add"] .editing-area:focus-within {
+html[data-ba-editor="add"] .editor-field:focus-within {
   border-color: var(--ba-accent) !important;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ba-accent) 16%, transparent) !important;
 }
 html[data-ba-editor="add"] .rich-text-editable,
 html[data-ba-editor="add"] .plain-text-input {
-  padding: 8px 14px !important;
+  padding: 10px 14px !important;
   min-height: 22px !important;
   font-family: var(--ba-serif) !important;
   font-size: 13pt !important;
   line-height: 1.5 !important;
-  color: #1f1d18 !important; /* always-dark text on the cream field bg */
+  color: #1f1d18 !important;
   background: transparent !important;
   border: 0 !important;
   outline: none !important;
 }
-/* Placeholder text in empty fields. Svelte tags rich-text-editable with
-   `.empty` when the contenteditable has no content. */
 html[data-ba-editor="add"] .rich-text-editable.empty::before {
   font-family: var(--ba-sans) !important;
   font-style: normal !important;
@@ -305,86 +292,101 @@ html[data-ba-editor="add"] .field-container[data-index="1"] .rich-text-editable.
 html[data-ba-editor="add"] .field-container:not([data-index="0"]):not([data-index="1"]) .rich-text-editable.empty::before {
   content: "Optional";
 }
-/* Cursor-friendly tone for the first/required field. */
-html[data-ba-editor="add"] .field-container:first-of-type .editing-area {
-  background: var(--ba-field) !important;
-}
 
-/* --- Tags --- *
- * The Tags section is NOT inside .fields. It's a top-level .collapse-label
- * (header text "Tags") followed by a .collapsible wrapping a .tag-editor.
- * We distinguish the tags' collapse-label from the field collapse-labels by
- * title="Collapse" (vs "Collapse field" for the fields). */
+/* ---------- Tags ----------
+ * The Svelte tag editor renders a top "Tags" header (a .collapse-label
+ * outside .fields) followed by a .collapsible wrapping a .tag-editor. The
+ * native chrome bundles the heading, a chevron, and a tag-icon button into
+ * an awkward row. We rebuild it as a single clean line:
+ *
+ *      tags  ·  #anatomy  #europe  +
+ *
+ * (a quiet italic-serif label, then chips, then a "+" affordance — but
+ * still backed by Anki's tag autocomplete since we don't replace the input).
+ */
+/* "Tags" header — match the field labels (small uppercase sans). The
+   collapse-label span contains both a chevron (hidden via .collapse-badge)
+   and the literal text "Tags"; we zero the text via font-size:0 then put
+   "TAGS" in a ::before with explicit size so the casing is consistent. */
 html[data-ba-editor="add"] .collapse-label[title="Collapse"] {
-  display: block !important;
-  padding: 14px 24px 6px 24px !important;
-  margin-top: 12px !important;
+  display: flex !important;
+  align-items: center !important;
+  padding: 14px 28px 4px 28px !important;
+  margin: 14px 0 0 0 !important;
   font-family: var(--ba-sans) !important;
-  font-size: 9pt !important;
-  font-weight: 700 !important;
-  letter-spacing: 1.4px !important;
-  text-transform: uppercase !important;
+  font-style: normal !important;
+  font-size: 0 !important;
   color: var(--ba-ink-faint) !important;
   border-top: 1px solid var(--ba-line) !important;
   background: var(--ba-paper) !important;
+  text-transform: uppercase !important;
+  letter-spacing: 1.2px !important;
 }
-/* The tag input itself */
-html[data-ba-editor="add"] .tag-editor {
-  background: var(--ba-paper) !important;
-  padding: 4px 24px 14px 24px !important;
-}
-html[data-ba-editor="add"] .tag-add-button,
-html[data-ba-editor="add"] .tag-options-button {
-  color: var(--ba-ink-faint) !important;
-  background: transparent !important;
-  border: 0 !important;
-  border-radius: 6px !important;
-  padding: 4px !important;
-}
-html[data-ba-editor="add"] .tag-add-button:hover,
-html[data-ba-editor="add"] .tag-options-button:hover {
-  background: var(--ba-hover) !important;
-  color: var(--ba-ink) !important;
-}
-html[data-ba-editor="add"] .tag-add-button svg,
-html[data-ba-editor="add"] .tag-options-button svg {
-  width: 16px !important;
-  height: 16px !important;
-}
-html[data-ba-editor="add"] .tag-spacer {
-  padding: 6px 8px !important;
-  color: var(--ba-ink) !important;
-  font-family: var(--ba-sans) !important;
-  position: relative;
-  flex: 1;
-}
-/* Placeholder hint when no tags. .tag-spacer is a contenteditable that
-   contains a single <br> by default; using ::after on the parent puts the
-   placeholder visually inside the area. The tag-editor adds children when
-   tags are present, so we hide the placeholder when there's more than one. */
-html[data-ba-editor="add"] .tag-editor:not(:focus-within)::after {
-  content: "Add tags";
-  position: absolute;
-  left: 70px;  /* clear of the .tag-add-button icons */
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--ba-ink-faint) !important;
-  font-family: var(--ba-sans);
-  font-size: 11pt;
-  pointer-events: none;
-}
-html[data-ba-editor="add"] .tag-editor {
-  position: relative;
-}
-/* If there are any tag badges, hide the placeholder. */
-html[data-ba-editor="add"] .tag-editor:has(.tag) {
-  /* support browsers without :has — but most modern WebEngine supports it */
-}
-html[data-ba-editor="add"] .tag-editor:has(.tag)::after {
-  display: none !important;
+html[data-ba-editor="add"] .collapse-label[title="Collapse"]::before {
+  content: "TAGS";
+  font-size: 9.5pt;
+  font-weight: 600;
 }
 
-/* CodeMirror (plain-text mode) */
+/* Tag editor row. */
+html[data-ba-editor="add"] .tag-editor {
+  background: var(--ba-paper) !important;
+  padding: 4px 28px 14px 28px !important;
+  display: flex !important;
+  align-items: center !important;
+  flex-wrap: wrap !important;
+  gap: 6px !important;
+}
+/* Hide the leading "tag-options-button" cluster — that's the tag icon plus
+   the tag-plus button bundled inelegantly. We add a clean "+" via the
+   tag-spacer's surrounding area instead. */
+html[data-ba-editor="add"] .tag-options-button {
+  display: none !important;
+}
+html[data-ba-editor="add"] .tag-add-button {
+  background: transparent !important;
+  border: 0 !important;
+  padding: 0 !important;
+}
+/* The actual tag-typing area. */
+html[data-ba-editor="add"] .tag-spacer {
+  flex: 1;
+  padding: 6px 10px !important;
+  color: var(--ba-ink) !important;
+  font-family: var(--ba-sans) !important;
+  font-size: 11pt !important;
+  background: var(--ba-field) !important;
+  border-radius: var(--ba-radius) !important;
+  border: 1px solid var(--ba-line) !important;
+  min-height: 18px !important;
+  position: relative;
+}
+html[data-ba-editor="add"] .tag-editor:focus-within .tag-spacer {
+  border-color: var(--ba-accent) !important;
+}
+/* Placeholder when no tags. */
+html[data-ba-editor="add"] .tag-editor:not(:focus-within) .tag-spacer::before {
+  content: "Add tags";
+  color: var(--ba-ink-faint) !important;
+  pointer-events: none;
+}
+html[data-ba-editor="add"] .tag-editor:focus-within .tag-spacer::before,
+html[data-ba-editor="add"] .tag-editor:has(.tag) .tag-spacer::before {
+  display: none !important;
+}
+/* Tag chips (when tags present). */
+html[data-ba-editor="add"] .tag {
+  background: color-mix(in srgb, var(--ba-accent) 14%, transparent) !important;
+  color: var(--ba-accent) !important;
+  border-radius: 999px !important;
+  padding: 3px 10px !important;
+  font-size: 10.5pt !important;
+  font-family: var(--ba-sans) !important;
+  font-weight: 500 !important;
+  margin-right: 4px !important;
+}
+
+/* CodeMirror (plain-text mode). */
 html[data-ba-editor="add"] .code-mirror,
 html[data-ba-editor="add"] .CodeMirror {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace !important;
@@ -393,7 +395,7 @@ html[data-ba-editor="add"] .CodeMirror {
   color: var(--ba-ink) !important;
 }
 
-/* Scrollbars inside the webview */
+/* Scrollbars. */
 html[data-ba-editor="add"] ::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/web/addcard.css
+++ b/web/addcard.css
@@ -1,0 +1,410 @@
+/* BetterAnki — Add Card editor webview overlay.
+ *
+ * Restyles the Svelte note editor *only* when running inside the AddCards
+ * window (data-ba-editor="add"). Anki's own editor.css uses Bootstrap-ish
+ * tokens; we override the visible surface to match the editorial chrome.
+ *
+ * Anki's Svelte components carry hashed class suffixes (e.g.
+ * `.editor-toolbar.svelte-1jmvn33`), but the unhashed base class is stable
+ * across Anki versions, so we target by base class alone.
+ */
+
+/* Design tokens scoped to the editor in add mode. */
+html[data-ba-editor="add"] {
+  /* light defaults */
+  --ba-paper: #f6f3ec;
+  --ba-panel: #fbf9f3;
+  --ba-field: #ffffff;
+  --ba-ink: #1f1d18;
+  --ba-ink-dim: #6a6557;
+  --ba-ink-faint: #a39d8b;
+  --ba-line: rgba(31, 29, 24, 0.10);
+  --ba-line-strong: rgba(31, 29, 24, 0.22);
+  --ba-hover: rgba(31, 29, 24, 0.04);
+  --ba-accent: var(--rf-accent, #6c8cff);
+  --ba-serif: var(--rf-serif, "New York", "Hoefler Text", Charter, Georgia, serif);
+  --ba-sans: var(--rf-sans, "SF Pro Text", "Helvetica Neue", system-ui, sans-serif);
+}
+
+@media (prefers-color-scheme: dark) {
+  html[data-ba-editor="add"]:not([data-rf-theme="light"]) {
+    --ba-paper: #0b0c0f;
+    --ba-panel: #15171c;
+    --ba-field: #f6f3ec;
+    --ba-ink: #eceae2;
+    --ba-ink-dim: #9b978a;
+    --ba-ink-faint: #5d5a51;
+    --ba-line: rgba(236, 234, 226, 0.10);
+    --ba-line-strong: rgba(236, 234, 226, 0.20);
+    --ba-hover: rgba(236, 234, 226, 0.05);
+  }
+}
+html[data-ba-editor="add"][data-rf-theme="dark"] {
+  --ba-paper: #0b0c0f;
+  --ba-panel: #15171c;
+  /* The field input keeps a paper-light background even in dark mode so
+     the card content renders the same as it will on the review screen
+     (where the note type stylesheet sets a dark-on-light look by default).
+     This is consistent with native Anki's add-card field behavior. */
+  --ba-field: #f6f3ec;
+  --ba-ink: #eceae2;
+  --ba-ink-dim: #9b978a;
+  --ba-ink-faint: #5d5a51;
+  --ba-line: rgba(236, 234, 226, 0.10);
+  --ba-line-strong: rgba(236, 234, 226, 0.20);
+  --ba-hover: rgba(236, 234, 226, 0.05);
+}
+
+html[data-ba-editor="add"], html[data-ba-editor="add"] body {
+  background: var(--ba-paper) !important;
+  color: var(--ba-ink) !important;
+  font-family: var(--ba-sans) !important;
+}
+
+/* --- The note editor frame --- */
+html[data-ba-editor="add"] .note-editor {
+  background: var(--ba-paper) !important;
+  color: var(--ba-ink) !important;
+}
+/* The mathjax & image overlays are positioned inside the fields scroll
+   area but have no business taking layout space when empty. */
+html[data-ba-editor="add"] .mathjax-overlay:empty,
+html[data-ba-editor="add"] .image-overlay:empty {
+  display: none !important;
+}
+
+/* --- Top format toolbar --- */
+html[data-ba-editor="add"] .editor-toolbar {
+  background: var(--ba-panel) !important;
+  border-bottom: 1px solid var(--ba-line) !important;
+  padding: 8px 22px !important;
+  box-shadow: none !important;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar {
+  gap: 2px !important;
+  /* Anki gates the toolbar wrap via this CSS var, not by flex-wrap. */
+  --buttons-size: 1.55rem !important;
+  --buttons-wrap: nowrap !important;
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  padding-right: 8px;
+  scrollbar-width: none; /* Firefox */
+  align-items: center !important;
+}
+/* Move the gear/options group to the very end of the toolbar — it's a
+   "more" menu, not a formatting tool, and looked orphaned between the
+   notetype links and B/I/U. The .item lives inside .dynamically-slottable,
+   which IS a flex container, so the order applies there. */
+html[data-ba-editor="add"] .dynamically-slottable {
+  display: flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+}
+html[data-ba-editor="add"] .item#settings {
+  order: 99 !important;
+  margin-left: 6px !important;
+}
+html[data-ba-editor="add"] .item#notetype {
+  order: -1 !important;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar {
+  height: 0 !important;
+  display: none !important;
+}
+html[data-ba-editor="add"] .editor-toolbar {
+  overflow: hidden !important;
+}
+/* Kill the boxy borders/radii Bootstrap stamps onto every button-group and
+   button-group-item — we want a clean horizontal row of pill icons. */
+html[data-ba-editor="add"] .button-group,
+html[data-ba-editor="add"] .button-group.btn-group,
+html[data-ba-editor="add"] .button-group-item,
+html[data-ba-editor="add"] .dynamically-slottable {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 8px !important;
+  padding: 0 !important;
+  gap: 2px !important;
+  box-shadow: none !important;
+}
+/* Vertical divider between adjacent toolbar groups. */
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar > .item + .item {
+  position: relative;
+  padding-left: 12px !important;
+  margin-left: 0 !important;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar > .item + .item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 1px;
+  background: var(--ba-line);
+}
+html[data-ba-editor="add"] .icon-button,
+html[data-ba-editor="add"] .label-button {
+  color: var(--ba-ink-dim) !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 7px !important;
+  font-family: var(--ba-sans) !important;
+  font-size: 10.5pt !important;
+  padding: 5px 7px !important;
+  min-width: 0 !important;
+  flex-shrink: 0 !important;
+  transition: background 120ms ease, color 120ms ease;
+  box-shadow: none !important;
+}
+html[data-ba-editor="add"] .icon-button:hover,
+html[data-ba-editor="add"] .label-button:hover {
+  background: var(--ba-hover) !important;
+  color: var(--ba-ink) !important;
+}
+html[data-ba-editor="add"] .icon-button[aria-pressed="true"],
+html[data-ba-editor="add"] .icon-button.active {
+  background: color-mix(in srgb, var(--ba-accent) 14%, transparent) !important;
+  color: var(--ba-accent) !important;
+}
+html[data-ba-editor="add"] .icon-button svg,
+html[data-ba-editor="add"] .label-button svg {
+  fill: currentColor !important;
+  width: 18px !important;
+  height: 18px !important;
+}
+/* "Fields..." / "Cards..." should read as quiet meta links, not buttons. */
+html[data-ba-editor="add"] #notetype .label-button {
+  font-style: italic !important;
+  font-family: var(--ba-serif) !important;
+  color: var(--ba-ink-faint) !important;
+  font-size: 10.5pt !important;
+  padding: 6px 8px !important;
+}
+html[data-ba-editor="add"] #notetype .label-button:hover {
+  color: var(--ba-ink) !important;
+  background: var(--ba-hover) !important;
+}
+
+/* --- Fields list --- */
+html[data-ba-editor="add"] .fields {
+  background: var(--ba-paper) !important;
+  padding: 14px 24px 2px 24px !important;
+}
+html[data-ba-editor="add"] .field-container {
+  background: transparent !important;
+  border: 0 !important;
+  margin-bottom: 2px !important;
+  padding: 0 !important;
+}
+/* Highlight the focused field — the one the next keystroke writes to. */
+html[data-ba-editor="add"] .field-container:focus-within .label-name {
+  color: var(--ba-accent) !important;
+}
+
+/* Field label row — touch only what we need. */
+html[data-ba-editor="add"] .label-container .label-name {
+  font-family: var(--ba-sans) !important;
+  font-size: 9pt !important;
+  font-weight: 700 !important;
+  letter-spacing: 1.4px !important;
+  text-transform: uppercase !important;
+  color: var(--ba-ink-faint) !important;
+}
+html[data-ba-editor="add"] .field-container:focus-within .label-name {
+  color: var(--ba-accent) !important;
+}
+
+/* Hide just the chevron badge — the .collapse-label wraps the label NAME
+   so we mustn't display:none it. */
+html[data-ba-editor="add"] .collapse-badge {
+  display: none !important;
+}
+
+/* Field state icons (sticky pin, HTML edit, plain-text badge):
+   reveal only on hover so the field row stays calm at rest. The Svelte
+   templates also stamp them in by default for focused fields — we override
+   that so they're consistent. */
+html[data-ba-editor="add"] .field-state {
+  opacity: 0;
+  transition: opacity 180ms ease;
+  pointer-events: none;
+}
+html[data-ba-editor="add"] .field-container:hover .field-state {
+  opacity: 0.6;
+  pointer-events: auto;
+}
+html[data-ba-editor="add"] .field-container:hover .field-state:hover,
+html[data-ba-editor="add"] .field-state:focus-within {
+  opacity: 1;
+}
+html[data-ba-editor="add"] .field-state svg,
+html[data-ba-editor="add"] .field-state .badge svg {
+  width: 12px !important;
+  height: 12px !important;
+  fill: var(--ba-ink-faint) !important;
+}
+html[data-ba-editor="add"] .field-state .badge {
+  background: transparent !important;
+  border: 0 !important;
+  padding: 4px !important;
+}
+html[data-ba-editor="add"] .field-state .badge:hover {
+  background: var(--ba-hover) !important;
+  border-radius: 6px !important;
+}
+
+/* The actual editable box. Override both the outer .editing-area and the
+   inner .rich-text-input — Anki's editor.css sets backgrounds on both, and
+   without overriding the inner one the dark-mode bg shows through. */
+html[data-ba-editor="add"] .editing-area,
+html[data-ba-editor="add"] .editing-area .rich-text-input,
+html[data-ba-editor="add"] .editing-area .plain-text-input {
+  background: var(--ba-field) !important;
+  color: #1f1d18 !important; /* readable on the cream/white field bg */
+  border-radius: 10px !important;
+}
+html[data-ba-editor="add"] .editing-area {
+  border: 1px solid var(--ba-line) !important;
+  padding: 0 !important;
+  transition: border-color 160ms ease, box-shadow 160ms ease,
+              background 160ms ease;
+  overflow: hidden;  /* clip the inner bg to the rounded corners */
+}
+html[data-ba-editor="add"] .editing-area:focus-within {
+  border-color: var(--ba-accent) !important;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ba-accent) 16%, transparent) !important;
+}
+html[data-ba-editor="add"] .rich-text-editable,
+html[data-ba-editor="add"] .plain-text-input {
+  padding: 8px 14px !important;
+  min-height: 22px !important;
+  font-family: var(--ba-serif) !important;
+  font-size: 13pt !important;
+  line-height: 1.5 !important;
+  color: #1f1d18 !important; /* always-dark text on the cream field bg */
+  background: transparent !important;
+  border: 0 !important;
+  outline: none !important;
+}
+/* Placeholder text in empty fields. Svelte tags rich-text-editable with
+   `.empty` when the contenteditable has no content. */
+html[data-ba-editor="add"] .rich-text-editable.empty::before {
+  font-family: var(--ba-sans) !important;
+  font-style: normal !important;
+  font-size: 11.5pt !important;
+  color: var(--ba-ink-faint) !important;
+  opacity: 0.85;
+  pointer-events: none;
+}
+html[data-ba-editor="add"] .field-container[data-index="0"] .rich-text-editable.empty::before {
+  content: "Front of the card";
+}
+html[data-ba-editor="add"] .field-container[data-index="1"] .rich-text-editable.empty::before {
+  content: "Back of the card";
+}
+html[data-ba-editor="add"] .field-container:not([data-index="0"]):not([data-index="1"]) .rich-text-editable.empty::before {
+  content: "Optional";
+}
+/* Cursor-friendly tone for the first/required field. */
+html[data-ba-editor="add"] .field-container:first-of-type .editing-area {
+  background: var(--ba-field) !important;
+}
+
+/* --- Tags --- *
+ * The Tags section is NOT inside .fields. It's a top-level .collapse-label
+ * (header text "Tags") followed by a .collapsible wrapping a .tag-editor.
+ * We distinguish the tags' collapse-label from the field collapse-labels by
+ * title="Collapse" (vs "Collapse field" for the fields). */
+html[data-ba-editor="add"] .collapse-label[title="Collapse"] {
+  display: block !important;
+  padding: 14px 24px 6px 24px !important;
+  margin-top: 12px !important;
+  font-family: var(--ba-sans) !important;
+  font-size: 9pt !important;
+  font-weight: 700 !important;
+  letter-spacing: 1.4px !important;
+  text-transform: uppercase !important;
+  color: var(--ba-ink-faint) !important;
+  border-top: 1px solid var(--ba-line) !important;
+  background: var(--ba-paper) !important;
+}
+/* The tag input itself */
+html[data-ba-editor="add"] .tag-editor {
+  background: var(--ba-paper) !important;
+  padding: 4px 24px 14px 24px !important;
+}
+html[data-ba-editor="add"] .tag-add-button,
+html[data-ba-editor="add"] .tag-options-button {
+  color: var(--ba-ink-faint) !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 6px !important;
+  padding: 4px !important;
+}
+html[data-ba-editor="add"] .tag-add-button:hover,
+html[data-ba-editor="add"] .tag-options-button:hover {
+  background: var(--ba-hover) !important;
+  color: var(--ba-ink) !important;
+}
+html[data-ba-editor="add"] .tag-add-button svg,
+html[data-ba-editor="add"] .tag-options-button svg {
+  width: 16px !important;
+  height: 16px !important;
+}
+html[data-ba-editor="add"] .tag-spacer {
+  padding: 6px 8px !important;
+  color: var(--ba-ink) !important;
+  font-family: var(--ba-sans) !important;
+  position: relative;
+  flex: 1;
+}
+/* Placeholder hint when no tags. .tag-spacer is a contenteditable that
+   contains a single <br> by default; using ::after on the parent puts the
+   placeholder visually inside the area. The tag-editor adds children when
+   tags are present, so we hide the placeholder when there's more than one. */
+html[data-ba-editor="add"] .tag-editor:not(:focus-within)::after {
+  content: "Add tags";
+  position: absolute;
+  left: 70px;  /* clear of the .tag-add-button icons */
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ba-ink-faint) !important;
+  font-family: var(--ba-sans);
+  font-size: 11pt;
+  pointer-events: none;
+}
+html[data-ba-editor="add"] .tag-editor {
+  position: relative;
+}
+/* If there are any tag badges, hide the placeholder. */
+html[data-ba-editor="add"] .tag-editor:has(.tag) {
+  /* support browsers without :has — but most modern WebEngine supports it */
+}
+html[data-ba-editor="add"] .tag-editor:has(.tag)::after {
+  display: none !important;
+}
+
+/* CodeMirror (plain-text mode) */
+html[data-ba-editor="add"] .code-mirror,
+html[data-ba-editor="add"] .CodeMirror {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace !important;
+  font-size: 11.5pt !important;
+  background: var(--ba-field) !important;
+  color: var(--ba-ink) !important;
+}
+
+/* Scrollbars inside the webview */
+html[data-ba-editor="add"] ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+html[data-ba-editor="add"] ::-webkit-scrollbar-thumb {
+  background: var(--ba-line-strong);
+  border-radius: 5px;
+}
+html[data-ba-editor="add"] ::-webkit-scrollbar-thumb:hover {
+  background: var(--ba-ink-faint);
+}
+html[data-ba-editor="add"] ::-webkit-scrollbar-track {
+  background: transparent;
+}

--- a/web/addcard.js
+++ b/web/addcard.js
@@ -1,0 +1,45 @@
+// BetterAnki — Add Card editor webview script.
+//
+// Tags <html> so addcard.css can scope its overrides to the editor when it's
+// being shown in the AddCards window (not Browser, not Edit-Current). Anki's
+// CSP blocks inline scripts on the editor page, so this work happens in a
+// loaded JS file rather than a <script> in the page head.
+//
+// Also moves the gear/options button to the end of the toolbar (visual
+// order). CSS `order:` should do this but Anki's Svelte adds extra wrappers
+// that defeat the flex-order on some builds; a one-shot DOM reorder is
+// reliable and runs once on first paint plus once after Anki's async
+// editor ready.
+(function () {
+  "use strict";
+  try {
+    document.documentElement.dataset.baEditor = "add";
+    var theme = document.querySelector('meta[name="ba-theme"]');
+    if (theme && theme.content) {
+      document.documentElement.dataset.rfTheme = theme.content;
+    }
+  } catch (_) {}
+
+  function reorderToolbar() {
+    var toolbar = document.querySelector(".button-toolbar.btn-toolbar");
+    var settings = document.getElementById("settings");
+    if (!toolbar || !settings) return false;
+    // Walk up to find the closest sibling-set container.
+    var parent = settings.parentElement;
+    if (!parent) return false;
+    // Move to last position in its parent (the dynamically-slottable wrapper).
+    if (parent.lastElementChild !== settings) {
+      parent.appendChild(settings);
+    }
+    return true;
+  }
+
+  // Try immediately, then a few delayed tries to catch the async editor
+  // ready.
+  reorderToolbar();
+  var attempts = 0;
+  var iv = setInterval(function () {
+    attempts += 1;
+    if (reorderToolbar() || attempts > 30) clearInterval(iv);
+  }, 200);
+})();


### PR DESCRIPTION
## Summary

- Replaces the legacy Anki Add Cards QMainWindow with an editorial Qt+CSS chrome scoped to `EditorMode.ADD_CARDS` only (Browser & Edit-Current untouched), keeping every native handler, shortcut, and `add_cards_did_*` hook alive by hiding the stock `buttonBox` and proxying clicks.
- Note type / deck pickers no longer open the `StudyDeck` popup — clicking "Basic" or "Anki" in the inline "New ▾ card in ▾" sentence drops a local `QMenu` with all types/decks (current bold, "Manage…" / "New deck…" entries) anchored under the link.
- Add Card opens embedded in the main window as a tab: an overlay frame reparents the redressed central widget over `mw.form.centralwidget` offset by the 250-px sidebar, the BetterAnki sidebar stays visible with "Add" marked active via the existing `__baSetActive` bridge, and Esc / Decks / window resize all tear down or reposition cleanly.
- Fields use a single border painted on `.editor-field` (every inner wrapper stripped) to avoid the double-ring focus state; labels switched from italic-serif to small-caps sans for readability; tags rebuilt as a clean single-line input with chips; toolbar `overflow:visible` so the gear's Popper dropdown actually renders.
- Add card button redesigned: compact dark ink (border-radius 8, not 22-px pill), no hover chip — `⌘↩` shortcut lives in a small dim sans label to the left of the button.

## Test plan

- [ ] Open Add Card from the BetterAnki sidebar — embed appears in place of the deck browser, sidebar still visible with "Add" highlighted.
- [ ] Click "Basic" / "Anki" in the inline sentence — local dropdown opens; picking changes the value; "Manage…" / "New deck…" still work.
- [ ] Type into the fields, hit `⌘↩` — note adds, "Recent ▾" populates with the entry and opens at the visible button (not the hidden native one).
- [ ] Toggle the gear menu — dropdown renders above the toolbar (no clipping).
- [ ] Switch to dark theme — fields remain readable (cream input bg, ink text).
- [ ] Press Esc / click Decks in sidebar — overlay tears down, deck browser restored, "Decks" active again.
- [ ] Cmd+Shift+A still opens the legacy windowed AddCards (not routed through the embed; documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)