### PR TITLE
Reviewer rebuild: anchored card, header chrome, minimal ease selector

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,6 +38,17 @@ try:
     from aqt.toolbar import BottomToolbar as _BottomCtx
 except Exception:
     _BottomCtx = None
+# The reviewer's bottom strip ships as a separate context — `ReviewerBottomBar`,
+# NOT the generic `BottomToolbar` used elsewhere (e.g., deck-browser bottom).
+# We need both so theme + reviewer-bottom.css both apply.
+try:
+    from aqt.reviewer import ReviewerBottomBar as _ReviewerBottomCtx
+except Exception:
+    _ReviewerBottomCtx = None
+try:
+    from aqt.deckbrowser import DeckBrowserBottomBar as _DeckBrowserBottomCtx
+except Exception:
+    _DeckBrowserBottomCtx = None
 try:
     from aqt.qt import QTimer
 except Exception:
@@ -66,6 +77,8 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         isinstance(context, (DeckBrowser, Overview, Reviewer))
         or _is(context, _ToolbarCtx)
         or _is(context, _BottomCtx)
+        or _is(context, _ReviewerBottomCtx)
+        or _is(context, _DeckBrowserBottomCtx)
     )
     if not themed:
         return
@@ -153,21 +166,28 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
             '<button class="ba-cog" onclick="pycmd(\'ba:settings\')" '
             'title="BetterAnki settings">⚙</button>' + web_content.body
         )
-    # Reviewer: no sidebar, but the user needs a way back to the deck list.
-    # A small floating "← Decks" link top-left, plus a subtle settings cog
-    # (so they can still tweak from inside a session if they really need to).
-    if isinstance(context, Reviewer):
-        web_content.css.append(f"{WEB}/sidebar.css")  # for .ba-back / .ba-cog
-        web_content.body = (
-            '<button class="ba-back" onclick="pycmd(\'ba:decks\')" '
-            'title="Back to decks (Esc)">Decks</button>'
-            + web_content.body
-        )
+    # Reviewer header — deck name (with built-in back link) on the left,
+    # position counter on the right. Replaces the floating "Decks" button.
+    # We also append the ease selector so we can drop the bottom-toolbar
+    # webview entirely. Idempotent: if the previous webview content
+    # already has our header/ease (e.g., Anki recycles the body for the
+    # answer-state render), we skip to avoid stacking duplicates.
+    if isinstance(context, Reviewer) and "ba-rv-head" not in web_content.body:
+        try:
+            head_html = _reviewer_header_html()
+        except Exception:
+            head_html = ""
+        try:
+            ease_html = _reviewer_ease_html()
+        except Exception:
+            ease_html = ""
+        web_content.body = head_html + web_content.body + ease_html
     if _is(context, _ToolbarCtx):
         web_content.css.append(f"{WEB}/toolbar.css")
     # Reviewer's bottom bar (Show Answer, Edit, More, answer buttons) lives
-    # in BottomToolbar — restyle it so it doesn't look like 2003 Anki.
-    if _is(context, _BottomCtx):
+    # in `ReviewerBottomBar` — NOT the generic BottomToolbar (that's the
+    # deck-browser/overview strip we hide). Style only the reviewer bottom.
+    if _is(context, _ReviewerBottomCtx):
         web_content.css.append(f"{WEB}/reviewer-bottom.css")
     # reviewer.css always loads on the reviewer — it owns the back button,
     # answer divider, card chrome, AND the progress strip styling. Gating it
@@ -456,8 +476,12 @@ def on_state_did_change(new_state: str, old_state: str) -> None:
         _set_bottom_visible(not hide_decks)
     elif new_state == "overview":
         _set_bottom_visible(not hide_over)
+    elif new_state == "review":
+        # We render our own ease selector inside the reviewer webview; the
+        # native bottom toolbar is just chrome we don't need.
+        _set_bottom_visible(False)
     else:
-        _set_bottom_visible(True)  # always keep reviewer answer buttons
+        _set_bottom_visible(True)
     _update_title()
     _mark_toolbar_state(new_state)
     _apply_chrome()
@@ -548,6 +572,30 @@ def _on_js_message(handled, message, context):
             mw.on_sync_button_clicked()
         elif cmd == "settings":
             _open_settings()
+        elif cmd == "undo":
+            try:
+                mw.undo()
+            except Exception:
+                return handled
+        elif cmd == "flag-cycle":
+            # Cycle the current card's flag 0 → 1 → 2 → 3 → 4 → 0.
+            try:
+                rv = getattr(mw, "reviewer", None)
+                if rv is None or getattr(rv, "card", None) is None:
+                    return handled
+                card = rv.card
+                cur = int(card.user_flag())
+                nxt = (cur + 1) % 5  # 0..4
+                card.set_user_flag(nxt)
+                # The card needs to be saved so the flag persists; the
+                # reviewer's _showQuestion will re-pull on next render.
+                try:
+                    mw.col.update_card(card)
+                except Exception:
+                    pass
+                _push_progress()
+            except Exception:
+                return handled
         elif cmd == "create":
             _open_new_deck()
         elif cmd == "import":
@@ -602,17 +650,31 @@ def _open_new_deck() -> None:
 
 
 def _start_studying(did: int) -> None:
-    """Select a deck and go straight into the reviewer (one-click study from
-    the single-deck hero)."""
+    """Select a deck and go straight into the reviewer."""
     try:
+        _dev_cmd_log(f"start_studying: did={did}")
         mw.col.decks.select(did)
         try:
             mw.col.startTimebox()
         except Exception:
             pass
-        mw.moveToState("review")
-    except Exception:
-        # If anything goes wrong, fall back to opening the overview.
+        cur_state = getattr(mw, "state", "")
+        rv = getattr(mw, "reviewer", None)
+        if cur_state == "review" and rv is not None:
+            try:
+                rv._showQuestion()
+            except Exception:
+                pass
+        else:
+            mw.moveToState("review")
+        # Log final state for debugging.
+        try:
+            after = getattr(mw, "state", "")
+            _dev_cmd_log(f"start_studying done (state now={after})")
+        except Exception:
+            _dev_cmd_log("start_studying done")
+    except Exception as e:
+        _dev_cmd_log(f"start_studying err: {e!r}")
         try:
             mw.moveToState("overview")
         except Exception:
@@ -876,6 +938,138 @@ def _remaining() -> int:
         return 0
 
 
