### PR TITLE
Sidebar New Deck: morph button to inline input on click

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -750,7 +750,11 @@ def _on_js_message(handled, message, context):
             except Exception:
                 return handled
         elif cmd == "create":
-            _open_new_deck()
+            _focus_inline_new_deck()
+        elif cmd == "create-fallback":
+            _open_new_deck_dialog()
+        elif cmd.startswith("create:"):
+            _create_deck_inline(cmd.split(":", 1)[1])
         elif cmd == "import":
             mw.onImport()
         elif cmd.startswith("study:"):
@@ -809,17 +813,50 @@ def _on_js_message(handled, message, context):
     return (True, None)
 
 
-def _open_new_deck() -> None:
-    """Open the standard New Deck dialog (same one Anki uses)."""
+def _focus_inline_new_deck() -> None:
+    """Focus the inline create input in the sidebar. Falls back to Anki's
+    native dialog if the sidebar isn't reachable (other page, JS not loaded)."""
+    web = getattr(mw, "web", None)
+    state = getattr(mw, "state", "")
+    if web is not None and state in ("deckBrowser", "overview"):
+        try:
+            web.eval(
+                "if (window.__baFocusNewDeck) window.__baFocusNewDeck();"
+                "else pycmd('ba:create-fallback');"
+            )
+            return
+        except Exception:
+            pass
+    _open_new_deck_dialog()
+
+
+def _open_new_deck_dialog() -> None:
+    """Last-resort fallback: open Anki's native New Deck dialog."""
     try:
         from aqt.operations.deck import add_deck_dialog
         add_deck_dialog(parent=mw)
     except Exception:
         try:
-            # Fallback for older Anki APIs.
             mw.deckBrowser._on_create()  # type: ignore[attr-defined]
         except Exception:
             pass
+
+
+def _create_deck_inline(name: str) -> None:
+    """Create a deck by name from the inline sidebar input. `decks.id(name,
+    create=True)` is idempotent — a duplicate name returns the existing id,
+    so no pre-check is needed."""
+    name = (name or "").strip()
+    if not name:
+        return
+    try:
+        mw.col.decks.id(name, create=True)
+    except Exception:
+        return
+    try:
+        mw.reset()
+    except Exception:
+        pass
 
 
 def _start_studying(did: int) -> None:
@@ -1604,9 +1641,10 @@ def _dev_screenshot(request_path: str) -> None:
                 except Exception:
                     pass
                 return
+            # No raise_/activateWindow: widget.grab() renders offscreen via Qt's
+            # backing store, so the window doesn't need focus or to be on top.
+            # Surfacing it would steal focus from whatever the user is doing.
             try:
-                widget.raise_()
-                widget.activateWindow()
                 QApplication.processEvents()
             except Exception:
                 pass
@@ -1719,16 +1757,24 @@ def _dev_dump(request_path: str) -> None:
     try:
         from aqt.qt import QApplication
         widget = None
-        for w in QApplication.topLevelWidgets():
-            try:
-                if not w.isVisible():
+        web = None
+        if target_title in ("main", "mw"):
+            widget = mw
+            # mw has multiple QWebEngineViews (toolbarWeb, web, bottomWeb).
+            # findChild() returns whichever was constructed first — usually
+            # the toolbar — which gives a useless 1-line DOM. Pin to mw.web.
+            web = getattr(mw, "web", None)
+        else:
+            for w in QApplication.topLevelWidgets():
+                try:
+                    if not w.isVisible():
+                        continue
+                    title = (w.windowTitle() or "").lower()
+                    if target_title and target_title in title:
+                        widget = w
+                        break
+                except Exception:
                     continue
-                title = (w.windowTitle() or "").lower()
-                if target_title and target_title in title:
-                    widget = w
-                    break
-            except Exception:
-                continue
         if widget is None:
             with open(out, "w") as fh:
                 fh.write(f"<!-- no widget for title={target_title!r} -->")
@@ -1737,7 +1783,8 @@ def _dev_dump(request_path: str) -> None:
             from aqt.qt import QWebEngineView  # type: ignore
         except Exception:
             from PyQt6.QtWebEngineWidgets import QWebEngineView  # type: ignore
-        web = widget.findChild(QWebEngineView)
+        if web is None:
+            web = widget.findChild(QWebEngineView)
         if web is None:
             with open(out, "w") as fh:
                 fh.write("<!-- no QWebEngineView found -->")
@@ -1897,6 +1944,23 @@ def _dev_run_cmd(raw: str) -> None:
             rv = getattr(mw, "reviewer", None)
             if rv and getattr(rv, "bottom", None) and getattr(rv.bottom, "web", None):
                 rv.bottom.web.eval(js)
