### PR TITLE
Skip deck-overview page; row-click study; menu + sync polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store
 .devmode
 .context/
+.claude/

--- a/__init__.py
+++ b/__init__.py
@@ -217,6 +217,9 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
     if isinstance(context, DeckBrowser):
         web_content.css.append(f"{WEB}/heatmap.css")
         web_content.js.append(f"{WEB}/heatmap.js")
+        # Whole-row click → study (skips the Overview page). Loaded
+        # unconditionally on the deck browser, independent of sidebar.
+        web_content.js.append(f"{WEB}/deckrow.js")
         # Tag the deck browser's <center> so theme.css can scope the heavy
         # homepage layout to it alone — the Overview shares this stylesheet
         # and must keep its own simple layout (just palette + type).
@@ -599,6 +602,10 @@ def on_state_did_change(new_state: str, old_state: str) -> None:
     _apply_chrome()
     _mark_sidebar_active(new_state)
     _push_sidebar_standing()
+    # Re-check pending sync on every navigation so the sidebar dot reflects
+    # current state after reviewing/adding/etc., not just on deck-browser
+    # render.
+    _refresh_sync_status()
 
 
 def _post_render_fixups() -> None:
@@ -668,7 +675,21 @@ def _open_settings() -> None:
 def _on_js_message(handled, message, context):
     """Dispatch `ba:<cmd>` pycmds from our sidebar/settings. Filter hook:
     return (True, None) when we handle it."""
-    if not isinstance(message, str) or not message.startswith("ba:"):
+    if not isinstance(message, str):
+        return handled
+    # Anki's deck browser emits `open:<did>` when a deck is clicked, which
+    # normally lands on the intermediate Overview page. Skip that and go
+    # straight into studying — same target as the single-deck hero.
+    if message.startswith("open:") and isinstance(context, DeckBrowser):
+        tail = message.split(":", 1)[1]
+        if tail.isdigit():
+            try:
+                _start_studying(int(tail))
+            except Exception:
+                return handled
+            return (True, None)
+        return handled
+    if not message.startswith("ba:"):
         return handled
     cmd = message[3:]
     try:

--- a/web/deckopts.css
+++ b/web/deckopts.css
@@ -31,14 +31,25 @@
   transform: translateY(0);
 }
 