+def _current_deck_name() -> str:
+    try:
+        did = mw.col.decks.get_current_id()
+        return mw.col.decks.name(did) or ""
+    except Exception:
+        try:
+            return mw.col.decks.current()["name"]
+        except Exception:
+            return ""
+
+
+def _reviewer_ease_html() -> str:
+    """Four interval chips that appear under the answer. Text only —
+    no numbers, no labels, no bar. They're hidden by CSS until the
+    answer is revealed. We render four slots even for shorter button
+    counts (Anki may show 2/3/4 buttons); JS hides extras."""
+    return (
+        '<div class="ba-rv-ease" aria-label="Rate this card" hidden>'
+        '<button class="ba-rv-ease-key ba-rv-ease-1" type="button"'
+        '        onclick="pycmd(\'ease1\')" data-ease="1">'
+        '<span class="ba-rv-ease-int" data-ease-slot="1"></span></button>'
+        '<button class="ba-rv-ease-key ba-rv-ease-2" type="button"'
+        '        onclick="pycmd(\'ease2\')" data-ease="2">'
+        '<span class="ba-rv-ease-int" data-ease-slot="2"></span></button>'
+        '<button class="ba-rv-ease-key ba-rv-ease-3" type="button"'
+        '        onclick="pycmd(\'ease3\')" data-ease="3">'
+        '<span class="ba-rv-ease-int" data-ease-slot="3"></span></button>'
+        '<button class="ba-rv-ease-key ba-rv-ease-4" type="button"'
+        '        onclick="pycmd(\'ease4\')" data-ease="4">'
+        '<span class="ba-rv-ease-int" data-ease-slot="4"></span></button>'
+        '</div>'
+    )
+
+
+def _current_card_type() -> str:
+    """A short label for the current card's note type (e.g., "Basic",
+    "Cloze"). Empty when no card. Trimmed to fit the header."""
+    try:
+        c = mw.reviewer.card
+        if c is None:
+            return ""
+        nt = c.note_type() or c.note().model()
+        name = (nt.get("name") or "") if isinstance(nt, dict) else getattr(nt, "name", "")
+        return str(name)
+    except Exception:
+        return ""
+
+
+def _reviewer_header_html() -> str:
+    """Header above the card: back chevron + deck name on the left, the
+    count breakdown + position on the right, and Edit + More icon buttons
+    next to them (Anki's More menu already covers flag/mark/undo)."""
+    name = html.escape(_current_deck_name() or "Studying")
+    rem = _remaining()
+    total = _session["total"] or rem or 1
+    done = max(0, total - rem)
+    pos = min(done + 1, total)
+    new_n = learn_n = rev_n = 0
+    try:
+        c = mw.col.sched.counts()
+        new_n, learn_n, rev_n = int(c[0]), int(c[1]), int(c[2])
+    except Exception:
+        pass
+    edit_svg = (
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" '
+        'xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+        '<path d="M12 20h9"/>'
+        '<path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z"/></svg>'
+    )
+    more_svg = (
+        '<svg viewBox="0 0 24 24" fill="currentColor" '
+        'xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+        '<circle cx="5" cy="12" r="1.6"/>'
+        '<circle cx="12" cy="12" r="1.6"/>'
+        '<circle cx="19" cy="12" r="1.6"/></svg>'
+    )
+    return f"""
+    <header class="ba-rv-head">
+      <div class="ba-rv-head-left">
+        <button class="ba-rv-back" type="button"
+                onclick="pycmd('ba:decks')"
+                title="Back to decks (Esc)"
+                aria-label="Back to decks">‹</button>
+        <span class="ba-rv-deck" title="{name}">{name}</span>
+      </div>
+      <div class="ba-rv-head-right">
+        <span class="ba-rv-counts">
+          <span class="ba-rv-count ba-rv-c-new"
+                title="New cards still to study"><b id="ba-rv-c-new">{new_n}</b><i>new</i></span>
+          <span class="ba-rv-count ba-rv-c-learn"
+                title="Cards in learning"><b id="ba-rv-c-learn">{learn_n}</b><i>learn</i></span>
+          <span class="ba-rv-count ba-rv-c-due"
+                title="Review cards due today"><b id="ba-rv-c-due">{rev_n}</b><i>due</i></span>
+        </span>
+        <span class="ba-rv-sep" aria-hidden="true"></span>
+        <span class="ba-rv-pos">
+          <b id="ba-rv-pos-now">{pos}</b>
+          <span>of</span>
+          <b id="ba-rv-pos-total">{total}</b>
+        </span>
+        <button class="ba-rv-icon-btn" type="button"
+                onclick="pycmd('edit')" title="Edit card (E)"
+                aria-label="Edit card">{edit_svg}</button>
+        <button class="ba-rv-icon-btn" type="button"
+                onclick="pycmd('more')" title="More options (M)"
+                aria-label="More options">{more_svg}</button>
+      </div>
+    </header>
+    """
+
+
+def _ease_intervals() -> Optional[Dict[int, str]]:
+    """Return {ease: interval_str} for the current card's next-state
+    intervals (e.g., {1: "<1m", 2: "<10m", 3: "6d", 4: "13d"}). Returns
+    None if anything goes wrong — caller hides the chips in that case."""
+    try:
+        rv = mw.reviewer
+        if rv is None or rv.card is None:
+            return None
+        labels = mw.col.sched.describe_next_states(rv._v3.states)
+        # `labels` order matches Anki's _answerButtonList: Again, [Hard,]
+        # Good, [Easy]. Map back to ease number via the button list.
+        buttons = rv._answerButtonList()
+        out: Dict[int, str] = {}
+        for (ease, _name), interval in zip(buttons, labels):
+            out[int(ease)] = str(interval)
+        return out
+    except Exception:
+        return None
+
+
 def _push_progress() -> None:
     if not _config().get("show_progress", True):
         return
@@ -885,9 +1079,31 @@ def _push_progress() -> None:
     total = _session["total"] or 1
     done = max(0, total - rem)
     pct = min(100, int(done * 100 / total))
+    pos = min(done + 1, total)
+    new_n = learn_n = rev_n = 0
+    try:
+        c = mw.col.sched.counts()
+        new_n, learn_n, rev_n = int(c[0]), int(c[1]), int(c[2])
+    except Exception:
+        pass
+    intervals = _ease_intervals() or {}
+    default_ease = 3
+    try:
+        default_ease = int(mw.reviewer._defaultEase())
+    except Exception:
+        pass
+    import json as _json
+    intervals_js = _json.dumps(intervals)
     try:
         mw.reviewer.web.eval(
             f"window.__reforgeProgress && window.__reforgeProgress({pct},{done},{rem});"
+            f"var $=function(id){{return document.getElementById(id);}};"
+            f"var n=$('ba-rv-pos-now'),t=$('ba-rv-pos-total');"
+            f"if(n)n.textContent={pos};if(t)t.textContent={total};"
+            f"var cn=$('ba-rv-c-new'),cl=$('ba-rv-c-learn'),cd=$('ba-rv-c-due');"
+            f"if(cn)cn.textContent={new_n};if(cl)cl.textContent={learn_n};"
+            f"if(cd)cd.textContent={rev_n};"
+            f"window.__baSetEase && window.__baSetEase({intervals_js}, {default_ease});"
         )
     except Exception:
         pass
@@ -989,6 +1205,16 @@ gui_hooks.main_window_did_init.append(_add_tools_menu_action)
 # install the zip, no .devmode) never start the watcher thread.
 # --------------------------------------------------------------------------- #
 ADDON_SRC = os.path.dirname(os.path.abspath(__file__))
+# Dev: a heartbeat file so we can verify the addon module imported (and at
+# what time) without scraping stdout. Truncate-on-import so each Anki start
+# produces a fresh entry.
+try:
+    _ctx = os.path.join(ADDON_SRC, ".context")
+    if os.path.isdir(_ctx):
+        with open(os.path.join(_ctx, "addon.log"), "w") as _fh:
+            _fh.write(f"imported {time.time():.0f}\n")
+except Exception:
+    pass
 
 _dev_stop = threading.Event()
 _dev_thread: Optional[threading.Thread] = None
@@ -1098,6 +1324,284 @@ def _dev_shutdown() -> None:
     _dev_stop.set()
 
 