+        elif cmd == "reload_page":
+            # Force a full webview reload — addon JS changes don't propagate
+            # via the CSS-only hot-reload; reload picks them up cleanly.
+            try:
+                if getattr(mw, "web", None) is not None:
+                    mw.web.reload()
+            except Exception as e:
+                _dev_cmd_log(f"reload_page err: {e!r}")
+        elif cmd == "decks_list":
+            try:
+                names = [d.name for d in mw.col.decks.all_names_and_ids()]
+                _dev_cmd_log(f"decks: {names}")
+            except Exception as e:
+                _dev_cmd_log(f"decks err: {e!r}")
+        elif cmd.startswith("create_test:"):
+            _create_deck_inline(cmd.split(":", 1)[1])
+            _dev_cmd_log(f"create_test ran for: {cmd.split(':',1)[1]!r}")
         elif cmd.startswith("state_info"):
             try:
                 st = getattr(mw, "state", "")

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -178,6 +178,96 @@ body.ba-with-side {
 
 /* Streak block + lifetime stats moved out of the sidebar; styles deleted. */
 
+/* ---------------------------- NEW DECK ROW ----------------------------
+   Morphing inline-create row. Idle: same shape as .ba-side-act. Active:
+   the label slot swaps for a borderless text input — Enter creates the
+   deck via pycmd("ba:create:<name>"). The icon is the only stable
+   anchor; everything else cross-fades in the same flex slot so nothing
+   in the row moves. State is held on the row via data-state. */
+.ba-side-newdeck { cursor: pointer; }
+.ba-side-newdeck[data-state="active"] { cursor: text; }
+.ba-side-newdeck:focus-visible { outline: none; }
+.ba-side-newdeck:focus-visible .ba-side-newdeck-label {
+  /* When the row itself is keyboard-focused in idle, lift the label tone
+     to mirror :hover — a clearer "I'll respond" affordance. */
+  color: var(--rf-ink-dim);
+}
+
+/* The shared label/input slot. Has its own line-height so it doesn't
+   collapse when both children are absolutely positioned. */
+.ba-side-newdeck-swap {
+  position: relative;
+  flex: 1;
+  height: 14px;
+  line-height: 14px;
+}
+
+.ba-side-newdeck-label,
+.ba-side-newdeck-input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  width: 100%;
+  transition:
+    opacity 180ms ease,
+    transform 220ms cubic-bezier(.2, .8, .2, 1);
+}
+.ba-side-newdeck-input {
+  caret-color: var(--rf-accent, #6c8cff);
+  color: var(--rf-ink);
+}
+.ba-side-newdeck-input::placeholder {
+  color: var(--rf-ink-faint);
+  font-style: italic;
+}
+/* Idle: label visible, input tucked. */
+.ba-side-newdeck[data-state="idle"] .ba-side-newdeck-input {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-4px);
+}
+.ba-side-newdeck[data-state="idle"] .ba-side-newdeck-label {
+  opacity: 1;
+  transform: translateX(0);
+}
+/* Active: input visible, label tucked. The icon warms to the accent so
+   the row reads as "alive" without resizing. */
+.ba-side-newdeck[data-state="active"] {
+  background: var(--rf-row-hover);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-label {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(4px);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-input {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-icon {
+  color: var(--rf-accent, #6c8cff);
+  transform: rotate(0deg) scale(1.08);
+  transition: color 220ms ease, transform 220ms cubic-bezier(.2, .8, .2, 1);
+}
+.ba-side-newdeck .ba-side-icon {
+  transition: color 220ms ease, transform 220ms cubic-bezier(.2, .8, .2, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-side-newdeck-label,
+  .ba-side-newdeck-input,
+  .ba-side-newdeck .ba-side-icon {
+    transition: none;
+  }
+}
+
 /* ---------------------------- SYNC ----------------------------
    Three states the sidebar reflects:
    • pending  — local changes to push; soft accent dot, slow breathe

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -50,6 +50,84 @@
     return b;
   }
 
+  // Morphing "New deck" row. Idle: looks like any sidebar action row. Active:
+  // the label swaps for an inline input — Enter creates, Esc/blur cancels.
+  // The icon column anchors the transition so nothing jumps. We hold the open
+  // state on the wrapper element and toggle a single `data-state` so all
+  // transitions are CSS-driven.
+  function makeNewDeckRow() {
+    var row = document.createElement("div");
+    row.className = "ba-side-item ba-side-act ba-side-newdeck";
+    row.setAttribute("data-cmd", "create");
+    row.setAttribute("data-state", "idle");
+    // Label + input share a single flex slot so they overlap in place;
+    // CSS fades one in as the other fades out — no layout shift.
+    row.innerHTML =
+      iconSVG("create") +
+      '<span class="ba-side-newdeck-swap">' +
+        '<span class="ba-side-newdeck-label">New deck</span>' +
+        '<input type="text" class="ba-side-newdeck-input" autocomplete="off" ' +
+          'spellcheck="false" placeholder="Name a deck…" tabindex="-1" />' +
+      '</span>';
+
+    var input = row.querySelector(".ba-side-newdeck-input");
+
+    function open() {
+      if (row.getAttribute("data-state") === "active") { input.focus(); return; }
+      row.setAttribute("data-state", "active");
+      input.removeAttribute("tabindex");
+      // Defer focus one frame so the layout swap finishes before the caret
+      // is placed — otherwise the input can scroll its parent.
+      requestAnimationFrame(function () { input.focus(); });
+    }
+    function close() {
+      row.setAttribute("data-state", "idle");
+      input.setAttribute("tabindex", "-1");
+      input.value = "";
+    }
+    function submit() {
+      var name = input.value.trim();
+      if (!name) { close(); return; }
+      send("create:" + name);
+      // The Python handler calls mw.reset(); the deck list will refresh.
+      close();
+    }
+
+    // Click on the row (outside the input) opens it.
+    row.addEventListener("click", function (e) {
+      if (row.getAttribute("data-state") === "active") return;
+      e.preventDefault();
+      open();
+    });
+    // Keyboard activation when the row itself is focused (idle state).
+    row.tabIndex = 0;
+    row.addEventListener("keydown", function (e) {
+      if (row.getAttribute("data-state") === "idle" &&
+          (e.key === "Enter" || e.key === " ")) {
+        e.preventDefault();
+        open();
+      }
+    });
+
+    input.addEventListener("click", function (e) { e.stopPropagation(); });
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") { e.preventDefault(); submit(); }
+      else if (e.key === "Escape") { e.preventDefault(); close(); }
+    });
+    input.addEventListener("blur", function () {
+      // Defer so other in-flight handlers (e.g. our own submit) run first.
+      setTimeout(function () {
+        if (document.activeElement !== input) close();
+      }, 80);
+    });
+
+    // Public hook used by the Python handler when "ba:create" comes from a
+    // keyboard shortcut or external trigger.
+    window.__baFocusNewDeck = open;
+
+    return row;
+  }
+
   function build() {
     var aside = document.createElement("aside");
     aside.className = "ba-side";
@@ -112,10 +190,8 @@
     // Quick actions
     var quick = document.createElement("div");
     quick.className = "ba-side-quick";
-    [
-      { cmd: "create", label: "New deck",    cls: "ba-side-act" },
-      { cmd: "import", label: "Import file", cls: "ba-side-act" },
-    ].forEach(function (it) { quick.appendChild(makeRow(it)); });
+    quick.appendChild(makeNewDeckRow());
+    quick.appendChild(makeRow({ cmd: "import", label: "Import file", cls: "ba-side-act" }));
     aside.appendChild(quick);
 
     // Streak + lifetime stats moved out of the sidebar and into the


### PR DESCRIPTION
## Summary
- The sidebar's "New deck" action now expands in place into a text input — same row, same icon, label cross-fades for the input. Enter creates the deck via `mw.col.decks.id(name, create=True)` + `mw.reset()`; Esc/blur reverts. No modal, no extra row in the deck table — the sidebar is the sole entry point.
- Plumbing: new `pycmd` handlers (`ba:create` → focus inline UI, `ba:create:<name>` → create, `ba:create-fallback` → native dialog) and a JS hook `window.__baFocusNewDeck` for external triggers.
- Tag-along dev-tooling fixes: `_dev_screenshot` no longer steals focus, `_dev_dump` pins to `mw.web` instead of the toolbar webview, plus `reload_page`/`decks_list`/`create_test:` helpers in `_dev_run_cmd`.

## Test plan
- [ ] \`make demo-stop && make demo\` (or \`make dev && make run\`) to launch this worktree's Anki.
- [ ] Click sidebar **New deck** — label/input cross-fade, icon glows accent, row hover-tint appears.
- [ ] Type a name + Enter — deck appears in the list; sidebar returns to idle.
- [ ] Esc and click-outside both cancel without creating a deck.
- [ ] Keyboard: Tab to the row, Enter/Space opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)