-.ad-menu-item {
+/* All menu-item rules are scoped with `.ad-menu` to out-specify Anki's
+   `.fancy button` (0,1,1), which would otherwise paint a pill background,
+   border, drop shadow, and 15px corner radius on every item. */
+.ad-menu .ad-menu-item {
   display: flex;
   align-items: center;
   gap: 10px;
   width: 100%;
+  /* `<button>` defaults to content-box in WebKit, so width:100% + padding
+     pushes the hover background past the menu's right edge. Border-box
+     keeps the highlight inside. */
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  appearance: none;
   background: transparent;
   border: 0;
+  box-shadow: none;
   border-radius: 6px;
+  margin: 0;
   padding: 8px 10px;
   text-align: left;
   font: 500 13px/1.2 inherit;
@@ -47,42 +58,44 @@
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
-.ad-menu-item:hover,
-.ad-menu-item:focus-visible {
+.ad-menu .ad-menu-item:hover,
+.ad-menu .ad-menu-item:focus-visible {
   background: var(--rf-row-hover, rgba(0, 0, 0, 0.04));
+  border: 0;
+  box-shadow: none;
   outline: none;
 }
-.ad-menu-item .ad-menu-icon {
+.ad-menu .ad-menu-item .ad-menu-icon {
   flex: none;
   width: 14px;
   height: 14px;
   color: var(--rf-ink-faint, #8b8576);
   transition: color 120ms ease;
 }
-.ad-menu-item:hover .ad-menu-icon,
-.ad-menu-item:focus-visible .ad-menu-icon {
+.ad-menu .ad-menu-item:hover .ad-menu-icon,
+.ad-menu .ad-menu-item:focus-visible .ad-menu-icon {
   color: var(--rf-ink-dim, #4a4538);
 }
-.ad-menu-item .ad-menu-l {
+.ad-menu .ad-menu-item .ad-menu-l {
   flex: 1;
 }
 
-.ad-menu-sep {
+.ad-menu .ad-menu-sep {
   height: 1px;
   margin: 4px 6px;
   background: var(--rf-line, #e3decf);
 }
 
 /* Destructive items — quieter at rest, take on a warning tint on hover. */
-.ad-menu-item.ad-menu-danger {
+.ad-menu .ad-menu-item.ad-menu-danger {
   color: var(--rf-ink-dim, #4a4538);
 }
-.ad-menu-item.ad-menu-danger:hover,
-.ad-menu-item.ad-menu-danger:focus-visible {
+.ad-menu .ad-menu-item.ad-menu-danger:hover,
+.ad-menu .ad-menu-item.ad-menu-danger:focus-visible {
   background: rgba(200, 68, 49, 0.08);
   color: #c84431;
 }
-.ad-menu-item.ad-menu-danger:hover .ad-menu-icon,
-.ad-menu-item.ad-menu-danger:focus-visible .ad-menu-icon {
+.ad-menu .ad-menu-item.ad-menu-danger:hover .ad-menu-icon,
+.ad-menu .ad-menu-item.ad-menu-danger:focus-visible .ad-menu-icon {
   color: #c84431;
 }

--- a/web/deckrow.js
+++ b/web/deckrow.js
@@ -1,0 +1,49 @@
+/* Anki Design — make entire deck rows clickable to start studying.
+
+   Anki's default row only wires the deck-name link (and shift-click for
+   selection). Clicking blank space or the count cells does nothing. We
+   add a row-level handler so the whole row is the study target — except
+   inner anchors (deck name, gears) which keep their own onclick. */
+(function () {
+  "use strict";
+  if (window.__adDeckRowWired) return;
+  window.__adDeckRowWired = true;
+
+  function onRowClick(e) {
+    if (e.shiftKey) return;                      // native: select
+    if (e.button !== undefined && e.button !== 0) return;
+    // Inner anchors carry their own pycmd onclick (deck name → open,
+    // gears → opts). Let them handle their clicks and skip ours so we
+    // don't double-fire on the deck name.
+    if (e.target.closest && e.target.closest("a")) return;
+    var tr = e.currentTarget;
+    var did = tr.id;
+    if (!did) return;
+    e.preventDefault();
+    try { pycmd("open:" + did); } catch (_) {}
+  }
+
+  function wire() {
+    var rows = document.querySelectorAll("tr.deck");
+    for (var i = 0; i < rows.length; i++) {
+      var r = rows[i];
+      if (r.__adRowWired) continue;
+      r.__adRowWired = true;
+      r.addEventListener("click", onRowClick);
+    }
+  }
+
+  function init() {
+    wire();
+    if (window.MutationObserver) {
+      var mo = new MutationObserver(wire);
+      mo.observe(document.body, { childList: true, subtree: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -178,35 +178,60 @@ body.ba-with-side {
 
 /* Streak block + lifetime stats moved out of the sidebar; styles deleted. */
 
-/* ---------------------------- SYNC ---------------------------- */
+/* ---------------------------- SYNC ----------------------------
+   Three states the sidebar reflects:
+   • pending  — local changes to push; soft accent dot, slow breathe
+   • full     — full re-sync required; amber dot (stronger signal, no pulse)
+   • active   — sync in progress; icon spins
+   The dot lives at the row's right edge (next to the label) so it doesn't
+   visually compete with the icon, and gets a faint ring matching the row
+   background so it reads as a token rather than a colored speck. */
 .ba-side-item[data-cmd="sync"] .ba-side-dot {
-  width: 6px; height: 6px; border-radius: 999px;
+  width: 7px; height: 7px; border-radius: 999px;
   background: var(--rf-ink-faint);
   opacity: 0;
   transition: opacity 160ms ease, background 160ms ease,
-              transform 160ms ease;
+              box-shadow 160ms ease;
 }
-/* "Pending" (changes to push) — small accent dot */
+/* "Pending" (changes to push) — accent dot + matching icon/label tint. */
 .ba-side-item[data-cmd="sync"].ba-sync-pending { color: var(--rf-accent, #6c8cff); }
 .ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-icon { color: var(--rf-accent, #6c8cff); }
 .ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-dot {
   opacity: 1;
   background: var(--rf-accent, #6c8cff);
+  box-shadow: 0 0 0 2px color-mix(in srgb,
+                var(--rf-accent, #6c8cff) 22%, transparent);
+  animation: ba-sync-breathe 2.8s ease-in-out infinite;
 }
-/* "Full" — warning amber */
+/* "Full" — warning amber, no pulse (it's a stronger signal than pending). */
 .ba-side-item[data-cmd="sync"].ba-sync-full { color: var(--rf-learn); }
 .ba-side-item[data-cmd="sync"].ba-sync-full  .ba-side-icon { color: var(--rf-learn); }
 .ba-side-item[data-cmd="sync"].ba-sync-full  .ba-side-dot {
   opacity: 1;
   background: var(--rf-learn);
+  box-shadow: 0 0 0 2px color-mix(in srgb,
+                var(--rf-learn) 22%, transparent);
 }
-/* Active sync — gentle pulse */
+/* Active sync — icon spins. */
 .ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon {
   animation: ba-spin 1.4s linear infinite;
 }
 @keyframes ba-spin {
   from { transform: rotate(0deg); }
   to   { transform: rotate(360deg); }
+}
+/* Slow breath for the pending dot. Stays mostly visible — the cycle just
+   nudges opacity down and back so it catches the eye at a glance without
+   pulling attention away from real work. */
+@keyframes ba-sync-breathe {
+  0%, 100% { opacity: 1;    transform: scale(1); }
+  50%      { opacity: 0.55; transform: scale(0.88); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-dot,
+  .ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon {
+    animation: none;
+  }
 }
 
 /* Hover-reveal keyboard chip (absolutely positioned, no layout shift). */

--- a/web/theme.css
+++ b/web/theme.css
@@ -327,15 +327,14 @@ body::before {
   color: var(--rf-accent, #6c8cff) !important;
   font-style: italic;
 }
+/* Collapse indicator (`+` / `-`) on parent decks. Hidden: clicking the
+   row goes straight to studying, so the toggle has no place here. */
 .ba-home a.collapse,
-.ba-home span.collapse {
-  display: inline-block;
-  width: 1.2em;
-  color: var(--rf-ink-faint) !important;
-  font: 400 13px/1 var(--rf-sans);
-  text-decoration: none !important;
-}
-.ba-home a.collapse:hover { color: var(--rf-ink) !important; }
+.ba-home span.collapse { display: none !important; }
+/* Whole row is a study target — make that intent visible on hover. */
+.ba-home tr.deck { cursor: pointer; }
+.ba-home tr.deck td.opts,
+.ba-home tr.deck td.opts a { cursor: pointer; }
 
 /* Counts: tight sans tabular figures grouped on the right of each row.
    Visually they read as a single small cluster, not three table columns. */


### PR DESCRIPTION
## Summary
- Clicking a deck in the multi-deck list goes straight to the reviewer instead of the intermediate Overview page; the whole row is the study target (gears unchanged) and the `+`/`-` collapse toggle is hidden.
- Deck-options popup: scoped rules with `.ad-menu` to out-specify Anki's `.fancy button` (no more pill backgrounds / drop shadows on each item) and added `box-sizing: border-box` so the hover highlight stays inside the menu.
- Sidebar sync indicator now refreshes on every state change, not just deck-browser render; "pending" dot gets a slightly larger ring + slow breathe for at-a-glance visibility, with `prefers-reduced-motion` respected.

## Test plan
- [ ] With multiple decks, clicking any row (counts, blank space, deck name) opens the reviewer directly — no Overview page in between.
- [ ] Clicking the gears icon on a row still opens the deck-options menu; menu items are flush, no pill chrome, hover highlight does not bleed past the right edge.
- [ ] After reviewing or adding a card (without returning to the deck browser), the sidebar sync dot reflects current pending state on the next navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)