+# Dev-only side channel: write a single line to .context/cmd to drive the UI
+# from outside the GUI process (used by the screenshot/iteration workflow).
+# Commands:
+#   review:<did>      - enter review mode for that deck id
+#   decks             - return to deck list
+#   overview:<did>    - select deck and open overview
+#   show              - flip the current card (Show Answer)
+#   ease:<1..4>       - rate the current card
+#   eval:<js>         - run JS in the reviewer webview (debug)
+_dev_cmd_seen_mtime = {"v": 0.0}
+
+
+def _dev_run_cmd(raw: str) -> None:
+    try:
+        cmd = raw.strip()
+        if not cmd:
+            return
+        state = getattr(mw, "state", "")
+        _dev_cmd_log(f"run: {cmd!r} (state={state})")
+        if cmd.startswith("review:"):
+            _start_studying(int(cmd.split(":", 1)[1]))
+        elif cmd == "decks":
+            mw.moveToState("deckBrowser")
+        elif cmd.startswith("overview:"):
+            did = int(cmd.split(":", 1)[1])
+            mw.col.decks.select(did)
+            mw.moveToState("overview")
+        elif cmd == "show":
+            # Only valid when actively reviewing a card.
+            if state != "review":
+                _dev_cmd_log("show: not in review, ignored")
+                return
+            rv = getattr(mw, "reviewer", None)
+            card = getattr(rv, "card", None) if rv else None
+            if rv and card and getattr(rv, "state", "") == "question":
+                try:
+                    rv._showAnswer()
+                except Exception as e:
+                    _dev_cmd_log(f"show err: {e!r}")
+                    if rv.web:
+                        rv.web.eval("pycmd('ans')")
+        elif cmd.startswith("ease:"):
+            if state != "review":
+                _dev_cmd_log("ease: not in review, ignored")
+                return
+            n = int(cmd.split(":", 1)[1])
+            rv = getattr(mw, "reviewer", None)
+            rv_state = getattr(rv, "state", "") if rv else ""
+            _dev_cmd_log(f"ease: rv.state={rv_state}")
+            if rv and getattr(rv, "card", None) and rv_state == "answer":
+                rv._answerCard(n)
+                _dev_cmd_log("ease: _answerCard ok")
+        elif cmd.startswith("eval:"):
+            js = cmd[5:]
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                rv.web.eval(js)
+            elif getattr(mw, "web", None):
+                mw.web.eval(js)
+        elif cmd.startswith("beval:"):
+            # Eval JS in the reviewer's bottom toolbar webview.
+            js = cmd[6:]
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "bottom", None) and getattr(rv.bottom, "web", None):
+                rv.bottom.web.eval(js)
+        elif cmd.startswith("state_info"):
+            try:
+                st = getattr(mw, "state", "")
+                rv = getattr(mw, "reviewer", None)
+                rvs = getattr(rv, "state", "") if rv else "no-rv"
+                card = getattr(rv, "card", None) if rv else None
+                cardid = card.id if card else "no-card"
+                web = getattr(mw, "web", None)
+                _dev_cmd_log(
+                    f"state={st} rv.state={rvs} card={cardid} "
+                    f"web={web!r} bottomWeb={getattr(mw, 'bottomWeb', None)!r}"
+                )
+                if web:
+                    _dev_cmd_log(
+                        f"web visible={web.isVisible()} size={web.size().width()}x{web.size().height()}"
+                    )
+                bw = getattr(mw, "bottomWeb", None)
+                if bw:
+                    _dev_cmd_log(
+                        f"bottomWeb visible={bw.isVisible()} size={bw.size().width()}x{bw.size().height()}"
+                    )
+            except Exception as e:
+                _dev_cmd_log(f"state_info err: {e!r}")
+        elif cmd.startswith("dump_ease_main"):
+            out = os.path.join(ADDON_SRC, ".context", "ease_main.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "var btns=document.querySelectorAll('.ba-rv-ease-key');"
+                    "var out=[];"
+                    "btns.forEach(function(b){"
+                    "var cs=getComputedStyle(b);"
+                    "var ca=getComputedStyle(b,'::after');"
+                    "var cb=getComputedStyle(b,'::before');"
+                    "out.push({text:b.textContent.trim(),"
+                    "td:cs.textDecoration,tdl:cs.textDecorationLine,"
+                    "outline:cs.outline,bs:cs.boxShadow,bb:cs.borderBottom,"
+                    "after:{content:ca.content,bs:ca.boxShadow,bb:ca.borderBottom},"
+                    "before:{content:cb.content,bs:cb.boxShadow}"
+                    "});});"
+                    "return JSON.stringify(out);})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("dump_ease"):
+            out = os.path.join(ADDON_SRC, ".context", "ease.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "bottom", None) and getattr(rv.bottom, "web", None):
+                js = (
+                    "(function(){"
+                    "var btns=document.querySelectorAll('#middle button');"
+                    "var out=[];"
+                    "btns.forEach(function(b){"
+                    "var bb=b.getBoundingClientRect();"
+                    "var bcs=getComputedStyle(b,'::before');"
+                    "out.push({"
+                    "btn:{rect:[bb.x,bb.y,bb.width,bb.height]},"
+                    "before:{content:bcs.content,fs:bcs.fontSize,"
+                    "w:bcs.width,h:bcs.height,bg:bcs.backgroundColor}"
+                    "});});"
+                    "return JSON.stringify(out);})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.bottom.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("dump_bottom_compute"):
+            out = os.path.join(ADDON_SRC, ".context", "bottom_compute.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "bottom", None) and getattr(rv.bottom, "web", None):
+                js = (
+                    "(function(){"
+                    "var b=document.body,h=document.documentElement;"
+                    "var cs=function(el){return el?getComputedStyle(el):null;};"
+                    "return JSON.stringify({"
+                    "html:{theme:h.dataset.rfTheme,cls:h.className,"
+                    "rfpaper:getComputedStyle(h).getPropertyValue('--rf-paper').trim()},"
+                    "body:{bg:cs(b).backgroundColor,fg:cs(b).color}});"
+                    "})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.bottom.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("dump_compute"):
+            out = os.path.join(ADDON_SRC, ".context", "compute.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "var b=document.body,q=document.getElementById('qa');"
+                    "var cs=function(el){return el?getComputedStyle(el):null;};"
+                    "return JSON.stringify({"
+                    "body:{fs:cs(b).fontSize,ff:cs(b).fontFamily},"
+                    "qa:{fs:cs(q).fontSize,ff:cs(q).fontFamily}"
+                    "});})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("dump_card"):
+            out = os.path.join(ADDON_SRC, ".context", "card.html")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "JSON.stringify({"
+                    "html: document.documentElement.outerHTML,"
+                    "card: (document.querySelector('.card')||document.body).outerHTML"
+                    "})"
+                )
+                def _cb(result, _path=out):
+                    try:
+                        with open(_path, "w") as fh:
+                            fh.write(str(result))
+                    except Exception:
+                        pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("dump_bottom"):
+            # Print the bottom bar's outerHTML to stdout (via a tempfile).
+            import json as _json
+            out = os.path.join(ADDON_SRC, ".context", "bottom.html")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "bottom", None) and getattr(rv.bottom, "web", None):
+                js = (
+                    "(function(){var x={html:document.documentElement.outerHTML,"
+                    "links:Array.from(document.querySelectorAll('link')).map(l=>l.href)};"
+                    "var b=document.querySelector('button');"
+                    "if(b){var cs=getComputedStyle(b);"
+                    "x.btn={border:cs.border,bg:cs.backgroundColor,br:cs.borderRadius,"
+                    "appearance:cs.appearance,wkApp:cs.webkitAppearance};}"
+                    "return JSON.stringify(x);})()"
+                )
+                def _cb(result, _path=out):
+                    try:
+                        with open(_path, "w") as fh:
+                            fh.write(str(result))
+                    except Exception:
+                        pass
+                rv.bottom.web.evalWithCallback(js, _cb)
+    except Exception as e:
+        try:
+            print("[ba-dev-cmd]", repr(e))
+        except Exception:
+            pass
+
+
+def _dev_cmd_log(msg: str) -> None:
+    try:
+        with open(os.path.join(ADDON_SRC, ".context", "addon.log"), "a") as fh:
+            fh.write(f"[{time.strftime('%H:%M:%S')}] {msg}\n")
+    except Exception:
+        pass
+
+
+def _dev_cmd_watch() -> None:
+    cmd_file = os.path.join(ADDON_SRC, ".context", "cmd")
+    _dev_cmd_log("dev_cmd_watch started")
+    while not _dev_stop.is_set() and _dev_active():
+        try:
+            if os.path.exists(cmd_file):
+                mtime = os.path.getmtime(cmd_file)
+                if mtime != _dev_cmd_seen_mtime["v"]:
+                    _dev_cmd_seen_mtime["v"] = mtime
+                    try:
+                        with open(cmd_file, "r") as fh:
+                            data = fh.read()
+                    except Exception as e:
+                        _dev_cmd_log(f"read err: {e!r}")
+                        data = ""
+                    for line in data.splitlines():
+                        if line.strip():
+                            _dev_cmd_log(f"cmd: {line!r}")
+                            try:
+                                mw.taskman.run_on_main(
+                                    lambda l=line: _dev_run_cmd(l)
+                                )
+                            except Exception as e:
+                                _dev_cmd_log(f"dispatch err: {e!r}")
+        except Exception as e:
+            _dev_cmd_log(f"loop err: {e!r}")
+        _dev_stop.wait(0.2)
+    _dev_cmd_log("dev_cmd_watch exited")
+
+
+_dev_cmd_started = {"v": False}
+
+
+def _dev_cmd_start() -> None:
+    if not _dev_active():
+        return
+    if _dev_cmd_started["v"]:
+        return
+    _dev_cmd_started["v"] = True
+    # Drain any stale cmd file from a prior session so we don't auto-fire
+    # a command (like `show`) against the homepage state on startup.
+    try:
+        stale = os.path.join(ADDON_SRC, ".context", "cmd")
+        if os.path.exists(stale):
+            _dev_cmd_seen_mtime["v"] = os.path.getmtime(stale)
+    except Exception:
+        pass
+    t = threading.Thread(
+        target=_dev_cmd_watch, name="betteranki-dev-cmd", daemon=True
+    )
+    t.start()
+
+
 gui_hooks.profile_did_open.append(_dev_start)
+gui_hooks.profile_did_open.append(_dev_cmd_start)
 gui_hooks.main_window_did_init.append(_dev_start)
+gui_hooks.main_window_did_init.append(_dev_cmd_start)
 gui_hooks.profile_will_close.append(_dev_shutdown)

--- a/web/reviewer-bottom.css
+++ b/web/reviewer-bottom.css
@@ -7,41 +7,70 @@
            <td.stat>      <button>Edit</button>            ← E
            <td#middle>    {show-answer | ease buttons}
            <td.stat>      <button>More ▾<span#time></span></button>  ← M
-   show-answer state injects in #middle:
-     <table><tr><td.stat2><button#ansbut>Show Answer <span.stattxt>{counts}</span></button>
-   ease state injects 2–4 plain <button>s in #middle (one is #defease).
 
-   This stylesheet strips ALL button chrome. The bottom bar reads as quiet
-   typography — a letterspaced "press SPACE" cue for show-answer, and four
-   stat-columns (KEY · LABEL · INTERVAL) for the ease state, matching the
-   numerics language of the homepage hero. */
+   Question state injects in #middle:
+     <table><tr><td.stat2>
+       <button#ansbut>Show Answer <span.stattxt>{counts}</span></button>
+
+   Answer state injects 2–4 plain <button>s in #middle (one is #defease).
+     Anki's templates put the interval inside a child `<small>` (or empty
+     if the deck shows seconds), and the label as the button's textContent.
+
+   We rebuild this surface from scratch as a 3-column flex row:
+       [edit-cluster]   [primary-cluster]   [more-cluster]
+   In the primary cluster:
+     - question: a big "Show Answer" CTA with a keyboard hint chip
+     - answer  : a row of 4 ease "keys" (large key + label + interval),
+                 each color-coded; "Good" is highlighted as default.
+
+   We never touch card content; this is bottom-bar webview only. */
 
 :root {
+  --rf-paper: #f6f3ec;
+  --rf-paper-2: #ece8de;
+  --rf-ink: #1f1d18;
+  --rf-ink-dim: #6a6557;
+  --rf-ink-faint: #a39d8b;
+  --rf-line: rgba(31, 29, 24, 0.10);
+  --rf-line-2: rgba(31, 29, 24, 0.22);
+  --rf-row-hover: rgba(31, 29, 24, 0.05);
+  --rf-accent: #6c8cff;
+  --rf-again: #c95a4b;
+  --rf-hard:  #c69142;
+  --rf-good:  #4a8f6b;
+  --rf-easy:  #3f7fb2;
+  --rf-sans: ui-sans-serif, -apple-system, "SF Pro Text", system-ui, sans-serif;
+  --rf-serif: ui-serif, "New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif;
+}
+:root[data-rf-theme="dark"],
+:root.night-mode {
   --rf-paper: #0b0c0f;
+  --rf-paper-2: #131418;
   --rf-ink: #eceae2;
   --rf-ink-dim: #9b978a;
   --rf-ink-faint: #5d5a51;
   --rf-line: rgba(236, 234, 226, 0.10);
   --rf-line-2: rgba(236, 234, 226, 0.20);
   --rf-row-hover: rgba(236, 234, 226, 0.05);
-  --rf-due: #79b69b;
-  --rf-new: #8bb0e6;
-  --rf-learn: #d7a76c;
-  --rf-sans: ui-sans-serif, -apple-system, "SF Pro Text", system-ui, sans-serif;
-  --rf-serif: ui-serif, "New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif;
+  --rf-again: #e07466;
+  --rf-hard:  #d4a35d;
+  --rf-good:  #79b69b;
+  --rf-easy:  #6fa9d8;
 }
-@media (prefers-color-scheme: light) {
-  :root:not([data-rf-theme="dark"]) {
-    --rf-paper: #f6f3ec;
-    --rf-ink: #1f1d18;
-    --rf-ink-dim: #6a6557;
-    --rf-ink-faint: #a39d8b;
-    --rf-line: rgba(31, 29, 24, 0.10);
-    --rf-line-2: rgba(31, 29, 24, 0.22);
-    --rf-row-hover: rgba(31, 29, 24, 0.04);
-    --rf-due: #2f8462;
-    --rf-new: #2f5fb5;
-    --rf-learn: #a05f1e;
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) {
+    --rf-paper: #0b0c0f;
+    --rf-paper-2: #131418;
+    --rf-ink: #eceae2;
+    --rf-ink-dim: #9b978a;
+    --rf-ink-faint: #5d5a51;
+    --rf-line: rgba(236, 234, 226, 0.10);
+    --rf-line-2: rgba(236, 234, 226, 0.20);
+    --rf-row-hover: rgba(236, 234, 226, 0.05);
+    --rf-again: #e07466;
+    --rf-hard:  #d4a35d;
+    --rf-good:  #79b69b;
+    --rf-easy:  #6fa9d8;
   }
 }
 
@@ -53,49 +82,66 @@ html, body {
   padding: 0 !important;
 }
 
-/* Outer / table layout */
+/* Outer container — a slim row. The center carries either the keyboard
+   prompt (question state) or the ease shortcuts (answer state). Edit
+   and More are consolidated into one right-side cluster. */
 #outer {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
   width: 100%;
-  padding: 18px 26px 22px !important;
+  padding: 12px 22px 14px !important;
   box-sizing: border-box;
+  gap: 14px;
 }
-#innertable {
-  border: 0 !important;
-  background: transparent !important;
-  border-collapse: collapse !important;
-  border-spacing: 0 !important;
-  width: 100% !important;
+
+/* Anki gives us a single-row table — make it disappear into flex.
+   We want Edit and More side-by-side on the right (the user wants them
+   "next to each other"), so we reorder via flex order. */
+#innertable,
+#innertable tbody,
+#innertable tr {
+  display: contents !important;
 }
 #innertable td {
-  border: 0 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  vertical-align: middle !important;
   padding: 0 !important;
-  vertical-align: middle !important;
+  border: 0 !important;
 }
