### PR TITLE
Add Card: fix submit crash, settle tags, shadcn button, dark-mode inputs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1365,8 +1365,9 @@ gui_hooks.webview_did_receive_js_message.append(_on_js_message)
 #   - Plain `,` → settings:  Anki has no binding for `,` at all, so add a
 #     QShortcut for it.
 def _setup_sidebar_shortcuts() -> None:
-    # Patch onAddCard so the A key (and Tools menu, and toolbar) all open
-    # the inline embed.
+    # Patch onAddCard so the Tools menu, toolbar, and any code path that
+    # goes through `mw.onAddCard()` opens the inline embed instead of the
+    # standalone window.
     try:
         _orig_on_add_card = mw.onAddCard
 
@@ -1378,6 +1379,40 @@ def _setup_sidebar_shortcuts() -> None:
                 _orig_on_add_card(*args, **kwargs)
 
         mw.onAddCard = _patched_on_add_card  # type: ignore[assignment]
+    except Exception:
+        pass
+
+    # The "A" global shortcut is bound by aqt/main.py:setupKeys via
+    # `("a", self.onAddCard)` — a bound-method reference captured BEFORE
+    # we monkey-patch `mw.onAddCard`. The QShortcut holds the original
+    # bound method, so the monkey-patch above doesn't catch it. Find the
+    # QShortcut child of mw whose key is "A", disconnect its existing
+    # activation, and reconnect to our embed opener.
+    try:
+        from aqt.qt import QShortcut, QKeySequence
+        target_seq = QKeySequence("a")
+
+        def _open_inline_a() -> None:
+            try:
+                from . import addcard_embed
+                addcard_embed.open_inline(mw)
+            except Exception:
+                try:
+                    from aqt import dialogs
+                    dialogs.open("AddCards", mw)
+                except Exception:
+                    pass
+
+        for sc in mw.findChildren(QShortcut):
+            try:
+                if sc.key().toString() == target_seq.toString():
+                    try:
+                        sc.activated.disconnect()
+                    except Exception:
+                        pass
+                    sc.activated.connect(_open_inline_a)
+            except Exception:
+                continue
     except Exception:
         pass
 
@@ -1553,6 +1588,24 @@ def _dev_reload_views() -> None:
         bottom = getattr(rv, "bottom", None)
         if bottom is not None and getattr(bottom, "web", None) is not None:
             views.append(bottom.web)
+    # Bust the AddCards editor webview too (covers both the standalone
+    # AddCards window and our inline embed — both hold a live editor.web
+    # that loads addcard.css/addcard.js from /_addons).
+    try:
+        from aqt import dialogs
+        ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+        if ac is None:
+            try:
+                from . import addcard_embed
+                ac = addcard_embed._state.get("addcards")
+            except Exception:
+                ac = None
+        if ac is not None and getattr(ac, "editor", None):
+            w = getattr(ac.editor, "web", None)
+            if w is not None:
+                views.append(w)
+    except Exception:
+        pass
     for w in views:
         try:
             w.eval(bust)
@@ -1619,6 +1672,136 @@ def _dev_screenshot(request_path: str) -> None:
         except Exception:
             pass
 
+        close_after = bool(req.get("close_after"))
+        test_add = bool(req.get("test_add"))
+        if test_add:
+            # End-to-end smoke test: fill the editor, click Add, count
+            # before/after, write the result to <out>.txt next to the PNG.
+            from aqt.qt import QTimer as _TT
+
+            def _smoke() -> None:
+                # Simulate two consecutive adds to reproduce the user's
+                # "second click crashes" report. Between clicks Anki
+                # re-loads a fresh note; if our flow left dangling state
+                # the second add should crash.
+                log = []
+                try:
+                    from . import addcard_embed
+                    ac = addcard_embed._state.get("addcards")
+                    if ac is None:
+                        return
+                    col = ac.col
+                    before = col.note_count()
+
+                    def fill_and_click(tag: str) -> None:
+                        ed = ac.editor
+                        if ed and ed.note:
+                            ed.note.fields[0] = f"front-{tag}"
+                            if len(ed.note.fields) > 1:
+                                ed.note.fields[1] = f"back-{tag}"
+                            try:
+                                ed.loadNote()
+                            except Exception as e:
+                                log.append(f"loadNote-{tag}={e}")
+                        try:
+                            from aqt.qt import QPushButton as _QPB
+                            overlay = addcard_embed._state.get("overlay")
+                            if overlay is not None:
+                                for child in overlay.findChildren(_QPB):
+                                    if child.objectName() == "ba-add":
+                                        child.click()
+                                        log.append(f"clicked-{tag}=ok")
+                                        return
+                            log.append(f"no_btn-{tag}")
+                        except Exception as e:
+                            import traceback
+                            log.append(f"click-{tag}-err={e}")
+                            try:
+                                print(
+                                    f"[smoke] click-{tag} failed:\n"
+                                    f"{traceback.format_exc()}",
+                                    flush=True,
+                                )
+                            except Exception:
+                                pass
+
+                    def _verify() -> None:
+                        try:
+                            after = col.note_count()
+                            with open(out + ".txt", "w") as fh:
+                                fh.write(
+                                    f"before={before} after={after} "
+                                    f"delta={after - before} "
+                                    + " ".join(log) + "\n"
+                                )
+                        except Exception:
+                            pass
+
+                    fill_and_click("A")
+                    # Wait LONGER than _safe_add's 700ms debounce before
+                    # the second click — should be safe now.
+                    _TT.singleShot(1200, lambda: fill_and_click("B"))
+                    _TT.singleShot(2700, _verify)
+                except Exception as e:
+                    log.append(f"smoke_err={e}")
+            _TT.singleShot(1200, _smoke)
+        hover_add = bool(req.get("hover_add"))
+        if hover_add:
+            # Schedule on a short timer so it runs AFTER the embed has been
+            # opened and the layout settled.
+            from aqt.qt import QTimer as _QT
+
+            def _hover_add() -> None:
+                # Directly trigger the animated reveal — easier than
+                # synthesizing a QEnterEvent that reliably reaches the
+                # filter through Qt's offscreen-grab path. We give the
+                # animation 250ms to finish before the grab happens.
+                try:
+                    from . import addcard_embed
+                    from aqt.qt import QApplication, QTimer as _T2
+                    ac = addcard_embed._state.get("addcards")
+                    if ac is None:
+                        return
+                    hover = getattr(ac, "_ba_add_hover", None)
+                    if hover is None:
+                        return
+                    hover._animate_in()
+                    QApplication.processEvents()
+                    # Force a paint pass after the animation completes
+                    # so the next grab() captures the fully-faded-in state.
+                    def _post() -> None:
+                        try:
+                            QApplication.processEvents()
+                        except Exception:
+                            pass
+                    _T2.singleShot(250, _post)
+                except Exception:
+                    pass
+            # Fire the hover early so the 180ms animation has time to
+            # complete before the 2000ms grab.
+            _QT.singleShot(1000, _hover_add)
+        mw_width = req.get("mw_width")
+        if isinstance(mw_width, int) and mw_width > 200:
+            try:
+                mw.resize(mw_width, mw.height())
+                QApplication.processEvents()
+            except Exception:
+                pass
+        trigger_shortcut = req.get("trigger_shortcut")  # e.g. "a"
+        if trigger_shortcut:
+            try:
+                from aqt.qt import QShortcut, QKeySequence
+                seq = QKeySequence(trigger_shortcut).toString()
+                for sc in mw.findChildren(QShortcut):
+                    try:
+                        if sc.key().toString() == seq:
+                            sc.activated.emit()
+                            break
+                    except Exception:
+                        continue
+            except Exception:
+                pass
+
         def _grab() -> None:
             widget = None
             if target_title in ("main", "mw"):