-#innertable td.stat {
-  width: 1%;
-  white-space: nowrap;
-  vertical-align: middle !important;
+/* Edit is the first .stat cell, More is the last. Place both on the
+   right side with Edit just before More. */
+#innertable td.stat:first-of-type { order: 3; }
+#innertable td.stat:last-of-type  { order: 4; }
+#middle { order: 2; flex: 1 1 auto; justify-content: center !important; }
+/* A spacer on the left mirrors the right cluster's width so the middle
+   stays optically centered. */
+#outer::before {
+  content: "";
+  order: 1;
+  flex: 0 0 96px;  /* roughly matches Edit + More width */
 }
-#middle {
-  text-align: center;
+/* The ease state nests `#middle > center > table > tbody > tr > td > button`.
+   Flatten everything to display: contents so the buttons live on the same
+   flex line. The td.stat2 special-case (show-answer single-cell wrapper)
+   needs to remain a flex item, so we re-set it after. */
+#middle center,
+#middle table,
+#middle tbody,
+#middle tr,
+#middle td {
+  display: contents !important;
 }
-#middle table {
-  margin: 0 auto !important;
-  border-collapse: collapse !important;
-  width: auto !important;
-}
-#middle table td { padding: 0 !important; }
-/* Only the ease-state tds get the counter; the show-answer state wraps its
-   button in a td.stat2 which we exclude. */
-#middle table tr td:not(.stat2) { counter-increment: ba-ease; }
+#middle td.stat2 { display: inline-flex !important; }
 
-/* Reset: kill all the default button chrome — we use pure typography. */
+/* Reset all native button chrome — we draw our own. */
 button {
   -webkit-appearance: none !important;
   appearance: none !important;
   background: transparent !important;
   border: 0 !important;
-  border-radius: 8px !important;
+  border-radius: 10px !important;
   padding: 8px 12px !important;
   margin: 0 !important;
   color: var(--rf-ink-dim) !important;
@@ -104,120 +150,197 @@ button {
   cursor: pointer !important;
   box-shadow: none !important;
   outline: none !important;
-  transition: color 160ms ease, background 160ms ease !important;
-}
-button:hover {
-  color: var(--rf-ink) !important;
-  background: var(--rf-row-hover) !important;
+  transition: color 160ms ease, background 160ms ease, transform 80ms ease !important;
 }
 button:active { transform: translateY(1px) !important; }
 
-/* Edit / More — quietly tucked in the corners */
+/* Edit + More — icon-only, fixed-dimension hit targets, side-by-side on
+   the right. Hover changes opacity only; no background swap (which felt
+   like a "popping" hover before). Anki's button text is hidden via
+   font-size: 0 on the parent. */
 button[onclick*="'edit'"],
 button[onclick*="'more'"] {
-  font: 500 10.5px/1 var(--rf-sans) !important;
-  letter-spacing: 0.14em !important;
-  text-transform: uppercase !important;
+  width: 28px !important;
+  height: 28px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border-radius: 7px !important;
+  background: transparent !important;
   color: var(--rf-ink-faint) !important;
-  padding: 8px 10px !important;
+  font-size: 0 !important;  /* hide Anki's label text */
+  opacity: 0.55;
+  transition: color 160ms ease, opacity 160ms ease;
 }
 button[onclick*="'edit'"]:hover,
-button[onclick*="'more'"]:hover { color: var(--rf-ink-dim) !important; }
-.stattxt {
-  color: var(--rf-ink-faint) !important;
-  font-variant-numeric: tabular-nums;
+button[onclick*="'more'"]:hover {
+  color: var(--rf-ink) !important;
+  opacity: 1;
+  background: transparent !important;
+}
+button[onclick*="'edit'"]::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M12 20h9'/><path d='M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z'/></svg>") no-repeat center / contain;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M12 20h9'/><path d='M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z'/></svg>") no-repeat center / contain;
 }
 
-/* ===== SHOW ANSWER — pure typography, no button =====
-   Stack: a letterspaced label + the colored count summary below. */
-#outer button#ansbut,
-button#ansbut {
-  display: inline-flex !important;
-  flex-direction: column !important;
-  align-items: center !important;
-  gap: 7px !important;
-  padding: 10px 18px !important;
-  background: transparent !important;
-  color: var(--rf-ink) !important;
-  font: 600 13px/1 var(--rf-sans) !important;
-  text-transform: uppercase !important;
-  letter-spacing: 0.32em !important;
-  border-radius: 10px !important;
+button[onclick*="'more'"]::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='5' cy='12' r='1.6'/><circle cx='12' cy='12' r='1.6'/><circle cx='19' cy='12' r='1.6'/></svg>") no-repeat center / contain;
+          mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='5' cy='12' r='1.6'/><circle cx='12' cy='12' r='1.6'/><circle cx='19' cy='12' r='1.6'/></svg>") no-repeat center / contain;
 }
-button#ansbut:hover { color: var(--rf-accent, #6c8cff) !important; background: transparent !important; }
-button#ansbut .stattxt {
-  display: block;
+button[onclick*="'more'"] #time { display: none !important; }
+
+/* ===== QUESTION STATE — Show Answer =====
+   No big button. Replace the label with a single quiet line:
+   "Press space · or click the card".
+   The original button is still clickable (Anki keys "Space" off this
+   button's onclick) but we shrink it so it disappears into a typographic
+   prompt, not a CTA. */
+#ansbut {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  padding: 6px 12px !important;
+  border-radius: 8px !important;
+  background: transparent !important;
+  border: 0 !important;
+  color: var(--rf-ink-faint) !important;
   font: 500 11.5px/1 var(--rf-sans) !important;
   letter-spacing: 0 !important;
   text-transform: none !important;
-  color: var(--rf-ink-faint) !important;
-  margin: 0 !important;
+  font-size: 0 !important;  /* hide Anki's "Show Answer" text */
+  opacity: 0.7;
+  transition: opacity 160ms ease, color 160ms ease;
 }
-button#ansbut .new-count   { color: var(--rf-new)   !important; font-weight: 600; }
-button#ansbut .learn-count { color: var(--rf-learn) !important; font-weight: 600; }
-button#ansbut .review-count{ color: var(--rf-due)   !important; font-weight: 600; }
-button#ansbut u { text-decoration: none; font-weight: 700; color: var(--rf-ink) !important; }
+#ansbut::before {
+  content: "Press";
+  font-size: 11.5px;
+  letter-spacing: 0;
+  color: var(--rf-ink-faint);
+}
+#ansbut::after {
+  content: "Space";
+  display: inline-flex;
+  align-items: center;
+  font: 500 10.5px/1 var(--rf-sans);
+  letter-spacing: 0.04em;
+  padding: 4px 8px 3px;
+  border-radius: 5px;
+  background: transparent;
+  border: 1px solid var(--rf-line-2);
+  color: var(--rf-ink-dim);
+}
+#ansbut:hover { opacity: 1; color: var(--rf-ink) !important; background: transparent !important; }
+#ansbut .stattxt { display: none !important; }
 
-/* ===== EASE BUTTONS — four stat columns =====
-   Each <button> becomes: KEY NUMBER (big) · LABEL (uppercase) · INTERVAL (dim).
-   The key counter (1/2/3/4) is injected with CSS counter-increment so it
-   shows the user's keyboard shortcut, not the label.
+/* The counts under SHOW ANSWER are redundant — the header in the main
+   webview already carries the new/learn/due breakdown + the position. */
+#ansbut .stattxt { display: none !important; }
 
-   Hover: subtle background tint + key in accent.
-   Default ease (#defease, usually Good): key is in accent by default. */
-#middle table { counter-reset: ba-ease 0; }
-#outer #middle table tr td button,
-#middle table tr td button {
-  display: inline-flex !important;
-  flex-direction: column !important;
-  align-items: center !important;
-  gap: 8px !important;
-  min-width: 90px !important;
-  padding: 12px 14px !important;
+/* ===== ANSWER STATE — ease keys =====
+   No labels (AGAIN/HARD/GOOD/EASY), no big blocks. Each ease button is a
+   small inline "key · interval" pair, color-coded. The default (Good)
+   has slightly higher weight.
+
+   Counter-reset goes on #outer (always rendered) since #middle's
+   descendants are flattened with `display: contents` and CSS counters
+   don't reliably increment on contents'd elements in WebKit. The
+   show-answer state has a single ansbut button which would also
+   increment the counter to 1 — that's fine, it's unused there. */
+#outer { counter-reset: ba-ease 0; }
+#middle button[data-ease] { counter-increment: ba-ease; }
+#middle table { border-spacing: 0 !important; }
+/* Inline-block button. The button's font-size is 0 (to hide the "Again"
+   text node Anki injects); ::before and .nobold each declare their own
+   font + line-height, and vertical-align: middle on the children keeps
+   them aligned against the button's explicit 24px line-height baseline. */
+#middle table tr td:not(.stat2) button {
+  display: inline-block !important;
+  text-align: center !important;
+  padding: 4px 10px !important;
+  margin: 0 4px !important;
   background: transparent !important;
+  border: 0 !important;
+  border-radius: 6px !important;
   color: var(--rf-ink-dim) !important;
-  font: 600 10px/1 var(--rf-sans) !important;
-  letter-spacing: 0.18em !important;
-  text-transform: uppercase !important;
-  border-radius: 10px !important;
-  margin: 0 6px !important;
+  font: 500 0/24px var(--rf-sans) !important;  /* font-size 0 hides Anki's label */
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  white-space: nowrap !important;
   position: relative;
+  --ba-key: var(--rf-ink-faint);
+  opacity: 0.85;
+  transition: opacity 160ms ease;
+  vertical-align: middle !important;
 }
-/* Inject the key number above the label — only for ease buttons (non-stat2) */
+/* The colored key square — inline-block, vertically aligned with the
+   interval text after it. */
 #middle table tr td:not(.stat2) button::before {
   content: counter(ba-ease);
-  display: block;
-  font: 500 26px/1 var(--rf-sans);
+  display: inline-block;
+  vertical-align: middle;
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  border-radius: 5px;
+  font: 700 13px/20px var(--rf-sans);
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.025em;
-  color: var(--rf-ink);
-  text-transform: none;
-  margin-bottom: 2px;
+  text-align: center;
+  color: var(--rf-paper);
+  background: var(--ba-key);
 }
-#middle table tr td button:hover {
-  background: var(--rf-row-hover) !important;
-  color: var(--rf-ink) !important;
-}
-#middle table tr td button:hover::before {
-  color: var(--rf-accent, #6c8cff);
-}
-/* Real Anki uses .nobold inside ease buttons for the interval; .stattxt
-   on the show-answer button for the count summary. Style both. */
-#middle table tr td button .nobold,
-#middle table tr td button .stattxt {
-  display: block;
-  font: 500 10px/1 var(--rf-sans) !important;
+/* Color each ease key by its data-ease attribute — robust against
+   DOM structure changes (and works through `display: contents`).
+   We match the long selector's specificity above so these wins. */
+#middle table tr td:not(.stat2) button[data-ease="1"] { --ba-key: var(--rf-again); }
+#middle table tr td:not(.stat2) button[data-ease="2"] { --ba-key: var(--rf-hard); }
+#middle table tr td:not(.stat2) button[data-ease="3"] { --ba-key: var(--rf-good); }
+#middle table tr td:not(.stat2) button[data-ease="4"] { --ba-key: var(--rf-easy); }
+
+/* Interval label sits next to the key, color-matched, quiet.
+   Anki's stock reviewer-bottom.css positions .nobold absolutely above the
+   button (`top: -3px; transform: translate(-50%, -100%)`) — we override
+   to static flow so it sits inline next to the colored key. */
+#middle table tr td:not(.stat2) button .nobold,
+#middle table tr td:not(.stat2) button .stattxt,
+#middle table tr td:not(.stat2) button small {
+  position: static !important;
+  transform: none !important;
+  top: auto !important;
+  left: auto !important;
+  display: inline-block !important;
+  vertical-align: middle !important;
+  font: 500 12px/18px var(--rf-sans) !important;
   font-weight: 500 !important;