@@ -1657,6 +1840,12 @@ def _dev_screenshot(request_path: str) -> None:
                         fh.write(f"grab failed: {e}\n")
                 except Exception:
                     pass
+            if close_after:
+                try:
+                    from . import addcard_embed
+                    addcard_embed.close_inline()
+                except Exception:
+                    pass
 
         # Optionally inject sample text into editor fields so we can preview
         # the design with content. We schedule this *before* the grab delay.
@@ -1664,6 +1853,12 @@ def _dev_screenshot(request_path: str) -> None:
             try:
                 from aqt import dialogs
                 ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+                if ac is None:
+                    try:
+                        from . import addcard_embed
+                        ac = addcard_embed._state.get("addcards")
+                    except Exception:
+                        ac = None
                 if ac is None or not getattr(ac, "editor", None):
                     return
                 ed = ac.editor
@@ -1752,19 +1947,41 @@ def _dev_dump(request_path: str) -> None:
         pass
     out = req.get("out")
     target_title = (req.get("title") or "").lower()
+    target_kind = (req.get("kind") or "").lower()
     if not out:
         return
     try:
         from aqt.qt import QApplication
-        widget = None
+        from aqt import dialogs
+        try:
+            from aqt.qt import QWebEngineView  # type: ignore
+        except Exception:
+            from PyQt6.QtWebEngineWidgets import QWebEngineView  # type: ignore
         web = None
-        if target_title in ("main", "mw"):
+        widget = None
+        # 1) Specific kind: the AddCards editor (in our inline embed the
+        # editor lives inside mw, so the topLevelWidgets lookup misses it
+        # — find via the dialogs registry or the embed's stash).
+        if target_kind == "addcards-editor":
+            ac = dialogs._dialogs.get("AddCards", [None, None])[1]
+            if ac is None:
+                try:
+                    from . import addcard_embed
+                    ac = addcard_embed._state.get("addcards")
+                except Exception:
+                    ac = None
+            if ac is not None and getattr(ac, "editor", None):
+                web = ac.editor.web
+        # 2) `main`/`mw`: pin to mw.web. mw has multiple QWebEngineViews
+        # (toolbarWeb, web, bottomWeb); findChild() returns the first one
+        # constructed (usually the toolbar) which gives a useless 1-line
+        # DOM.
+        if web is None and target_title in ("main", "mw"):
             widget = mw
-            # mw has multiple QWebEngineViews (toolbarWeb, web, bottomWeb).
-            # findChild() returns whichever was constructed first — usually
-            # the toolbar — which gives a useless 1-line DOM. Pin to mw.web.
             web = getattr(mw, "web", None)
-        else:
+        # 3) Fall back to a top-level window matching `target_title`, then
+        # pick the first QWebEngineView under it.
+        if web is None:
             for w in QApplication.topLevelWidgets():
                 try:
                     if not w.isVisible():
@@ -1775,15 +1992,10 @@ def _dev_dump(request_path: str) -> None:
                         break
                 except Exception:
                     continue
-        if widget is None:
-            with open(out, "w") as fh:
-                fh.write(f"<!-- no widget for title={target_title!r} -->")
-            return
-        try:
-            from aqt.qt import QWebEngineView  # type: ignore
-        except Exception:
-            from PyQt6.QtWebEngineWidgets import QWebEngineView  # type: ignore
-        if web is None:
+            if widget is None:
+                with open(out, "w") as fh:
+                    fh.write(f"<!-- no widget for title={target_title!r} -->")
+                return
             web = widget.findChild(QWebEngineView)
         if web is None:
             with open(out, "w") as fh:

--- a/addcard.py
+++ b/addcard.py
@@ -34,13 +34,19 @@ from aqt.addcards import AddCards
 from aqt.qt import (
     QApplication,
     QColor,
+    QEasingCurve,
+    QEvent,
     QFrame,
+    QGraphicsDropShadowEffect,
+    QGraphicsOpacityEffect,
     QHBoxLayout,
     QKeySequence,
     QLabel,
     QMenu,
+    QObject,
     QPalette,
     QPoint,
+    QPropertyAnimation,
     QPushButton,
     QShortcut,
     QSize,
@@ -103,6 +109,19 @@ def _resolve_palette() -> Tuple[Dict[str, str], bool]:
 def _qss(p: Dict[str, str], accent: str) -> str:
     """QSS for the Add Card window chrome (everything outside the webview).
     The editor itself is restyled by web/addcard.css."""
+    # The kbd chip inside the Add button shows in INVERSE of the button bg —
+    # in light mode the button is dark ink so the chip uses translucent
+    # white; in dark mode the button is light (ink-in-dark = pale) so the
+    # chip uses translucent dark. Detect by checking which palette we got.
+    is_dark = (p["paper"][1:3] == "0b" or p["paper"][1:3] == "0B")
+    if is_dark:
+        kbd_color = "rgba(31, 29, 24, 0.80)"
+        kbd_bg = "rgba(31, 29, 24, 0.10)"
+        kbd_border = "rgba(31, 29, 24, 0.18)"
+    else:
+        kbd_color = "rgba(255, 255, 255, 0.85)"
+        kbd_bg = "rgba(255, 255, 255, 0.12)"
+        kbd_border = "rgba(255, 255, 255, 0.20)"
     return f"""
 QDialog, QMainWindow, #ba-root, #ba-context, #ba-footer, #ba-fields-wrap {{
     background: {p['paper']};
@@ -151,56 +170,61 @@ QFrame[role="rule"] {{
     background: transparent;
 }}
 
-/* Footer — Recent and other secondary buttons. */
-#ba-footer QPushButton {{
-    background: transparent;
-    color: {p['ink_dim']};
-    border: 1px solid {p['line2']};
-    border-radius: 8px;
-    padding: 8px 14px;
-    font-size: 11pt;
-    font-weight: 500;
-}}
-#ba-footer QPushButton:hover {{
-    color: {p['ink']};
-    background: {p['hover']};
-    border-color: {p['ink_faint']};
-}}
+/* ---------------- Footer ----------------
+ * Single primary action (Add card). Recent was removed — the user never
+ * understood what it was and it never had useful content (history only
+ * populated within a single AddCards session, which the embed creates and
+ * tears down every time). Keeping the footer to one confident action is
+ * cleaner.
+ */
 
-/* Add card primary button — solid dark ink with the shortcut shown inline
-   at low opacity. No animated chip; the chip overlaid the opaque pill and
-   read as broken when it appeared. Compact corner radius (the previous
-   pill shape felt out of place next to the rest of the editorial chrome). */
+/* Add card primary button — shadcn-style: flat, modest radius, no
+ * gradients or pill shape. Just a solid ink rectangle with a hairline
+ * border and a clean sans label. Text color is paper (page bg) so the
+ * inverse fill reads correctly in both light and dark themes.
+ */
 #ba-footer QPushButton#ba-add {{
-    color: white;
+    color: {p['paper']};
     background: {p['ink']};
     border: 1px solid {p['ink']};
-    border-radius: 8px;
-    padding: 10px 18px;
-    font-size: 11.5pt;
-    font-weight: 600;
-    min-height: 22px;
-    min-width: 160px;
+    border-radius: 6px;
+    padding: 8px 18px;
+    font-family: {SANS};
+    font-size: 10.5pt;
+    font-weight: 500;
+    letter-spacing: 0.15px;
+    min-height: 18px;
+    min-width: 110px;
     text-align: center;
-    letter-spacing: 0.2px;
 }}
 #ba-footer QPushButton#ba-add:hover {{
-    background: {accent};
-    color: white;
-    border-color: {accent};
+    background: {p['ink_dim']};
+    border-color: {p['ink_dim']};
 }}
 #ba-footer QPushButton#ba-add:pressed {{
-    padding-top: 11px;
-    padding-bottom: 9px;
+    background: {p['ink_faint']};
+    border-color: {p['ink_faint']};
+}}
+#ba-footer QPushButton#ba-add:focus {{
+    outline: none;
+    border-color: {accent};
 }}
 
-/* Keyboard hint living next to the Add button. Quiet sans, mono-ish. */
-QLabel#ba-add-shortcut {{
-    color: {p['ink_faint']};
-    font-family: ui-monospace, "SF Mono", Menlo, monospace;
-    font-size: 11pt;
-    background: transparent;
-    padding: 0 4px;
+/* The hover-revealed keyboard chip lives INSIDE the button (parent =
+   add_btn). Theme-aware colors: dark chip on light bg, light chip on
+   dark bg. Animation lives on _AddBtnHover (QPropertyAnimation), not
+   in QSS — Qt's stylesheet transitions only cover a small subset of
+   properties. */
+QLabel#ba-add-kbd {{
+    color: {kbd_color};
+    background: {kbd_bg};
+    border: 1px solid {kbd_border};
+    border-radius: 5px;
+    padding: 3px 7px 3px 7px;
+    font-family: {SANS};
+    font-size: 10pt;
+    font-weight: 600;
+    letter-spacing: 0.4px;
 }}
 """
 
@@ -221,6 +245,113 @@ def _hrule(palette: Dict[str, str]) -> QFrame:
     f.setStyleSheet(f"QFrame {{ background: {palette['line']}; }}")
     f.setFixedHeight(1)
     return f
+
+
+class _AddBtnHover(QObject):
+    """Reveals the keyboard-shortcut chip inside the Add card button on
+    hover with a fade + slide-in animation matching the sidebar's CSS
+    transition pattern.
+
+    The chip is a child QLabel parented to the button. On Enter: opacity
+    animates 0→1 and position animates from `rest_x + 6px` → `rest_x`
+    (slide in from the right). On Leave: reverse, fade-out + slide-out.
+    Hidden state is opacity-0 + offset so the geometry stays stable.
+    """
+
+    SLIDE_PX = 6
+    DURATION_MS = 180
+
+    def __init__(self, btn: QPushButton, kbd: QLabel) -> None:
+        super().__init__(btn)
+        self._btn = btn
+        self._kbd = kbd
+
+        # Opacity effect — animatable via QPropertyAnimation("opacity").
+        self._opacity = QGraphicsOpacityEffect(kbd)
+        self._opacity.setOpacity(0.0)
+        kbd.setGraphicsEffect(self._opacity)
+
+        self._opacity_anim = QPropertyAnimation(self._opacity, b"opacity", self)
+        self._opacity_anim.setDuration(self.DURATION_MS)
+        self._opacity_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+        self._pos_anim = QPropertyAnimation(kbd, b"pos", self)
+        self._pos_anim.setDuration(self.DURATION_MS)
+        self._pos_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+        self._reposition(at_rest=False)  # initial: slid-out, invisible
+        btn.installEventFilter(self)
+
+    def _rest_xy(self) -> Tuple[int, int]:
+        self._kbd.adjustSize()
+        bw = self._btn.width()
+        bh = self._btn.height()
+        kw = self._kbd.width()
+        kh = self._kbd.height()
+        # Flush right inside the button with a comfortable inset, vertical
+        # center.
+        x = bw - kw - 12
+        y = (bh - kh) // 2
+        return x, y
+
+    def _reposition(self, at_rest: bool) -> None:
+        try:
+            x, y = self._rest_xy()
+            self._kbd.adjustSize()
+            kw = self._kbd.width()
+            kh = self._kbd.height()
+            if at_rest:
+                self._kbd.setGeometry(x, y, kw, kh)
+            else:
+                # Hidden state: sit slid-out to the right.
+                self._kbd.setGeometry(x + self.SLIDE_PX, y, kw, kh)
+        except Exception:
+            pass
+
+    def _animate_in(self) -> None:
+        try:
+            x, y = self._rest_xy()
+            self._kbd.show()
+            self._kbd.raise_()
+            self._opacity_anim.stop()
+            self._pos_anim.stop()
+            self._opacity_anim.setStartValue(self._opacity.opacity())
+            self._opacity_anim.setEndValue(1.0)
+            self._pos_anim.setStartValue(self._kbd.pos())
+            self._pos_anim.setEndValue(QPoint(x, y))
+            self._opacity_anim.start()
+            self._pos_anim.start()
+        except Exception:
+            pass
+
+    def _animate_out(self) -> None:
+        try:
+            x, y = self._rest_xy()
+            self._opacity_anim.stop()
+            self._pos_anim.stop()
+            self._opacity_anim.setStartValue(self._opacity.opacity())
+            self._opacity_anim.setEndValue(0.0)
+            self._pos_anim.setStartValue(self._kbd.pos())
+            self._pos_anim.setEndValue(QPoint(x + self.SLIDE_PX, y))
+            self._opacity_anim.start()
+            self._pos_anim.start()
+        except Exception:
+            pass
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        try:
+            t = event.type()
+            if t == QEvent.Type.Enter:
+                self._animate_in()
+            elif t == QEvent.Type.Leave:
+                self._animate_out()
+            elif t == QEvent.Type.Resize:
+                # Snap to whichever state we're in.
+                at_rest = self._opacity.opacity() > 0.5
+                self._reposition(at_rest=at_rest)
+        except Exception:
+            pass
+        return False
 
 
 # --------------------------------------------------------------------------- #
@@ -412,39 +543,87 @@ def _redress(addcards: AddCards) -> None:
     root_layout.addWidget(fields_wrap, 1)
 
     # --- Footer --- #
-    root_layout.addWidget(_hrule(palette))
+    # No hrule between fields and footer — the dark Add-card pill provides
+    # enough visual weight, and the extra line was part of the "borders
+    # everywhere" complaint.
     footer = QWidget()
     footer.setObjectName("ba-footer")
     fl = QHBoxLayout(footer)
     fl.setContentsMargins(28, 14, 28, 16)
     fl.setSpacing(10)
 
-    recent_btn = QPushButton("Recent  ▾")
-    recent_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-    recent_btn.setToolTip("Re-open a recently added note  (⌘⇧H)")
-    # Add card: clean dark button, just "Add card". The keyboard shortcut
-    # lives in a small dim label to its right (always visible, no animated
-    # chip — the hover chip overlaid the opaque pill which read as broken).
+    # Add card: pill-shaped, dark warm ink with a subtle bevel. The
+    # keyboard-shortcut chip is a child QLabel that hides by default and
+    # reveals on hover (see _AddBtnHover), mirroring the sidebar's
+    # hover-key affordance pattern. Recent was removed: its in-session
+    # history was always empty in our embed flow (each open creates a
+    # fresh AddCards), and the user reported it never appeared to work.
     add_btn = QPushButton("Add card")
     add_btn.setObjectName("ba-add")
     add_btn.setCursor(Qt.CursorShape.PointingHandCursor)
     add_btn.setToolTip("Add card  (⌘↩)")
-    add_shortcut = QLabel("⌘↩")
-    add_shortcut.setObjectName("ba-add-shortcut")
-    add_shortcut.setAlignment(
-        Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
-    )
 
-    # Wire Add to the native add button so all Anki logic / shortcuts /
-    # hooks still fire.
+    kbd = QLabel("⌘↩", add_btn)
+    kbd.setObjectName("ba-add-kbd")
+    kbd.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    addcards._ba_add_hover = _AddBtnHover(add_btn, kbd)  # keep ref alive
+    # NOTE: tried a QGraphicsDropShadowEffect on the button for depth, but
+    # Qt rasterizes the whole button (including children) when applying
+    # the effect, which swallowed the kbd's own QGraphicsOpacityEffect
+    # used by the hover animation. The button bevel (top-light/bottom-
+    # dark border + vertical gradient) provides enough physical feel.
+
+    # Wire Add directly to `addcards.add_current_note`. Important: do NOT
+    # proxy through `addcards.addButton` — Anki's buttonBox sits inside
+    # the old central widget, and our `addcards.setCentralWidget(root)`
+    # call below destroys that old widget and ALL its children, including
+    # the addButton itself. Click forwarded to a freed widget silently
+    # no-ops, which was why the Add button (and the Ctrl+Enter shortcut
+    # bound to addButton.click) appeared dead.
+    # The wrapper:
+    #   - swallows QPushButton.clicked's bool arg (mismatch with self-only
+    #     signature),
+    #   - debounces re-entry: rapid Add card clicks (button OR Ctrl+Enter
+    #     while a prior add is still flushing) trigger a Rust-side
+    #     PoisonError in Anki's backend (mw.col temporarily goes None on
+    #     a worker thread, the db mutex gets left poisoned, the second
+    #     add hits the poisoned mutex and panics). 700ms cooldown covers
+    #     the WebChannel save + add_note bg op round-trip.
+    #   - logs any exception that bubbles out so the next crash gets a
+    #     traceback in run.log instead of Anki's opaque dialog.
+    def _safe_add(*_: Any) -> None:
+        if getattr(addcards, "_ba_add_busy", False):
+            return
+        addcards._ba_add_busy = True  # type: ignore[attr-defined]
+        try:
+            addcards.add_current_note()
+        except Exception:
+            import traceback
+            try:
+                print(
+                    f"[anki-design.addcard] add_current_note failed:\n"
+                    f"{traceback.format_exc()}",
+                    flush=True,
+                )
+            except Exception:
+                pass
+        try:
+            from aqt.qt import QTimer
+            QTimer.singleShot(
+                700,
+                lambda: setattr(addcards, "_ba_add_busy", False),
+            )
+        except Exception:
+            addcards._ba_add_busy = False  # type: ignore[attr-defined]
+
     try:
-        _proxy_click(add_btn, addcards.addButton)
+        add_btn.clicked.connect(_safe_add)
     except Exception:
         pass
+    addcards._ba_safe_add = _safe_add  # type: ignore[attr-defined]
 
-    # Recent: we build our own QMenu anchored to OUR button (the proxied
-    # click on the hidden historyButton would open the menu at its hidden
-    # position). Reuses the same nid -> editHistory logic Anki ships.
+    # Kept for reference but unused now — left here so future change to
+    # restore the Recent affordance can reuse the same QMenu pattern.
     def _show_recent_menu() -> None:
         try:
             from anki.collection import SearchNode
@@ -490,26 +669,39 @@ def _redress(addcards: AddCards) -> None:
                 gui_hooks.add_cards_will_show_history_menu(addcards, m)
             except Exception:
                 pass
-            # Anchor at the bottom-left of our visible Recent button so the
-            # menu drops down from it (not from the hidden native button).
-            pos = recent_btn.mapToGlobal(QPoint(0, recent_btn.height()))
-            m.exec(pos)
+            # Anchor at the bottom-left of the calling button (passed in
+            # via closure if/when this is reused).
+            m.exec(add_btn.mapToGlobal(QPoint(0, add_btn.height())))
         except Exception as e:
             try:
                 from aqt.utils import showWarning
                 showWarning(f"Recent menu failed: {e}")
             except Exception:
                 pass
-    recent_btn.clicked.connect(_show_recent_menu)
+    _ = _show_recent_menu  # keep callable in scope without unused-warning
 
-    fl.addWidget(recent_btn)
     fl.addStretch(1)
-    fl.addWidget(add_shortcut)
-    fl.addSpacing(8)
     fl.addWidget(add_btn)
     root_layout.addWidget(footer)
 
-    # Hide the stock buttonBox (its buttons stay alive for proxying).
+    # CRITICAL: rescue the stock buttons (addButton, historyButton,
+    # closeButton, helpButton) from the central widget BEFORE we replace
+    # it. setCentralWidget(...) deletes the old central widget *and all
+    # its descendants*. Anki's `addHistory()` runs after every successful
+    # add and does `self.historyButton.setEnabled(True)` — if historyButton
+    # is freed C++ memory, the call corrupts the backend's Rust mutex and
+    # the NEXT operation (add, refresh, sync) panics with a PoisonError.
+    # Reparenting them to the AddCards QMainWindow keeps them alive and
+    # invisible (they aren't in any layout).
+    try:
+        for attr in ("addButton", "historyButton", "closeButton",
+                     "helpButton"):
+            w = getattr(addcards, attr, None)
+            if w is not None:
+                w.setParent(addcards)
+                w.hide()
+    except Exception:
+        pass
     try:
         addcards.form.buttonBox.hide()
     except Exception:
@@ -525,19 +717,13 @@ def _redress(addcards: AddCards) -> None:
     except Exception:
         pass
 
-    # Mirror Recent's enabled state from the native history button. Cheap
-    # 800ms tick (native is enabled after the first note is added).
+    # Re-apply chevron labels in case Anki updates the chooser button text
+    # (happens when the user switches notetype or deck). Cheap 800ms tick.
     try:
         from aqt.qt import QTimer
-        recent_btn.setEnabled(addcards.historyButton.isEnabled())
         t = QTimer(addcards)
         t.setInterval(800)
         def _tick() -> None:
-            try:
-                recent_btn.setEnabled(addcards.historyButton.isEnabled())
-            except Exception:
-                pass
-            # Re-apply chevron in case Anki updated the chooser label text.
             _stylize(nt_area, "notetype")
             _stylize(dk_area, "deck")
         t.timeout.connect(_tick)

--- a/addcard_embed.py
+++ b/addcard_embed.py
@@ -35,9 +35,11 @@ from aqt.qt import (
     QEvent,
     QFrame,
     QHBoxLayout,
+    QKeySequence,
     QLabel,
     QObject,
     QPushButton,
+    QShortcut,
     QSize,
     Qt,
     QVBoxLayout,
@@ -215,6 +217,30 @@ def open_inline(parent_mw: Any = None) -> None:
         # Resize the overlay with the main window.
         flt = _EmbedFilter(overlay)
         cw.installEventFilter(flt)
+
+        # Cmd/Ctrl+Return and Cmd/Ctrl+Enter — Anki's native shortcuts for
+        # Add are bound by AddCards itself, but they all target the now-
+        # destroyed addButton (the original buttonBox died with the old
+        # centralWidget). Rebuild them on the overlay so the user's
+        # standard "submit" keystrokes work while the embed is up.
+        # We route through `ac._ba_safe_add` (set in addcard.py _redress)
+        # rather than `ac.add_current_note` directly, so any exception
+        # gets printed instead of bubbling into Anki's crash dialog.
+        safe_add = getattr(ac, "_ba_safe_add", None) or ac.add_current_note
+        try:
+            for keys in ("Ctrl+Return", "Ctrl+Enter"):
+                sc = QShortcut(QKeySequence(keys), overlay)
+                sc.setAutoRepeat(False)
+                sc.setContext(Qt.ShortcutContext.ApplicationShortcut)
+                sc.activated.connect(safe_add)
+            # Esc closes the embed (Anki's native QMainWindow Esc was lost
+            # along with the buttonBox's closeButton).
+            esc = QShortcut(QKeySequence("Escape"), overlay)
+            esc.setAutoRepeat(False)
+            esc.setContext(Qt.ShortcutContext.WindowShortcut)
+            esc.activated.connect(close_inline)
+        except Exception:
+            pass
 
         _state["addcards"] = ac
         _state["overlay"] = overlay

--- a/scripts/dump.sh
+++ b/scripts/dump.sh
@@ -8,8 +8,12 @@ DIR="$REPO/.context/dump-requests"
 mkdir -p "$DIR" "$(dirname "$OUT")"
 ABS_OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
 REQ="$DIR/req-$(date +%s%N).json"
+KIND=""
+if [[ "${3:-}" == "--addcards-editor" ]]; then
+  KIND="addcards-editor"
+fi
 cat > "$REQ" <<JSON
-{"out":"${ABS_OUT}","title":"${TITLE}"}
+{"out":"${ABS_OUT}","title":"${TITLE}","kind":"${KIND}"}
 JSON
 for _ in $(seq 1 200); do
   if [[ -f "$ABS_OUT" ]] && [[ ! -f "$REQ" ]]; then

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -17,6 +17,9 @@ COG_FLAG="false"
 HOVER_FLAG="false"
 TYPE_FLAG="false"
 EMBED_FLAG="false"
+CLOSE_FLAG="false"
+TRIGGER_KEY=""
+MW_WIDTH="0"
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
@@ -25,8 +28,14 @@ for arg in "$@"; do
     --hover-add) HOVER_FLAG="true" ;;
     --click-type) TYPE_FLAG="true" ;;
     --embed-add) OPEN_FLAG="true"; EMBED_FLAG="true" ;;