-  letter-spacing: 0.04em !important;
+  letter-spacing: 0 !important;
   text-transform: none !important;
-  color: var(--rf-ink-faint) !important;
+  color: var(--ba-key) !important;
+  opacity: 0.95;
   margin: 0 !important;
+  padding: 0 !important;
+  font-variant-numeric: tabular-nums;
 }
 
-/* Default ease — the key number is accent, signaling Enter would pick it. */
-#outer #middle button#defease,
-button#defease { color: var(--rf-ink) !important; }
-#outer #middle button#defease::before,
-button#defease::before { color: var(--rf-accent, #6c8cff); }
-#outer #middle button#defease:hover,
-button#defease:hover { background: var(--rf-row-hover) !important; }
+#middle table tr td:not(.stat2) button:hover { opacity: 1; background: transparent !important; }
+
+/* Default ease (Good) — the only one that gets extra weight. A quiet
+   ↵ follows the interval, signaling Enter triggers it. */
+#middle table tr td:not(.stat2) button#defease { opacity: 1; }
+#middle table tr td:not(.stat2) button#defease::before { box-shadow: 0 0 0 3px color-mix(in oklab, var(--rf-good) 12%, transparent); }
+#middle table tr td:not(.stat2) button#defease .nobold,
+#middle table tr td:not(.stat2) button#defease small,
+#middle table tr td:not(.stat2) button#defease .stattxt { font-weight: 600 !important; }

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -1,125 +1,466 @@
 /* BetterAnki — reviewer card-area chrome.
-   We don't touch card content (user note types are sacred), but we own the
+   We don't touch card content (note-type CSS is sacred), but we own the
    surrounding chrome: page background, body typography, the answer divider,
-   the top progress strip, and the small back affordance. */
+   the top header, progress strip, and the back affordance. The goal is a
+   focused reading surface — book-like, calm, centered. */
+
+:root {
+  --rf-paper: #f6f3ec;
+  --rf-ink: #1f1d18;
+  --rf-ink-dim: #6a6557;
+  --rf-ink-faint: #a39d8b;
+  --rf-line: rgba(31, 29, 24, 0.08);
+  --rf-line-2: rgba(31, 29, 24, 0.18);
+  --rf-row-hover: rgba(31, 29, 24, 0.04);
+  --rf-accent: #6c8cff;
+  --rf-sans: ui-sans-serif, -apple-system, "SF Pro Text", system-ui, sans-serif;
+  --rf-serif: ui-serif, "New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif;
+}
+:root[data-rf-theme="dark"],
+:root.night-mode {
+  --rf-paper: #0b0c0f;
+  --rf-ink: #eceae2;
+  --rf-ink-dim: #9b978a;
+  --rf-ink-faint: #5d5a51;
+  --rf-line: rgba(236, 234, 226, 0.08);
+  --rf-line-2: rgba(236, 234, 226, 0.18);
+  --rf-row-hover: rgba(236, 234, 226, 0.05);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) {
+    --rf-paper: #0b0c0f;
+    --rf-ink: #eceae2;
+    --rf-ink-dim: #9b978a;
+    --rf-ink-faint: #5d5a51;
+    --rf-line: rgba(236, 234, 226, 0.08);
+    --rf-line-2: rgba(236, 234, 226, 0.18);
+    --rf-row-hover: rgba(236, 234, 226, 0.05);
+  }
+}
 
 html, body {
-  background: var(--rf-paper, #0b0c0f) !important;
-  color: var(--rf-ink, #eceae2) !important;
-}
-/* Anki sets `<body class="card cardN">` on the reviewer. We center the
-   reading column by giving body symmetric padding via calc — viewports
-   ≥ 784px get an auto-centered 720px column; narrower viewports collapse
-   to a 32px gutter. Doing this on body (instead of a wrapper) means we
-   don't need to modify Anki's reviewer DOM, and the back-button (fixed)
-   and progress strip (fixed) aren't affected. */
-body {
-  font-family: var(--rf-sans, ui-sans-serif, -apple-system, system-ui, sans-serif);
-  padding-top: 56px !important;
-  padding-bottom: 84px !important;
-  padding-left: max(32px, calc((100% - 720px) / 2)) !important;
-  padding-right: max(32px, calc((100% - 720px) / 2)) !important;
+  background: var(--rf-paper) !important;
+  background-image: none !important;
+  background-position: 0 0 !important;
+  background-attachment: scroll !important;
+  background-size: auto !important;
+  background-repeat: no-repeat !important;
+  color: var(--rf-ink) !important;
   margin: 0 !important;
-  line-height: 1.55;
+  padding: 0 !important;
+}
+
+/* Anki sets `<body class="card cardN">` on the reviewer and adds inline
+   `background-position-y: -44px` for its native fade — kill that.
+
+   We use a CSS Grid to lay out: header / card / spacer, so the card content
+   sits in a vertically-balanced reading position no matter how short it is.
+   The bottom bar lives in a separate webview so we just leave room with
+   padding-bottom. */
+body {
+  font-family: var(--rf-serif) !important;
+  min-height: 100vh !important;
+  display: grid !important;
+  grid-template-rows: auto 1fr auto !important;
+  background-position: 0 0 !important;
+  background-attachment: scroll !important;
+  background-size: auto !important;
+  background-repeat: no-repeat !important;
+  color: var(--rf-ink) !important;
   text-align: center;
-  font-size: 18px;
+  line-height: 1.5;
+  font-size: 25px;
+  box-sizing: border-box;
 }
 
-/* `<body class="card">` would otherwise inherit our generic `.card` rule
-   below — make sure body never gets its own max-width / centering. */
-body.card {
-  max-width: none !important;
-}
+/* Anki's reviewer.css sets margin:20px and a hairline `hr` rule — we wipe
+   the margin (we control layout) and use our own divider. */
+body.card { max-width: none !important; }
 
-/* Generic .card rules — apply to a card wrapper if the user's template uses
-   one, but NOT to body (handled above). */
-:not(body).card {
-  max-width: 720px;
-  margin: 0 auto;
-  font-size: 18px;
-  line-height: 1.55;
-  color: var(--rf-ink, #eceae2);
+/* Top header band — injected via __init__.py before the card div. Carries
+   deck name (left) + count breakdown + position (right). No border under
+   it; the layout speaks for itself. */
+.ba-rv-head {
+  grid-row: 1;
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 28px 12px;
+  font: 500 12px/1 var(--rf-sans);
+  letter-spacing: 0;
+  color: var(--rf-ink-faint);
 }
-
-/* The answer divider — Anki ships <hr id=answer>. Render as a hairline
-   with a centred "ANSWER" caption that visually breaks the line. The
-   caption sits in a paper-colored chip so the line appears to interrupt
-   around it. */
-#answer {
+.ba-rv-head-left,
+.ba-rv-head-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.ba-rv-head-right { justify-content: flex-end; }
+.ba-rv-deck {
+  color: var(--rf-ink-dim);
+  font-weight: 600;
+  font-size: 13px;
+  max-width: 38ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.ba-rv-type {
+  display: inline-block;
+  font: 500 11px/1 var(--rf-sans);
+  letter-spacing: 0;
+  color: var(--rf-ink-faint);
+  max-width: 18ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.ba-rv-type[hidden] { display: none !important; }
+/* Back affordance: just the chevron. All sizing is locked with both
+   width/height AND min/max so no hover state, focus, or active state
+   can stretch the box. transform stays at none too — no scale pulses. */
+.ba-rv-back {
+  flex: 0 0 28px;
+  box-sizing: border-box;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  max-width: 28px;
+  min-height: 28px;
+  max-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
   border: 0;
-  position: relative;
-  height: 1px;
-  background: var(--rf-line, rgba(127, 127, 127, 0.18));
-  margin: 38px auto 28px;
-  max-width: 720px;
-  overflow: visible;
+  padding: 0;
+  margin: 0 -4px 0 -4px;
+  border-radius: 999px;
+  color: var(--rf-ink-faint);
+  font: 500 18px/1 var(--rf-sans);
+  letter-spacing: 0;
+  cursor: pointer;
+  transform: none;
+  transition: color 160ms ease, opacity 160ms ease;
+  opacity: 0.6;
 }
-#answer::after {
-  content: "Answer";
+.ba-rv-back:hover,
+.ba-rv-back:focus,
+.ba-rv-back:focus-visible,
+.ba-rv-back:active {
+  color: var(--rf-ink);
+  opacity: 1;
+  background: transparent;
+  outline: none;
+  box-shadow: none;
+  transform: none;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+.ba-rv-sep {
+  display: inline-block;
+  width: 1px;
+  height: 12px;
+  background: var(--rf-line-2);
+  margin: 0 2px;
+}
+.ba-rv-pos {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  color: var(--rf-ink-faint);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.ba-rv-pos b {
+  color: var(--rf-ink-dim);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.ba-rv-pos span { color: var(--rf-ink-faint); font-size: 11px; }
+
+/* Header counts breakdown — three quiet "N · label" units, dot-prefixed.
+   Each pair sits on a row, vertically centered, with a faint colored dot. */
+.ba-rv-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+.ba-rv-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  font: 500 12px/1 var(--rf-sans);
+  letter-spacing: 0;
+  color: var(--rf-ink-faint);
+  position: relative;
+  padding-left: 13px;
+}
+.ba-rv-count::before {
+  content: "";
   position: absolute;
-  left: 50%;
+  left: 0;
   top: 50%;
-  transform: translate(-50%, -50%);
-  background: var(--rf-paper, #0b0c0f);
-  padding: 0 14px;
-  color: var(--rf-ink-faint, #5d5a51);
-  font: 600 9.5px/1 var(--rf-sans, system-ui, sans-serif);
-  letter-spacing: 0.3em;
-  text-transform: uppercase;
+  transform: translateY(-50%);
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.85;
+}
+.ba-rv-count b {
+  color: var(--rf-ink-dim);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+.ba-rv-count i {
+  font-style: normal;
+  color: var(--rf-ink-faint);
+  letter-spacing: 0;
+}
+.ba-rv-c-new   { color: #3f7fb2; }   /* matches --rf-easy/new color slot */
+.ba-rv-c-learn { color: #c69142; }   /* learn = warm/learning */
+.ba-rv-c-due   { color: #4a8f6b; }   /* due = ready review */
+:root[data-rf-theme="dark"] .ba-rv-c-new,
+:root.night-mode .ba-rv-c-new   { color: #6fa9d8; }
+:root[data-rf-theme="dark"] .ba-rv-c-learn,
+:root.night-mode .ba-rv-c-learn { color: #d4a35d; }
+:root[data-rf-theme="dark"] .ba-rv-c-due,
+:root.night-mode .ba-rv-c-due   { color: #79b69b; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) .ba-rv-c-new   { color: #6fa9d8; }
+  :root:not([data-rf-theme="light"]) .ba-rv-c-learn { color: #d4a35d; }
+  :root:not([data-rf-theme="light"]) .ba-rv-c-due   { color: #79b69b; }
+}
+/* Header icon buttons (Edit, More). All sizing is locked: width, height,
+   min/max, box-sizing, padding — so hover/focus/active never resize. */
+.ba-rv-icon-btn {
+  flex: 0 0 28px;
+  box-sizing: border-box;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  max-width: 28px;
+  min-height: 28px;
+  max-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  border-radius: 7px;
+  color: var(--rf-ink-faint);
+  opacity: 0.55;
+  transform: none;
+  transition: color 160ms ease, opacity 160ms ease;
+}
+.ba-rv-icon-btn svg { width: 15px; height: 15px; display: block; }
+.ba-rv-icon-btn:hover,
+.ba-rv-icon-btn:focus,
+.ba-rv-icon-btn:focus-visible,
+.ba-rv-icon-btn:active {
+  color: var(--rf-ink);
+  opacity: 1;
+  background: transparent;
+  outline: none;
+  box-shadow: none;
+  transform: none;
+  padding: 0;
+  width: 28px;
+  height: 28px;
+}
+.ba-rv-icon-btn[hidden] { display: none !important; }
+
+/* Ease key colours — used by the ease selector below the answer. */
+:root {
+  --rf-again: #c95a4b;
+  --rf-hard:  #c69142;
+  --rf-good:  #4a8f6b;
+  --rf-easy:  #3f7fb2;
+}
+:root[data-rf-theme="dark"], :root.night-mode {
+  --rf-again: #e07466;
+  --rf-hard:  #d4a35d;
+  --rf-good:  #79b69b;
+  --rf-easy:  #6fa9d8;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) {
+    --rf-again: #e07466;
+    --rf-hard:  #d4a35d;
+    --rf-good:  #79b69b;
+    --rf-easy:  #6fa9d8;
+  }
 }
 
-/* Progress strip across the top — accent only. No floating "X/Y" label. */
+/* The ease selector — four colored interval words. No numbers, no labels,
+   no bar. Just typography you click. The default key is heavier weight
+   and full opacity, with NO animation (per user feedback: don't make the
+   default attract attention, that's distracting). */
+.ba-rv-ease {
+  grid-row: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;       /* small gap; each key carries its own roomy padding */
+  padding: 16px 32px 24px;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 680px;
+  box-sizing: border-box;
+  font-variant-numeric: tabular-nums;
+}
+.ba-rv-ease[hidden] { display: none !important; }
+
+/* Each ease key has a generous padding that becomes the click hit area,
+   and on hover a soft background paints that area in. The text inside is
+   centered and never changes size, weight, or position on hover. The
+   default (data-default) stays heavier; that's the only thing that
+   distinguishes it idle. */
+.ba-rv-ease-key,
+.ba-rv-ease-key:hover,
+.ba-rv-ease-key:focus,
+.ba-rv-ease-key:focus-visible,
+.ba-rv-ease-key:active {
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  border: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+  text-decoration: none !important;
+}
+.ba-rv-ease-key {
+  /* Roomy padding = bigger click target. Visual text remains the same. */
+  padding: 14px 28px;
+  margin: 0;
+  cursor: pointer;
+  font: 500 14px/1 var(--rf-sans);
+  letter-spacing: 0;
+  color: var(--ba-key, var(--rf-ink-faint));
+  background: transparent;
+  border-radius: 10px;
+  opacity: 0.8;
+  /* Only color these on hover — no transform, no padding change. */
+  transition: background-color 160ms ease, opacity 160ms ease;
+}
+.ba-rv-ease-key[hidden] { display: none !important; }
+.ba-rv-ease-key:hover {
+  /* Significant: a real surface appears so the user sees the click area.
+     We don't touch font/weight/transform, so the text doesn't move. */
+  background: color-mix(in oklab, var(--ba-key, var(--rf-ink-faint)) 12%, transparent);
+  opacity: 1;
+}
+.ba-rv-ease-1 { --ba-key: var(--rf-again); }
+.ba-rv-ease-2 { --ba-key: var(--rf-hard); }
+.ba-rv-ease-3 { --ba-key: var(--rf-good); }
+.ba-rv-ease-4 { --ba-key: var(--rf-easy); }
+.ba-rv-ease-key[data-default] { font-weight: 700; opacity: 1; }
+
+/* Card content sits in the second grid row. We anchor it at a stable Y
+   (28% from the top of the available space) so revealing the answer
+   below the question never *moves* the question. */
+#qa {
+  grid-row: 2;
+  display: flex !important;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: max(96px, 18vh) 32px 64px;
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  min-height: 0;
+  font-size: 25px;
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+  overflow-y: auto;
+}
+
+/* The card content itself is rendered as-is (note-type CSS wins). We just
+   give it a comfortable reading column so long answers wrap kindly, AND
+   we promote the inherited size so default note-types feel substantial. */
+#qa > * { max-width: 100%; }
+.card {
+  color: var(--rf-ink) !important;
+  background: transparent !important;
+  font-size: 25px !important;  /* override note-type's 20px default */
+}
+
+/* The answer divider — a quiet hairline, no caption. Anki's internal
+   reviewer.css sets a thick #737373 bar on every `hr`; this overrides. */
+#qa hr#answer,
+hr#answer {
+  all: unset;
+  display: block;
+  height: 1px;
+  background: var(--rf-line-2) !important;
+  margin: 32px auto 28px;
+  width: 100%;
+  max-width: 320px;
+}
+/* Any other `<hr>` inside the card should respect our hairline, not the
+   default 1em-margin #737373 slab from Anki's reviewer.css. */
+#qa hr {
+  background: var(--rf-line) !important;
+  height: 1px !important;
+  border: 0 !important;
+  margin: 18px auto !important;
+}
+
+/* The answer reveal — a soft fade + 4px slide. Fast (220ms), no easing
+   that lingers. The question above doesn't move because the wrap sits
+   below it in normal flow; only `.ba-rv-answer` animates. */
+.ba-rv-answer {
+  animation: ba-rv-reveal 220ms cubic-bezier(.2, .7, .2, 1) both;
+}
+@keyframes ba-rv-reveal {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-rv-answer { animation: none; }
+}
+
+/* Progress strip across the top, hairline above the header. Slightly
+   thicker so the fill reads as an actual "you are X% through this session"
+   indicator and not a stray pixel.
+
+   We also reserve the same height as a faint backdrop so the strip is
+   present even at 0% — empty isn't surprising, you see the channel. */
 #reforge-progress {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   height: 3px;
-  background: var(--rf-line, rgba(255, 255, 255, 0.06));
+  background: var(--rf-line);
   z-index: 9999;
   pointer-events: none;
 }
 #reforge-progress-fill {
   height: 100%;
   width: 0%;
-  background: var(--rf-accent, #6c8cff);
-  transition: width 220ms cubic-bezier(.2, .7, .2, 1);
+  background: var(--rf-accent);
+  transition: width 280ms cubic-bezier(.2, .7, .2, 1);
 }
-/* The progress-remaining text was visually noisy + redundant with the
-   counts in the bottom bar. Hide it. */
 #reforge-progress-label { display: none !important; }
 
-/* Back-to-decks affordance — small chevron + "Decks" always visible. Stable
-   geometry (no width changes) so hover never feels jumpy. Only color +
-   opacity respond to hover. */
+/* Legacy back button (still used on non-injected views as a fallback).
+   In the new layout the header carries the back link. */
 .ba-back {
   position: fixed !important;
   top: 12px !important;
   left: 16px !important;
   z-index: 200 !important;
-  display: inline-flex !important;
-  align-items: center;
-  gap: 6px;
-  background: transparent !important;
-  border: 0 !important;
-  padding: 7px 12px 7px 8px !important;
-  border-radius: 999px !important;
-  font: 500 11.5px/1 var(--rf-sans, system-ui, sans-serif) !important;
-  letter-spacing: 0.04em !important;
-  color: var(--rf-ink-faint, #5d5a51) !important;
-  cursor: pointer !important;
-  opacity: 0.55 !important;
-  transition: opacity 180ms ease, color 180ms ease, background 180ms ease !important;
-}
-.ba-back::before {
-  content: "‹";
-  font-size: 18px;
-  line-height: 1;
-  font-weight: 400;
-  margin-right: 1px;
-}
-.ba-back:hover {
-  opacity: 1 !important;
-  color: var(--rf-ink, #eceae2) !important;
-  background: var(--rf-row-hover, rgba(127, 127, 127, 0.06)) !important;
+  display: none !important;  /* superseded by .ba-rv-back in the header */
 }

--- a/web/reviewer.js
+++ b/web/reviewer.js
@@ -1,6 +1,18 @@
-// BetterAnki — reviewer progress bar. Python pushes values via window.__reforgeProgress.
+// BetterAnki — reviewer progress bar + body cleanup + answer-reveal wrap.
 (function () {
+  function cleanupBody() {
+    if (!document.body) return;
+    // Anki injects `background-position-y: -44px` inline — kill it so
+    // we don't get a horizontal banding artifact.
+    try {
+      document.body.style.removeProperty("background-position-y");
+      document.body.style.removeProperty("background-position");
+      document.body.style.removeProperty("background-image");
+    } catch (_) {}
+  }
+
   function ensureBar() {
+    cleanupBody();
     var bar = document.getElementById("reforge-progress");
     if (!bar) {
       bar = document.createElement("div");
@@ -14,6 +26,92 @@
     }
   }
 
+  // Wrap everything from the answer divider onward in a single .ba-rv-answer
+  // element so CSS can fade it in without moving the question above it.
+  function wrapAnswer() {
+    var qa = document.getElementById("qa");
+    if (!qa) return;
+    var ease = document.querySelector(".ba-rv-ease");
+    var hr = qa.querySelector("hr#answer");
+    var hasAnswer = !!hr || !!qa.querySelector(".ba-rv-answer");
+    if (ease) ease.hidden = !hasAnswer;
+    if (qa.querySelector(".ba-rv-answer")) return;  // already wrapped
+    if (!hr) return;
+    var wrap = document.createElement("div");
+    wrap.className = "ba-rv-answer";
+    var parent = hr.parentNode;
+    var nodes = [];
+    var n = hr;
+    while (n) {
+      nodes.push(n);
+      n = n.nextSibling;
+    }
+    nodes.forEach(function (node) { wrap.appendChild(node); });
+    parent.appendChild(wrap);
+  }
+
+  // Receive {ease: interval_string} + defaultEase from Python and write
+  // the interval strings into the ease chips, hiding chips with no
+  // matching ease (i.e., 2/3-button new cards).
+  window.__baSetEase = function (intervals, defaultEase) {
+    var ease = document.querySelector(".ba-rv-ease");
+    if (!ease) return;
+    ease.querySelectorAll(".ba-rv-ease-key").forEach(function (btn) {
+      var e = btn.getAttribute("data-ease");
+      var label = intervals && intervals[e];
+      var slot = btn.querySelector(".ba-rv-ease-int");
+      if (label && slot) {
+        slot.textContent = label;
+        btn.hidden = false;
+      } else {
+        btn.hidden = true;
+      }
+      if (parseInt(e, 10) === parseInt(defaultEase, 10)) {
+        btn.setAttribute("data-default", "");
+      } else {
+        btn.removeAttribute("data-default");
+      }
+    });
+  };
+
+  // Anki rewrites body.style on every card swap. We can't override its inline
+  // styles permanently from CSS, so observe and re-strip when it reappears.
+  function watchBody() {
+    if (!document.body || !window.MutationObserver) return;
+    var mo = new MutationObserver(function () {
+      cleanupBody();
+      wrapAnswer();
+    });
+    mo.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["style"],
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  // Click-the-card to reveal: clicking anywhere on the card area while in
+  // the question state triggers the same shortcut as Space. Avoid hijacking
+  // clicks on actual links, inputs, or media inside the card body.
+  function clickToReveal() {
+    var qa = document.getElementById("qa");
+    if (!qa) return;
+    qa.addEventListener("click", function (e) {
+      if (qa.querySelector(".ba-rv-answer")) return;  // already answered
+      var t = e.target;
+      while (t && t !== qa) {
+        var tag = (t.tagName || "").toLowerCase();
+        if (tag === "a" || tag === "button" || tag === "input"
+            || tag === "textarea" || tag === "select" || tag === "audio"
+            || tag === "video" || t.isContentEditable) {
+          return;  // let the user actually interact with that thing
+        }
+        t = t.parentNode;
+      }
+      try { pycmd && pycmd("ans"); } catch (_) {}
+    }, { passive: true });
+  }
+
   window.__reforgeProgress = function (pct, done, rem) {
     ensureBar();
     var fill = document.getElementById("reforge-progress-fill");
@@ -22,9 +120,16 @@
     if (label) label.textContent = done + " / " + (done + rem);
   };
 
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", ensureBar);
-  } else {
+  function boot() {
     ensureBar();
+    wrapAnswer();
+    clickToReveal();
+    watchBody();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
   }
 })();


### PR DESCRIPTION
## Summary
- Strip Anki's native bottom toolbar on the reviewer state; replace it with a header band (deck name, counts, position, Edit/More icons) and an inline ease selector under the card — four color-coded interval words, no numbers, no labels, no bar.
- Anchor the question at a stable Y (`padding-top: max(96px, 18vh)`) so revealing the answer never moves it; wrap the answer in a `.ba-rv-answer` div via JS and fade it in (220ms, reduced-motion aware).
- Hover on header chips changes only color/opacity (size locked with `min/max-width`, `box-sizing`, `transform: none`); ease keys have a roomy hit area with a tinted hover surface so the click target is obvious without moving any text.
- Fix the original `BottomToolbar` vs `ReviewerBottomBar` mismatch (why the bottom bar was unstyled before), drop Anki's inline `background-position-y` banding via MutationObserver, override the stock `.nobold` `position: absolute` so intervals flow inline, and add an idempotency guard on body injection so re-fires of `webview_will_set_content` can't double the header.

## Test plan
- [ ] `make dev && make run` on a worktree with a real seeded collection (`make seed`).
- [ ] Enter a deck: header reads as `‹ Deck · n new · n learn · n due · m of total · Edit · More`, no border under it.
- [ ] Press Space (or click the card): the question stays in place; the answer fades in below a hairline divider.
- [ ] Bottom of page shows four intervals (e.g. `<1m  <10m  6d  13d`), color-coded; the default (Good) is heavier. Hover paints a soft tinted surface; nothing moves.
- [ ] Hover ‹ / Edit / More: color brightens, dimensions don't change.
- [ ] Toggle light/dark theme in settings: both modes look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)