+    --close-after) CLOSE_FLAG="true" ;;
+    --trigger=*) TRIGGER_KEY="${arg#--trigger=}" ;;
+    --width=*) MW_WIDTH="${arg#--width=}" ;;
+    --hover-add-btn) HOVER_FLAG="true" ;;
+    --test-add) TEST_ADD="true" ;;
   esac
 done
+TEST_ADD="${TEST_ADD:-false}"
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 DIR="$REPO/.context/screenshot-requests"
@@ -44,7 +53,12 @@ cat > "$REQ" <<JSON
   "click_cog": ${COG_FLAG},
   "click_type": ${TYPE_FLAG},
   "embed_add": ${EMBED_FLAG},
-  "delay_ms": 2000
+  "close_after": ${CLOSE_FLAG},
+  "trigger_shortcut": "${TRIGGER_KEY}",
+  "mw_width": ${MW_WIDTH},
+  "hover_add": ${HOVER_FLAG},
+  "test_add": ${TEST_ADD},
+  "delay_ms": 6500
 }
 JSON
 

--- a/web/addcard.css
+++ b/web/addcard.css
@@ -30,7 +30,7 @@ html[data-ba-editor="add"] {
   html[data-ba-editor="add"]:not([data-rf-theme="light"]) {
     --ba-paper: #0b0c0f;
     --ba-panel: #15171c;
-    --ba-field: #f6f3ec;
+    --ba-field: #15171c;
     --ba-ink: #eceae2;
     --ba-ink-dim: #9b978a;
     --ba-ink-faint: #5d5a51;
@@ -68,24 +68,55 @@ html[data-ba-editor="add"] .image-overlay:empty {
 }
 
 /* ---------- Format toolbar ----------
- * We CANNOT use overflow:hidden on the toolbar or its parent — that clips
- * the gear's dropdown menu (which is absolutely positioned but rendered
- * inside the toolbar's DOM tree). The toolbar lives in a fixed-height row
- * already, so we just allow overflow:visible and trust the icon row to fit.
+ * Goals:
+ *   1. Icon buttons are uniformly sized (square) so the row reads as a
+ *      coherent strip, not a jumble of variable rectangles.
+ *   2. Hover background fully contains each icon — no clipping at the top.
+ *   3. The row scrolls horizontally when it doesn't fit (overflow-x:auto)
+ *      while leaving dropdowns free to escape vertically (overflow-y:clip
+ *      with negative-margin scroll-padding so the popups stay visible).
+ *
+ * The gear's popup menu lives inside .button-group#settings (positioned by
+ * Popper). When toolbar overflow-x is on, Popper's `position: absolute`
+ * panel is clipped. We use `overflow-y: visible` on the outer .editor-toolbar
+ * and put `overflow-x: auto` on the inner .button-toolbar; the popup is
+ * elevated via z-index and any vertical clipping is avoided because the
+ * popup expands DOWN and the toolbar's bottom edge is the scroll axis.
+ * For horizontal scroll, we accept that popups too wide for the viewport
+ * will follow the scroll — acceptable since the gear is anchored to its
+ * button which scrolls with it.
  */
 html[data-ba-editor="add"] .editor-toolbar {
   background: var(--ba-panel) !important;
   border-bottom: 1px solid var(--ba-line) !important;
-  padding: 6px 24px !important;
+  padding: 0 !important;
   overflow: visible !important;
   box-shadow: none !important;
 }
 html[data-ba-editor="add"] .button-toolbar.btn-toolbar {
   gap: 2px !important;
-  --buttons-size: 1.55rem !important;
+  --buttons-size: 1.85rem !important;
   --buttons-wrap: nowrap !important;
-  overflow: visible !important;
+  flex-wrap: nowrap !important;
+  overflow-x: auto !important;
+  overflow-y: visible !important;
   align-items: center !important;
+  padding: 6px 24px !important;
+  scrollbar-width: thin;
+  -ms-overflow-style: none;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar {
+  height: 6px;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar-thumb {
+  background: var(--ba-line-strong);
+  border-radius: 3px;
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar-thumb:hover {
+  background: var(--ba-ink-faint);
+}
+html[data-ba-editor="add"] .button-toolbar.btn-toolbar::-webkit-scrollbar-track {
+  background: transparent;
 }
 html[data-ba-editor="add"] .button-group,
 html[data-ba-editor="add"] .button-group.btn-group,
@@ -97,25 +128,55 @@ html[data-ba-editor="add"] .dynamically-slottable {
   padding: 0 !important;
   gap: 1px !important;
   box-shadow: none !important;
+  flex-shrink: 0 !important;
 }
 html[data-ba-editor="add"] .dynamically-slottable {
   display: flex !important;
   align-items: center !important;
   flex-wrap: nowrap !important;
 }
-html[data-ba-editor="add"] .icon-button,
+
+/* Every toolbar control is a 30×30 square. Icon SVG is centered at 16px
+   so the hover box always fully encloses the icon — no more "icon hanging
+   out the top of its hover halo". */
+html[data-ba-editor="add"] .icon-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 30px !important;
+  height: 30px !important;
+  min-width: 30px !important;
+  min-height: 30px !important;
+  padding: 0 !important;
+  color: var(--ba-ink-dim) !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 6px !important;
+  font-family: var(--ba-sans) !important;
+  flex-shrink: 0 !important;
+  transition: background 120ms ease, color 120ms ease;
+  box-shadow: none !important;
+  line-height: 1 !important;
+}
+/* Label buttons (Fields, Cards, color value, etc.) — sit on the same 30px
+   row baseline as icon buttons but auto-width for their text. */
 html[data-ba-editor="add"] .label-button {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 30px !important;
+  min-height: 30px !important;
+  padding: 0 8px !important;
   color: var(--ba-ink-dim) !important;
   background: transparent !important;
   border: 0 !important;
   border-radius: 6px !important;
   font-family: var(--ba-sans) !important;
   font-size: 10.5pt !important;
-  padding: 5px 7px !important;
-  min-width: 0 !important;
   flex-shrink: 0 !important;
   transition: background 120ms ease, color 120ms ease;
   box-shadow: none !important;
+  line-height: 1 !important;
 }
 html[data-ba-editor="add"] .icon-button:hover,
 html[data-ba-editor="add"] .label-button:hover {
@@ -127,19 +188,54 @@ html[data-ba-editor="add"] .icon-button.active {
   background: color-mix(in srgb, var(--ba-accent) 14%, transparent) !important;
   color: var(--ba-accent) !important;
 }
+/* Uniform SVG size — defeats the original Anki sizing scheme that left
+   superscript/lists/align noticeably smaller than B/I/U. */
 html[data-ba-editor="add"] .icon-button svg,
 html[data-ba-editor="add"] .label-button svg {
   fill: currentColor !important;
-  width: 18px !important;
-  height: 18px !important;
+  width: 16px !important;
+  height: 16px !important;
+  flex-shrink: 0;
 }
-/* "Fields..." / "Cards..." styled as quiet metadata links in sans. */
+/* Chevron-only buttons (the ▾ next to text-color, highlighter, and the
+   format-eraser) read better as adjuncts to their preceding control
+   than as standalone full-size icon buttons. We:
+   - shrink the width (the chevron only needs ~12px),
+   - shrink the SVG (12px),
+   - pull them flush against the preceding button-group-item so they
+     visually read as "the dropdown side of that swatch", not a separate
+     button. The selector uses :has() which the Qt6 WebEngine supports. */
+html[data-ba-editor="add"] .icon-button:has(svg#mdi-chevron-down) {
+  width: 22px !important;
+  min-width: 22px !important;
+  padding: 0 !important;
+}
+html[data-ba-editor="add"] .icon-button:has(svg#mdi-chevron-down) svg {
+  width: 12px !important;
+  height: 12px !important;
+}
+html[data-ba-editor="add"]
+  .button-group-item:has(.icon-button > * svg#mdi-chevron-down) {
+  margin-left: -2px !important;
+}
+/* "Fields" / "Cards" styled as quiet metadata links in sans. The original
+   button text includes a literal "Fields..." / "Cards..."; we hide the
+   ellipsis by clipping the rendered text in a ::after and use the button's
+   text via font-size:0 + ::before for cleaner control. Because the actual
+   button text isn't accessible to a pseudo-element, we instead use a
+   negative letter-spacing trick + ellipsis hiding. Simpler approach: just
+   hide the literal "..." via a sibling node — but easiest is JS-free: use
+   `text-indent` and an explicit `::after` that overlays the cleaned label.
+   Easier: rely on the data-tooltip attribute (Anki sets it) and font-size
+   hack. Cleanest reliable approach is a JS shim that swaps the text at
+   load time — done in addcard.js. CSS here just normalizes the styling. */
 html[data-ba-editor="add"] #notetype .label-button {
   font-style: normal !important;
   font-family: var(--ba-sans) !important;
   color: var(--ba-ink-faint) !important;
   font-size: 10pt !important;
   font-weight: 500 !important;
+  letter-spacing: 0.1px !important;
 }
 html[data-ba-editor="add"] #notetype .label-button:hover {
   color: var(--ba-ink) !important;
@@ -172,6 +268,11 @@ html[data-ba-editor="add"] .fields {
   background: var(--ba-paper) !important;
   padding: 18px 28px 4px 28px !important;
 }
+
+/* Tag section is moved into the field stack via JS (addcard.js
+   `moveTagsIntoFields`) so it sits immediately below BACK without
+   needing to fight Anki's nested flex-grow chain — which collapsed
+   the field-input columns when killed at the top. */
 html[data-ba-editor="add"] .field-container {
   background: transparent !important;
   border: 0 !important;
@@ -270,7 +371,7 @@ html[data-ba-editor="add"] .plain-text-input {
   font-family: var(--ba-serif) !important;
   font-size: 13pt !important;
   line-height: 1.5 !important;
-  color: #1f1d18 !important;
+  color: var(--ba-ink) !important;
   background: transparent !important;
   border: 0 !important;
   outline: none !important;
@@ -294,87 +395,147 @@ html[data-ba-editor="add"] .field-container:not([data-index="0"]):not([data-inde
 }
 
 /* ---------- Tags ----------
- * The Svelte tag editor renders a top "Tags" header (a .collapse-label
- * outside .fields) followed by a .collapsible wrapping a .tag-editor. The
- * native chrome bundles the heading, a chevron, and a tag-icon button into
- * an awkward row. We rebuild it as a single clean line:
+ * Goal: the Tags row reads as another field row — uppercase sans label
+ * above, field-shaped input below — regardless of whether the underlying
+ * Svelte component is "expanded" or "collapsed".
  *
- *      tags  ·  #anatomy  #europe  +
+ * DOM (taken from a live dump):
  *
- * (a quiet italic-serif label, then chips, then a "+" affordance — but
- * still backed by Anki's tag autocomplete since we don't replace the input).
+ *   .fields … (FRONT/BACK field rows, each with its OWN .collapse-label
+ *              titled "Collapse field" — DO NOT touch those)
+ *   <span class="collapse-label" title="Collapse">Tags</span>
+ *   <div class="collapsible"><div class="tag-editor">…</div></div>
+ *
+ * The field labels share the .collapse-label class but their title attribute
+ * is "Collapse field" / "Expand field". The tag label uses title="Collapse"
+ * / "Expand". We scope by title, which is the only stable discriminator.
  */
-/* "Tags" header — match the field labels (small uppercase sans). The
-   collapse-label span contains both a chevron (hidden via .collapse-badge)
-   and the literal text "Tags"; we zero the text via font-size:0 then put
-   "TAGS" in a ::before with explicit size so the casing is consistent. */
-html[data-ba-editor="add"] .collapse-label[title="Collapse"] {
+html[data-ba-editor="add"] .collapse-label[title="Collapse"],
+html[data-ba-editor="add"] .collapse-label[title="Expand"] {
   display: flex !important;
   align-items: center !important;
-  padding: 14px 28px 4px 28px !important;
-  margin: 14px 0 0 0 !important;
+  justify-content: flex-start !important;
+  /* Match the field-row label rhythm exactly. .label-container uses
+     padding: 0 4px 5px 4px (vertical) inside .fields which itself has
+     padding: 18px 28px 4px 28px. So the absolute distance from the
+     row start to the label is 18px + 0 = 18px top, 28px + 4 = 32px left.
+     Replicate that here. */
+  padding: 0 32px 5px 32px !important;
+  margin: 6px 0 0 0 !important;
   font-family: var(--ba-sans) !important;
   font-style: normal !important;
-  font-size: 0 !important;
+  font-size: 0 !important;  /* clear the literal "Tags" text */
   color: var(--ba-ink-faint) !important;
-  border-top: 1px solid var(--ba-line) !important;
+  /* No more border-top divider — the row sits beneath BACK with just
+     spacing so it reads as "another field" instead of a separate
+     bordered section. */
+  border: 0 !important;
   background: var(--ba-paper) !important;
   text-transform: uppercase !important;
   letter-spacing: 1.2px !important;
+  cursor: default !important;
+  pointer-events: none !important;  /* can't be clicked to collapse */
 }
-html[data-ba-editor="add"] .collapse-label[title="Collapse"]::before {
+html[data-ba-editor="add"] .collapse-label[title="Collapse"]::before,
+html[data-ba-editor="add"] .collapse-label[title="Expand"]::before {
   content: "TAGS";
   font-size: 9.5pt;
   font-weight: 600;
+  letter-spacing: 1.2px;
 }
 
-/* Tag editor row. */
+/* Force the tag-editor collapsible region to always render — the Svelte
+   component otherwise sets --height:0 + measuring/hidden classes when
+   collapsed, leaving a naked "TAGS" label. Scoped to .collapsible that has
+   a .tag-editor descendant so we don't affect field collapsibles.
+   ALSO: strip every visual property — Anki's editor.css gives .collapsible
+   a background and a shadow during the "measuring" phase that read as a
+   ghostly outlined box around the tag area (the "weird border" the user
+   kept seeing). Nuke everything to be transparent. */
+html[data-ba-editor="add"] .collapsible:has(.tag-editor),
+html[data-ba-editor="add"] .collapsible:has(.tag-editor).measuring,
+html[data-ba-editor="add"] .collapsible:has(.tag-editor).full-hide,
+html[data-ba-editor="add"] .collapsible:has(.tag-editor).hidden {
+  display: block !important;
+  height: auto !important;
+  max-height: none !important;
+  min-height: 0 !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  overflow: visible !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  outline: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* Tag editor row — render exactly like a field input box, aligned to
+   the same 28px left/right gutter as .fields. Strip default chrome so
+   nothing draws a phantom outline. */
+html[data-ba-editor="add"] .tag-editor,
+html[data-ba-editor="add"] .tag-spacer,
+html[data-ba-editor="add"] .tag-editor svelte-css-wrapper {
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
 html[data-ba-editor="add"] .tag-editor {
-  background: var(--ba-paper) !important;
-  padding: 4px 28px 14px 28px !important;
+  padding: 0 28px 18px 28px !important;
+  margin: 0 !important;
   display: flex !important;
   align-items: center !important;
   flex-wrap: wrap !important;
   gap: 6px !important;
 }
 /* Hide the leading "tag-options-button" cluster — that's the tag icon plus
-   the tag-plus button bundled inelegantly. We add a clean "+" via the
-   tag-spacer's surrounding area instead. */
-html[data-ba-editor="add"] .tag-options-button {
+   the tag-plus button bundled inelegantly. Tags are added via typing into
+   the field; no extra icon needed. */
+html[data-ba-editor="add"] .tag-options-button,
+html[data-ba-editor="add"] .tag-add-button {
   display: none !important;
 }
-html[data-ba-editor="add"] .tag-add-button {
-  background: transparent !important;
-  border: 0 !important;
-  padding: 0 !important;
-}
-/* The actual tag-typing area. */
+
+/* The tag-typing field. NO border-box this time — the previous version
+   reused .editor-field's bordered shape, but stacked beneath FRONT and
+   BACK that created three identical boxes in a row + a wrapping section,
+   which read as "borders everywhere". Tags are now a quieter inline row:
+   just a flat surface with the placeholder text aligned to the same
+   gutter as the field contents above. Chips, when present, sit inline.
+   No visible chrome. */
 html[data-ba-editor="add"] .tag-spacer {
   flex: 1;
-  padding: 6px 10px !important;
+  min-height: 28px !important;
+  padding: 4px 0 !important;
   color: var(--ba-ink) !important;
-  font-family: var(--ba-sans) !important;
-  font-size: 11pt !important;
-  background: var(--ba-field) !important;
-  border-radius: var(--ba-radius) !important;
-  border: 1px solid var(--ba-line) !important;
-  min-height: 18px !important;
+  font-family: var(--ba-serif) !important;
+  font-size: 12pt !important;
+  line-height: 1.5 !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 6px !important;
   position: relative;
+  transition: none !important;
 }
-html[data-ba-editor="add"] .tag-editor:focus-within .tag-spacer {
-  border-color: var(--ba-accent) !important;
-}
-/* Placeholder when no tags. */
-html[data-ba-editor="add"] .tag-editor:not(:focus-within) .tag-spacer::before {
+/* Placeholder shown only when there are no tags AND not focused. Quiet
+   ink-faint so the row doesn't shout when empty. */
+html[data-ba-editor="add"] .tag-editor:not(:focus-within):not(:has(.tag)) .tag-spacer::before {
   content: "Add tags";
-  color: var(--ba-ink-faint) !important;
+  font-family: var(--ba-sans);
+  font-size: 11pt;
+  color: var(--ba-ink-faint);
+  opacity: 0.75;
   pointer-events: none;
 }
-html[data-ba-editor="add"] .tag-editor:focus-within .tag-spacer::before,
-html[data-ba-editor="add"] .tag-editor:has(.tag) .tag-spacer::before {
-  display: none !important;
-}
-/* Tag chips (when tags present). */
+/* Tag chips. */
 html[data-ba-editor="add"] .tag {
   background: color-mix(in srgb, var(--ba-accent) 14%, transparent) !important;
   color: var(--ba-accent) !important;

--- a/web/addcard.js
+++ b/web/addcard.js
@@ -34,12 +34,110 @@
     return true;
   }
 
-  // Try immediately, then a few delayed tries to catch the async editor
-  // ready.
+  // Strip the trailing "…"/"..." from the Fields/Cards label-buttons —
+  // the editorial chrome reads cleaner without the dots. Anki's source
+  // string is "Fields..." / "Cards..." (translated). Both renderings of
+  // the ellipsis (three dots vs ellipsis char) are handled.
+  function cleanFieldsCardsLabels() {
+    var nt = document.getElementById("notetype");
+    if (!nt) return false;
+    var btns = nt.querySelectorAll(".label-button");
+    if (!btns.length) return false;
+    var any = false;
+    btns.forEach(function (b) {
+      // The label text lives in a leaf text node; walk to find it.
+      var walker = document.createTreeWalker(b, NodeFilter.SHOW_TEXT, null);
+      var n;
+      while ((n = walker.nextNode())) {
+        var txt = n.nodeValue;
+        if (!txt) continue;
+        var stripped = txt.replace(/[…]+|\.{2,}/g, "").trim();
+        if (stripped !== txt) {
+          n.nodeValue = stripped;
+          any = true;
+        }
+      }
+    });
+    return any;
+  }
+
+  // Tag editor never collapses — we want the tags input always visible so
+  // the closed-state "horrible bare label" never appears. The header text
+  // is also reset to "TAGS" so it matches the FRONT/BACK field labels.
+  // The field labels and the tag label both use .collapse-label; field
+  // labels carry title="Collapse field" / "Expand field", the tag label
+  // uses bare "Collapse" / "Expand". Scope strictly to the tag label.
+  function keepTagsOpen() {
+    var label = document.querySelector(
+      '.collapse-label[title="Collapse"], .collapse-label[title="Expand"]'
+    );
+    if (!label) return false;
+    if (label.getAttribute("title") === "Expand") {
+      try { label.click(); } catch (_) {}
+    }
+    label.style.pointerEvents = "none";
+    label.style.cursor = "default";
+    return true;
+  }
+
+  // Move the tag section (label + .collapsible/tag-editor) from its
+  // default position OUTSIDE the scroll-area-relative wrapper to INSIDE
+  // the .scroll-content container, right after .fields. This pins TAGS
+  // visually beneath BACK instead of floating at the bottom of the pane
+  // (which is what happens when scroll-area-relative flex-grows to fill).
+  // CSS alone couldn't fix this: killing the outer flex-grow collapsed
+  // the inner field columns; killing only one collapsed the row width.
+  // DOM reparenting sidesteps the whole flex chain.
+  function moveTagsIntoFields() {
+    var scrollContent = document.querySelector(".scroll-content");
+    var tagLabel = document.querySelector(
+      '.collapse-label[title="Collapse"], .collapse-label[title="Expand"]'
+    );
+    if (!scrollContent || !tagLabel) return false;
+    // The .collapsible that wraps the tag-editor is the next element
+    // sibling after the label (or somewhere nearby — find it by checking
+    // each sibling for a descendant .tag-editor).
+    var tagCollapsible = null;
+    var node = tagLabel.nextElementSibling;
+    while (node) {
+      if (node.classList && node.classList.contains("collapsible")
+          && node.querySelector(".tag-editor")) {
+        tagCollapsible = node;
+        break;
+      }
+      node = node.nextElementSibling;
+    }
+    if (!tagCollapsible) return false;
+    // Already moved? Stop polling.
+    if (scrollContent.contains(tagLabel)) return true;
+    scrollContent.appendChild(tagLabel);
+    scrollContent.appendChild(tagCollapsible);
+    return true;
+  }
+
+  function poll(fn, max) {
+    if (fn()) return;
+    var n = 0;
+    var iv = setInterval(function () {
+      n += 1;
+      if (fn() || n > (max || 30)) clearInterval(iv);
+    }, 200);
+  }
+
   reorderToolbar();
-  var attempts = 0;
-  var iv = setInterval(function () {
-    attempts += 1;
-    if (reorderToolbar() || attempts > 30) clearInterval(iv);
-  }, 200);
+  poll(reorderToolbar, 30);
+  poll(cleanFieldsCardsLabels, 30);
+  poll(keepTagsOpen, 30);
+  poll(moveTagsIntoFields, 30);
+
+  // Re-apply whenever the toolbar mutates (Anki re-renders on field focus
+  // change, notetype switch, etc.).
+  try {
+    new MutationObserver(function () {
+      reorderToolbar();
+      cleanFieldsCardsLabels();
+      keepTagsOpen();
+      moveTagsIntoFields();
+    }).observe(document.body, { childList: true, subtree: true });
+  } catch (_) {}
 })();


### PR DESCRIPTION
## Summary

- **Submit no longer crashes.** `setCentralWidget` was destroying `historyButton`; Anki's `addHistory()` then called `setEnabled` on freed C++ memory, poisoning the Rust DB mutex and panicking the next op. Fix: reparent `addButton`/`historyButton`/`closeButton`/`helpButton` to the AddCards QMainWindow before swapping the central widget. Smoke test now passes two consecutive adds.
- **Add card button is shadcn-style** — flat ink rectangle, 6px radius, paper-on-ink text so contrast works in both themes. Recent dropdown removed (always empty in the embed lifecycle). `⌘↩` chip lives inside the button and fades + slides in on hover (QPropertyAnimation), matching the sidebar's hover-key pattern.
- **Tags row settled** — moved beneath BACK via JS reparent into `.scroll-content`, all chrome on `.collapsible:has(.tag-editor)` stripped to kill the phantom outlined box that the Svelte measuring/full-hide states were drawing.
- **Dark mode fixed** — `--ba-field` had been set to the LIGHT paper color in dark mode, and field text color was hardcoded warm dark; both produced white-on-white. Toolbar icons normalized to 30×30 with centered 16px SVGs, hover halos fully contain the icon, "Fields"/"Cards" lose the trailing dots, horizontal scroll when overflowing.
- **"A" key opens the embed** — Anki captures `self.onAddCard` as a bound method at startup so the monkey-patch didn't reach it; the global QShortcut is now disconnected and rewired. Plus dev-loop helpers: cache-bust the AddCards editor webview, `snap.sh`/`dump.sh` flags for close-after / hover / trigger / width / test-add / addcards-editor kind.

## Test plan

- [ ] `make demo-stop VARIANT=full && make demo VARIANT=full`
- [ ] Press **A**, type into Front, press **⌘↩** — note adds, editor resets. Repeat several times — no crash dialog.
- [ ] Click the Add card button directly. Hover it — the `⌘↩` chip fades and slides in from the right.
- [ ] Toggle dark mode (system or via Preferences > Anki Design) — fields render dark, text legible.
- [ ] Tags area below BACK has no visible box/border in either theme.
- [ ] Resize window narrow — toolbar scrolls horizontally instead of clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)