### PR TITLE
Sidebar tab-flat fix + Congrats page rebuild + always-expanded deck tree

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -510,6 +510,39 @@ def build_heatmap_html(weeks: int = 53) -> str:
     """
 
 
+# Force the deck-browser tree to render with every node expanded — the user
+# wants the full hierarchy visible by default, not a "+/-" puzzle. We patch
+# `_render_deck_node` (not the persisted collapsed state) so the user's saved
+# collapse flags stay intact in the backend; we just ignore them in this view.
+def _patch_deck_tree_always_expanded() -> None:
+    try:
+        if getattr(DeckBrowser, "_ad_expand_patched", False):
+            return
+        _orig = DeckBrowser._render_deck_node
+
+        def _patched(self, node, ctx):
+            try:
+                # Walk and flatten any persisted collapse so all rows render.
+                # Per-call: only mutates the in-memory tree node Anki built
+                # for this render. The next render rebuilds from the backend.
+                stack = [node]
+                while stack:
+                    n = stack.pop()
+                    try:
+                        n.collapsed = False
+                    except Exception:
+                        pass
+                    stack.extend(getattr(n, "children", []) or [])
+            except Exception:
+                pass
+            return _orig(self, node, ctx)
+
+        DeckBrowser._render_deck_node = _patched  # type: ignore[assignment]
+        DeckBrowser._ad_expand_patched = True  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
 def on_deck_browser_will_render_content(
     deck_browser: DeckBrowser, content: DeckBrowserContent
 ) -> None:
@@ -1105,6 +1138,254 @@ def _refresh_sync_status() -> None:
         _push_sidebar_sync("")
 
 
+# --------------------------------------------------------------------------- #
+# Congrats page (Overview's empty state) — redesigned.
+# Anki's "Congratulations! You have finished this deck for now." is a Svelte
+# page loaded via `web.load_sveltekit_page("congrats")`. That bypasses the
+# `webview_will_set_content` filter, so we hook `webview_did_inject_style_into_page`
+# instead — it fires after Anki's standard CSS injection for *every* page,
+# including Svelte ones. We detect the congrats URL and inject our redesign.
+# --------------------------------------------------------------------------- #
+def _deck_and_descendant_ids(did: int) -> list:
+    """Return [did, *all_descendant_dids] for a given deck. Best-effort: we
+    fall back to just [did] if Anki's deck API surface differs."""
+    try:
+        ids = [int(did)]
+        try:
+            children = mw.col.decks.children(did)  # [(name, id), ...]
+            ids.extend(int(cid) for _name, cid in children)
+        except Exception:
+            pass
+        return ids
+    except Exception:
+        return [int(did)]
+
+
+def _finished_deck_stats(did: int) -> Dict[str, Any]:
+    """Today's revlog stats for the deck the user just finished (deck + its
+    descendants). Returns counts, total time, and ease breakdown — used as the
+    big-number panel on the redesigned congrats page."""
+    out: Dict[str, Any] = {
+        "thisDeck": 0,
+        "timeSec": 0,
+        "breakdown": {"again": 0, "hard": 0, "good": 0, "easy": 0},
+    }
+    try:
+        shift = _day_shift_seconds()
+        today_idx = int((time.time() + shift) // 86400)
+        ids = _deck_and_descendant_ids(int(did))
+        if not ids:
+            return out
+        placeholders = ",".join("?" * len(ids))
+        row = mw.col.db.first(
+            f"select count(*), coalesce(sum(time),0), "
+            f"sum(case when ease=1 then 1 else 0 end), "
+            f"sum(case when ease=2 then 1 else 0 end), "
+            f"sum(case when ease=3 then 1 else 0 end), "
+            f"sum(case when ease=4 then 1 else 0 end) "
+            f"from revlog where cid in "
+            f"(select id from cards where did in ({placeholders})) "
+            f"and cast((id/1000 + ?) / 86400 as int) = ?",
+            *ids, shift, today_idx,
+        )
+        if row:
+            cnt, ms, ag, hd, gd, ez = row
+            out["thisDeck"] = int(cnt or 0)
+            out["timeSec"] = int(float(ms or 0) / 1000.0)
+            out["breakdown"] = {
+                "again": int(ag or 0),
+                "hard":  int(hd or 0),
+                "good":  int(gd or 0),
+                "easy":  int(ez or 0),
+            }
+    except Exception:
+        pass
+    return out
+
+
+def _filtered_deck_tree(exclude_did: int) -> list:
+    """Flat list of decks with any work (new/learn/review > 0), excluding the
+    finished deck *and its descendants*. Preserves Anki's natural deck order
+    (a depth-first walk of `deck_due_tree()`), tagging each entry with its
+    visual depth so the JS can indent."""
+    out: list = []
+    try:
+        exclude = set(int(x) for x in _deck_and_descendant_ids(int(exclude_did)))
+        tree = mw.col.sched.deck_due_tree()
+
+        def visit(node, depth):
+            did = int(getattr(node, "deck_id", 0) or 0)
+            n = int(getattr(node, "new_count", 0) or 0)
+            l = int(getattr(node, "learn_count", 0) or 0)
+            r = int(getattr(node, "review_count", 0) or 0)
+            # Sum descendant work so a parent with empty self but stocked kids
+            # still surfaces as a row (we still show kids individually).
+            sub_total = n + l + r
+            kids = list(getattr(node, "children", []) or [])
+            kid_rows: list = []
+            for c in kids:
+                kid_rows.extend(visit(c, depth + 1))
+                cn = int(getattr(c, "new_count", 0) or 0)
+                cl = int(getattr(c, "learn_count", 0) or 0)
+                cr = int(getattr(c, "review_count", 0) or 0)
+                sub_total += cn + cl + cr
+            if did in exclude:
+                return []
+            if did == 0:
+                # Root — emit kids only.
+                return kid_rows
+            if sub_total == 0:
+                return []
+            # Leaf name (after the last "::" — Anki uses "^_" internally but
+            # the `name` field on the tree node is the display path; we want
+            # just the leaf for the row, the depth carries the hierarchy).
+            full = str(getattr(node, "name", "") or "")
+            leaf = full.split("::")[-1]
+            row = {
+                "did": did,
+                "name": leaf,
+                "depth": depth,
+                "new": n,
+                "learn": l,
+                "review": r,
+            }
+            return [row] + kid_rows
+
+        out = visit(tree, -1)  # root depth -1 so top-level decks are 0
+    except Exception:
+        pass
+    return out
+
+
+def _build_congrats_payload() -> Dict[str, Any]:
+    """Bundle everything congrats.js needs for the redesigned page."""
+    did = 0
+    name = ""
+    try:
+        did = int(mw.col.decks.get_current_id())
+    except Exception:
+        try:
+            did = int(mw.col.decks.current()["id"])
+        except Exception:
+            pass
+    try:
+        if did:
+            name = str(mw.col.decks.name(did) or "")
+            # Anki uses "::" as the display separator; the leaf reads best.
+            name = name.split("::")[-1] or name
+    except Exception:
+        pass
+    stats = _finished_deck_stats(did) if did else {}
+    today_total = 0
+    try:
+        s = _standing()
+        today_total = int(s.get("today", 0) or 0)
+    except Exception:
+        pass
+    return {
+        "deckId": did,
+        "deckName": name or "this deck",
+        "thisDeck": stats.get("thisDeck", 0),
+        "todayTotal": today_total,
+        "timeSec": stats.get("timeSec", 0),
+        "breakdown": stats.get("breakdown", {"again": 0, "hard": 0, "good": 0, "easy": 0}),
+        "otherDecks": _filtered_deck_tree(did),
+    }
+
+
+def _is_congrats_url(url: str) -> bool:
+    if not url:
+        return False
+    # Anki serves the Svelte congrats page at <serverURL>/congrats (with an
+    # optional `#night` fragment). Match flexibly so a future path tweak
+    # (e.g. /pages/congrats) doesn't break detection.
+    low = url.lower()
+    if low.endswith("/congrats") or low.endswith("/congrats/"):
+        return True
+    if "/congrats#" in low or "/congrats?" in low:
+        return True
+    if low.rstrip("/").endswith("/pages/congrats"):
+        return True
+    return False
+
+
+def on_webview_did_inject_style_into_page(webview) -> None:
+    """Detect Anki's congrats Svelte page after its dynamic styling finishes,
+    then graft our sidebar + redesign on top. Idempotent (the JS bails if it
+    already initialised), so re-firing on theme changes is harmless."""
+    try:
+        url = webview.page().url().toString()
+    except Exception:
+        return
+    if not _is_congrats_url(url):
+        return
+    try:
+        import json as _json
+        cfg = _config()
+        standing = _build_standing_payload()
+        # Dev override: if a `?did=N` query string is present on /congrats,
+        # build the payload around that deck instead of the current one.
+        # Lets the screenshot loop preview any deck without finishing it.
+        override_did = 0
+        try:
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(url).query)
+            override_did = int((qs.get("did") or ["0"])[0])
+        except Exception:
+            override_did = 0
+        if override_did:
+            try:
+                mw.col.decks.select(override_did)
+            except Exception:
+                pass
+        congrats = _build_congrats_payload()
+        # Build a single eval that:
+        #   1. seeds globals BEFORE the scripts run,
+        #   2. injects our stylesheets (tokens, theme, logo, sidebar, congrats),
+        #   3. injects sidebar.js + congrats.js as scripts.
+        # Asset URLs are absolute relative paths served by Anki's media server
+        # (`/_addons/<dir>/web/<file>`), which works for Svelte pages too.
+        accent = cfg.get("accent", "#6c8cff")
+        theme_pref = cfg.get("theme", "system")
+        # Mirror webview_will_set_content's :root accent declaration so colors
+        # land consistently here too.
+        theme_attr = ""
+        if theme_pref in ("light", "dark"):
+            theme_attr = (
+                f"document.documentElement.dataset.rfTheme={_json.dumps(theme_pref)};"
+            )
+        accent_style = (
+            f"var st=document.createElement('style');"
+            f"st.textContent=':root,body{{--rf-accent:{accent};}}';"
+            f"document.head.appendChild(st);"
+        )
+        css_files = [
+            "tokens.css", "theme.css", "logo.css", "sidebar.css", "congrats.css",
+        ]
+        js_files = ["sidebar.js", "congrats.js"]
+        css_inject = ""
+        for f in css_files:
+            css_inject += (
+                f"(function(){{var l=document.createElement('link');"
+                f"l.rel='stylesheet';l.href='{WEB}/{f}';"
+                f"document.head.appendChild(l);}})();"
+            )
+        js_inject = ""
+        for f in js_files:
+            js_inject += (
+                f"(function(){{var s=document.createElement('script');"
+                f"s.src='{WEB}/{f}';s.defer=false;"
+                f"document.head.appendChild(s);}})();"
+            )
+        seed = (
+            f"window.__baStandingData={_json.dumps(standing)};"
+            f"window.__baCongratsData={_json.dumps(congrats)};"
+        )
+        webview.eval(theme_attr + seed + accent_style + css_inject + js_inject)
+    except Exception:
+        pass
+
+
 def _push_sidebar_standing() -> None:
     """Push the day's standing into every webview's sidebar for live updates
     (state changes, post-render). The initial render is bootstrapped via a
@@ -1343,6 +1624,17 @@ def on_reviewer_will_end() -> None:
 gui_hooks.webview_will_set_content.append(on_webview_will_set_content)
 gui_hooks.deck_browser_will_render_content.append(on_deck_browser_will_render_content)
 gui_hooks.deck_browser_did_render.append(on_deck_browser_did_render)
+# Expand-all patch applied at import time; idempotent.
+_patch_deck_tree_always_expanded()
+# Svelte pages (congrats) bypass webview_will_set_content; this hook fires
+# after every page's dynamic styling finishes, so we use it to detect the
+# congrats URL and inject our redesign.
+try:
+    gui_hooks.webview_did_inject_style_into_page.append(
+        on_webview_did_inject_style_into_page
+    )
+except Exception:
+    pass
 gui_hooks.state_did_change.append(on_state_did_change)
 gui_hooks.reviewer_did_show_question.append(on_show_question)
 gui_hooks.reviewer_did_show_answer.append(on_show_answer)
@@ -1938,6 +2230,80 @@ def _dev_run_cmd(raw: str) -> None:
                 rv.web.eval(js)
             elif getattr(mw, "web", None):
                 mw.web.eval(js)
+        elif cmd.startswith("mweval:"):
+            js = cmd[7:]
+            if getattr(mw, "web", None):
+                mw.web.eval(js)
+        elif cmd.startswith("mwecb:"):
+            # Like mweval but writes the result to .context/eval_result.txt
+            js = cmd[6:]
+            out = os.path.join(ADDON_SRC, ".context", "eval_result.txt")
+            if getattr(mw, "web", None):
+                def _cb(result, _path=out):
+                    try:
+                        with open(_path, "w") as fh:
+                            fh.write(str(result))
+                    except Exception:
+                        pass
+                mw.web.evalWithCallback(js, _cb)
+        elif cmd.startswith("congrats:"):
+            # Dev-only: force-load Anki's congrats page for the given deck id.
+            # Lets us preview the redesign against any deck without having
+            # to drain its actual due queue first.
+            try:
+                did = int(cmd.split(":", 1)[1])
+            except Exception:
+                _dev_cmd_log("congrats: bad did")
+                return
+            try:
+                mw.col.decks.select(did)
+            except Exception:
+                pass
+            # Patch the scheduler's _is_finished check to True so Anki's
+            # native Overview._renderPage takes its `_show_finished_screen`
+            # branch and loads the Svelte congrats page naturally. Restored
+            # after a short window so normal navigation isn't affected.
+            try:
+                sched = mw.col.sched
+                orig = getattr(sched, "_orig_is_finished", None) or sched._is_finished
+                sched._orig_is_finished = orig
+                sched._is_finished = lambda: True  # type: ignore
+                _dev_cmd_log("congrats: patched _is_finished")
+                def _restore(orig=orig):
+                    try:
+                        sched._is_finished = orig  # type: ignore
+                        _dev_cmd_log("congrats: restored _is_finished")
+                    except Exception:
+                        pass
+                if QTimer is not None:
+                    QTimer.singleShot(5000, _restore)
+            except Exception as e:
+                _dev_cmd_log(f"congrats patch err: {e!r}")
+            try:
+                mw.moveToState("overview")
+            except Exception:
+                pass
+        elif cmd.startswith("dump_main:"):
+            # Dump main webview HTML to a file (parallel to dump_card which
+            # uses the reviewer webview). Argument is the output filename
+            # under .context/.
+            out_name = cmd.split(":", 1)[1].strip() or "main.html"
+            out = os.path.join(ADDON_SRC, ".context", out_name)
+            if getattr(mw, "web", None):
+                js = (
+                    "JSON.stringify({"
+                    "html: document.documentElement.outerHTML,"
+                    "url: location.href,"
+                    "title: document.title"
+                    "})"
+                )
+                def _cb(result, _path=out):
+                    try:
+                        with open(_path, "w") as fh:
+                            fh.write(str(result))
+                    except Exception:
+                        pass
+                mw.web.evalWithCallback(js, _cb)
         elif cmd.startswith("beval:"):
             # Eval JS in the reviewer's bottom toolbar webview.
             js = cmd[6:]

--- a/web/congrats.css
+++ b/web/congrats.css
@@ -1,0 +1,366 @@
+/* Anki Design — redesigned congrats page.
+   Replaces Anki's stock "Congratulations!" Svelte page with a session debrief:
+   big-number stats for the deck just finished, plus a click-to-jump tree of
+   the user's other decks with work remaining. The sidebar is restored so the
+   shortcuts (D / A / B / T / ,) and the Decks/Add/Browse/Stats rows still
+   navigate. */
+
+/* Hide Anki's stock Svelte congrats panel — we replace it with our own. */
+.congrats,
+svelte-css-wrapper:has(> div.container > svelte-css-wrapper > div.col > div.congrats) {
+  display: none !important;
+}
+
+/* Anki's standard webview CSS for Svelte pages sets
+   `.night-mode button { --canvas: #606060 }` and adds night-mode body
+   classes that knock down our text colours. Override all of that so our
+   sidebar nav rows and deck-tree buttons read at the same weights as on
+   the regular homepage (theme.css/sidebar.css). */
+.ba-cg button,
+.ba-side button,
+button.ba-cg-deck,
+button.ba-side-item {
+  --canvas: transparent !important;
+  background-color: transparent !important;
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+/* Sidebar text: explicit colours so the body's `.night_mode` classes can't
+   leach the text to near-invisible greys. */
+.ba-side .ba-side-item {
+  color: var(--rf-ink-dim) !important;
+  opacity: 1 !important;
+}
+.ba-side .ba-side-item[data-active="true"] {
+  color: var(--rf-ink) !important;
+  background-color: var(--rf-row-current) !important;
+}
+.ba-side .ba-side-item:hover {
+  background-color: var(--rf-row-hover) !important;
+}
+.ba-side .ba-side-icon {
+  color: var(--rf-ink-faint) !important;
+  opacity: 1 !important;
+}
+.ba-side .ba-side-item[data-active="true"] .ba-side-icon {
+  color: var(--rf-ink) !important;
+}
+/* Deck-tree buttons in the "Keep going" section. */
+.ba-cg .ba-cg-deck {
+  color: var(--rf-ink) !important;
+  opacity: 1 !important;
+}
+.ba-cg .ba-cg-deck:hover {
+  background-color: var(--rf-row-hover) !important;
+}
+/* Sub-deck names get the dim ink, parent stays full ink. */
+.ba-cg .ba-cg-deck[data-depth="1"] .ba-cg-deck-name,
+.ba-cg .ba-cg-deck[data-depth="2"] .ba-cg-deck-name,
+.ba-cg .ba-cg-deck[data-depth="3"] .ba-cg-deck-name {
+  color: var(--rf-ink-dim) !important;
+}
+
+/* Page bg + reset Anki's default canvas variable so our cream paper wins.
+   Note: only reset right-side padding so `body.ba-with-side` can keep its
+   `padding-left` (the sidebar gutter) intact. */
+html, body {
+  background: var(--rf-paper) !important;
+  color: var(--rf-ink) !important;
+  margin: 0 !important;
+  padding-top: 0 !important;
+  padding-right: 0 !important;
+  padding-bottom: 0 !important;
+  font-family: var(--rf-sans) !important;
+}
+body.ba-with-side {
+  padding-left: var(--rf-side-w, 264px) !important;
+}
+
+/* Outer page. A subtle fade-in (no translate so screenshots taken mid-frame
+   don't catch a misaligned position). Short duration so multi-render reloads
+   don't compound. */
+.ba-cg {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 56px 48px 72px;
+  text-align: left;
+  animation: ba-cg-fade 180ms ease both;
+}
+@media (max-width: 900px) {
+  .ba-cg { padding: 40px 28px 56px; }
+}
+@keyframes ba-cg-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-cg { animation: none; }
+}
+
+/* ---------------- Head: eyebrow + deck name ---------------- */
+.ba-cg-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin: 0 0 40px;
+  flex-wrap: wrap;
+}
+.ba-cg-eyebrow {
+  font: 600 11px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--rf-ink-faint);
+}
+.ba-cg-deck {
+  font: 500 36px/1.05 var(--rf-serif);
+  letter-spacing: -0.02em;
+  color: var(--rf-ink);
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ---------------- Stats grid: BIG numbers ---------------- */
+.ba-cg-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px 24px;
+  margin: 0 0 48px;
+  padding: 32px 0;
+  border-top: 1px solid var(--rf-line);
+  border-bottom: 1px solid var(--rf-line);
+}
+/* Anki's main webview often runs at ~660-900px CSS pixels (the sidebar
+   eats 264 of that), so four-column big-number stats don't fit cleanly.
+   Drop to a 2×2 grid until we have real room for 4 wide columns. */
+@media (max-width: 900px) {
+  .ba-cg-stats { grid-template-columns: repeat(2, 1fr); gap: 28px 18px; }
+}
+.ba-cg-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.ba-cg-stat-n {
+  font: 600 clamp(40px, 6vw, 56px)/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.035em;
+  color: var(--rf-ink);
+  /* Don't truncate: a compound value like "10m 13s" must read complete.
+     Wraps to a second line only if it really can't fit. */
+  white-space: nowrap;
+  overflow: visible;
+}
+.ba-cg-stat-n .sub {
+  font-size: 0.45em;
+  color: var(--rf-ink-dim);
+  letter-spacing: -0.02em;
+  margin-left: 2px;
+}
+.ba-cg-stat-l {
+  font: 600 10.5px/1.2 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--rf-ink-faint);
+}
+.ba-cg-stat-l b {
+  display: inline;
+  font: 500 11px/1.2 var(--rf-sans);
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--rf-ink-dim);
+  margin-left: 6px;
+}
+
+/* ---------------- Accuracy strip ---------------- */
+.ba-cg-acc {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin: 0 0 56px;
+}
+@media (max-width: 900px) {
+  .ba-cg-acc { grid-template-columns: repeat(2, 1fr); }
+}
+.ba-cg-acc-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 2px solid var(--ba-cg-acc-c, var(--rf-line));
+}
+.ba-cg-acc-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  justify-content: space-between;
+}
+.ba-cg-acc-label {
+  font: 600 11px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ba-cg-acc-c, var(--rf-ink-dim));
+}
+.ba-cg-acc-pct {
+  font: 500 13px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  color: var(--rf-ink-dim);
+}
+.ba-cg-acc-n {
+  font: 600 26px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.02em;
+  color: var(--rf-ink);
+}
+.ba-cg-acc-cell.again  { --ba-cg-acc-c: var(--rf-again, #c95a4b); }
+.ba-cg-acc-cell.hard   { --ba-cg-acc-c: var(--rf-learn, #c69142); }
+.ba-cg-acc-cell.good   { --ba-cg-acc-c: var(--rf-due, #4a8f6b); }
+.ba-cg-acc-cell.easy   { --ba-cg-acc-c: var(--rf-new, #3f7fb2); }
+:root[data-rf-theme="dark"] .ba-cg-acc-cell.again,
+:root.night-mode .ba-cg-acc-cell.again { --ba-cg-acc-c: #e07466; }
+:root[data-rf-theme="dark"] .ba-cg-acc-cell.hard,
+:root.night-mode .ba-cg-acc-cell.hard  { --ba-cg-acc-c: #d4a35d; }
+:root[data-rf-theme="dark"] .ba-cg-acc-cell.good,
+:root.night-mode .ba-cg-acc-cell.good  { --ba-cg-acc-c: #79b69b; }
+:root[data-rf-theme="dark"] .ba-cg-acc-cell.easy,
+:root.night-mode .ba-cg-acc-cell.easy  { --ba-cg-acc-c: #6fa9d8; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) .ba-cg-acc-cell.again { --ba-cg-acc-c: #e07466; }
+  :root:not([data-rf-theme="light"]) .ba-cg-acc-cell.hard  { --ba-cg-acc-c: #d4a35d; }
+  :root:not([data-rf-theme="light"]) .ba-cg-acc-cell.good  { --ba-cg-acc-c: #79b69b; }
+  :root:not([data-rf-theme="light"]) .ba-cg-acc-cell.easy  { --ba-cg-acc-c: #6fa9d8; }
+}
+
+/* Empty-stats state: when 0 cards were reviewed in this deck today. */
+.ba-cg-empty {
+  margin: 0 0 56px;
+  padding: 32px 0;
+  border-top: 1px solid var(--rf-line);
+  border-bottom: 1px solid var(--rf-line);
+  font: 500 14px/1.5 var(--rf-sans);
+  color: var(--rf-ink-dim);
+}
+
+/* ---------------- Other-decks tree ---------------- */
+.ba-cg-decks-h {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin: 0 0 18px;
+}
+.ba-cg-decks-h-title {
+  font: 600 11px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--rf-ink-faint);
+}
+.ba-cg-decks-h-sub {
+  font: 500 13px/1 var(--rf-sans);
+  color: var(--rf-ink-dim);
+}
+
+.ba-cg-decks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ba-cg-deck {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 10px;
+  margin: 0 -10px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  width: calc(100% + 20px);
+  color: var(--rf-ink);
+  font: 500 16px/1.25 var(--rf-serif);
+  letter-spacing: -0.005em;
+  transition: background 160ms ease, color 160ms ease;
+}
+.ba-cg-deck:hover,
+.ba-cg-deck:focus-visible {
+  background: var(--rf-row-hover);
+  color: var(--rf-ink-strong);
+  outline: none;
+}
+.ba-cg-deck-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.ba-cg-deck-counts {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 14px;
+  font: 500 13.5px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+.ba-cg-deck-counts span { min-width: 22px; text-align: right; }
+.ba-cg-deck-counts .new    { color: var(--rf-new); }
+.ba-cg-deck-counts .learn  { color: var(--rf-learn); }
+.ba-cg-deck-counts .review { color: var(--rf-due); }
+.ba-cg-deck-counts .zero   { color: var(--rf-ink-faint); font-weight: 400; }
+
+/* Sub-decks: indent by depth via inline padding from JS. */
+.ba-cg-deck[data-depth="0"] .ba-cg-deck-name {
+  font-weight: 500;
+}
+.ba-cg-deck[data-depth="1"] .ba-cg-deck-name,
+.ba-cg-deck[data-depth="2"] .ba-cg-deck-name,
+.ba-cg-deck[data-depth="3"] .ba-cg-deck-name {
+  font-weight: 400;
+  color: var(--rf-ink-dim);
+  font-size: 15px;
+}
+.ba-cg-deck[data-depth="1"] .ba-cg-deck-name::before,
+.ba-cg-deck[data-depth="2"] .ba-cg-deck-name::before,
+.ba-cg-deck[data-depth="3"] .ba-cg-deck-name::before {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 1px;
+  background: var(--rf-line-2);
+  margin-right: 10px;
+  vertical-align: middle;
+}
+
+/* All clear: when other_decks is empty. */
+.ba-cg-clear {
+  padding: 28px 0;
+  font: 500 14px/1.5 var(--rf-sans);
+  color: var(--rf-ink-dim);
+}
+.ba-cg-clear b {
+  color: var(--rf-ink);
+  font-weight: 600;
+}
+
+/* ---------------- Foot: custom study link ---------------- */
+.ba-cg-foot {
+  margin: 56px 0 0;
+  padding: 24px 0 0;
+  border-top: 1px solid var(--rf-line);
+  font: 500 12.5px/1.4 var(--rf-sans);
+  color: var(--rf-ink-faint);
+}
+.ba-cg-foot a {
+  color: var(--rf-ink-dim);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rf-line-2);
+  transition: color 160ms ease, border-color 160ms ease;
+}
+.ba-cg-foot a:hover {
+  color: var(--rf-ink);
+  border-bottom-color: currentColor;
+}

--- a/web/congrats.js
+++ b/web/congrats.js
@@ -1,0 +1,229 @@
+// Anki Design — redesigned congrats page.
+// Replaces Anki's stock Svelte panel with a session debrief: big-number stats
+// for the deck just finished, and a clickable tree of other decks with work.
+// Data is bootstrapped from window.__baCongratsData (set by Python before this
+// script runs).
+(function () {
+  "use strict";
+  if (window.__ankiDesignCongrats) return;
+  window.__ankiDesignCongrats = true;
+
+  function send(cmd) {
+    try { if (typeof pycmd === "function") pycmd("ba:" + cmd); } catch (_) {}
+  }
+  function bridge(cmd) {
+    // Anki's congrats page uses bridgeCommand for the customStudy link; keep
+    // compatibility by routing through the same channel.
+    try {
+      if (typeof bridgeCommand === "function") bridgeCommand(cmd);
+      else if (typeof pycmd === "function") pycmd(cmd);
+    } catch (_) {}
+  }
+
+  function fmtN(n) {
+    if (n == null) return "0";
+    return Number(n).toLocaleString();
+  }
+  // "3:42" for minutes:seconds, or "12s" for sub-minute. Total time on this
+  // deck today — meant to feel like a workout summary, not a stopwatch.
+  function fmtTime(totalSec) {
+    var s = Math.max(0, Math.round(totalSec || 0));
+    if (s < 60) return s + "<span class=\"sub\">s</span>";
+    var m = Math.floor(s / 60);
+    var rs = s % 60;
+    if (m < 60) {
+      return m + "<span class=\"sub\">m</span>" + (rs ? " " + rs + "<span class=\"sub\">s</span>" : "");
+    }
+    var h = Math.floor(m / 60);
+    var rm = m % 60;
+    return h + "<span class=\"sub\">h</span>" + (rm ? " " + rm + "<span class=\"sub\">m</span>" : "");
+  }
+  // Per-card avg in seconds, rounded to one decimal if under 10s.
+  function fmtPerCard(sec) {
+    if (!sec) return "—";
+    var x = sec;
+    if (x < 10) return (Math.round(x * 10) / 10) + "<span class=\"sub\">s</span>";
+    return Math.round(x) + "<span class=\"sub\">s</span>";
+  }
+  function pct(n, total) {
+    if (!total) return 0;
+    return Math.round((n / total) * 100);
+  }
+
+  // ---- DOM builders ---- //
+
+  function statHTML(n, label, sub) {
+    var labelHTML = label + (sub ? '<b>' + sub + '</b>' : '');
+    return ''
+      + '<div class="ba-cg-stat">'
+      +   '<div class="ba-cg-stat-n">' + n + '</div>'
+      +   '<div class="ba-cg-stat-l">' + labelHTML + '</div>'
+      + '</div>';
+  }
+
+  function statsBlockHTML(d) {
+    var thisN = d.thisDeck || 0;
+    var todayN = d.todayTotal || 0;
+    var timeSec = d.timeSec || 0;
+    var perCard = thisN > 0 ? (timeSec / thisN) : 0;
+    if (thisN === 0) {
+      return '<div class="ba-cg-empty">'
+        + 'No reviews on this deck today. '
+        + (todayN > 0 ? ('You did <b style="color:var(--rf-ink)">' + fmtN(todayN) + '</b> on other decks.')
+                      : 'Pick something below to start.')
+        + '</div>';
+    }
+    return ''
+      + '<div class="ba-cg-stats">'
+      +   statHTML(fmtN(thisN),   'cards',    'this deck')
+      +   statHTML(fmtN(todayN),  'today',    'all decks')
+      +   statHTML(fmtTime(timeSec), 'time',  'this deck')
+      +   statHTML(fmtPerCard(perCard), 'per card', '')
+      + '</div>';
+  }
+
+  function accuracyHTML(d) {
+    var b = d.breakdown || {};
+    var again = b.again || 0, hard = b.hard || 0, good = b.good || 0, easy = b.easy || 0;
+    var total = again + hard + good + easy;
+    if (total === 0) return '';
+    function cell(cls, label, n) {
+      return ''
+        + '<div class="ba-cg-acc-cell ' + cls + '">'
+        +   '<div class="ba-cg-acc-row">'
+        +     '<span class="ba-cg-acc-label">' + label + '</span>'
+        +     '<span class="ba-cg-acc-pct">' + pct(n, total) + '%</span>'
+        +   '</div>'
+        +   '<div class="ba-cg-acc-n">' + fmtN(n) + '</div>'
+        + '</div>';
+    }
+    return ''
+      + '<div class="ba-cg-acc">'
+      +   cell('again', 'Again', again)
+      +   cell('hard',  'Hard',  hard)
+      +   cell('good',  'Good',  good)
+      +   cell('easy',  'Easy',  easy)
+      + '</div>';
+  }
+
+  function countCell(n, cls) {
+    var z = !n ? ' zero' : '';
+    return '<span class="' + cls + z + '">' + (n || 0) + '</span>';
+  }
+
+  function deckRowHTML(node) {
+    var name = node.name == null ? '' : String(node.name);
+    var depth = node.depth || 0;
+    var n = node.new || 0, l = node.learn || 0, r = node.review || 0;
+    return ''
+      + '<button class="ba-cg-deck" data-depth="' + depth + '" '
+      +         'data-did="' + node.did + '" type="button">'
+      +   '<span class="ba-cg-deck-name">' + escapeHTML(name) + '</span>'
+      +   '<span class="ba-cg-deck-counts">'
+      +     countCell(n, 'new')
+      +     countCell(l, 'learn')
+      +     countCell(r, 'review')
+      +   '</span>'
+      + '</button>';
+  }
+
+  function decksBlockHTML(decks) {
+    if (!decks || !decks.length) {
+      return ''
+        + '<div class="ba-cg-clear">'
+        +   '<b>Everything’s clear.</b> No other decks have cards to study right now. '
+        +   'Come back tomorrow, or '
+        +   '<a href="javascript:void(0)" onclick="bridgeCommand(\'customStudy\')">try custom study</a>.'
+        + '</div>';
+    }
+    var head = ''
+      + '<div class="ba-cg-decks-h">'
+      +   '<span class="ba-cg-decks-h-title">Keep going</span>'
+      +   '<span class="ba-cg-decks-h-sub">Other decks with work</span>'
+      + '</div>';
+    var rows = decks.map(deckRowHTML).join('');
+    return head + '<div class="ba-cg-decks">' + rows + '</div>';
+  }
+
+  function footHTML() {
+    return ''
+      + '<div class="ba-cg-foot">'
+      +   'Want to study off-schedule? '
+      +   '<a href="javascript:void(0)" onclick="bridgeCommand(\'customStudy\')">Custom study</a>.'
+      + '</div>';
+  }
+
+  function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c];
+    });
+  }
+
+  function build() {
+    var d = window.__baCongratsData || {};
+    var deckName = d.deckName || 'this deck';
+    var wrap = document.createElement('div');
+    wrap.className = 'ba-cg';
+    wrap.innerHTML = ''
+      + '<header class="ba-cg-head">'
+      +   '<span class="ba-cg-eyebrow">Done for now</span>'
+      +   '<h1 class="ba-cg-deck">' + escapeHTML(deckName) + '</h1>'
+      + '</header>'
+      + statsBlockHTML(d)
+      + accuracyHTML(d)
+      + decksBlockHTML(d.otherDecks)
+      + footHTML();
+
+    // Wire deck-row clicks → jump straight into that deck's reviewer.
+    wrap.addEventListener('click', function (e) {
+      var btn = e.target.closest && e.target.closest('.ba-cg-deck');
+      if (!btn) return;
+      var did = btn.getAttribute('data-did');
+      if (did) send('study:' + did);
+    });
+
+    return wrap;
+  }
+
+  function mount() {
+    if (document.querySelector('.ba-cg')) return;
+    // Anki's Svelte page is async; wait for the body to exist.
+    if (!document.body) {
+      document.addEventListener('DOMContentLoaded', mount);
+      return;
+    }
+    // Find Anki's congrats container and hide it (CSS does this too, but we
+    // also remove children to stop screen readers from announcing both).
+    var stock = document.querySelector('.congrats');
+    if (stock) stock.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(build());
+    // Force scroll to top — the Svelte announcer (an absolutely-positioned
+    // element at the bottom of the doc) can leave the viewport mid-page on
+    // some renders. We want the headline visible.
+    try {
+      window.scrollTo(0, 0);
+      document.documentElement.scrollTop = 0;
+      document.body.scrollTop = 0;
+    } catch (_) {}
+  }
+
+  // The Svelte mount can win our race; observe for late insertion and rebuild
+  // if the page swaps state on us.
+  function watch() {
+    if (!window.MutationObserver) return;
+    var mo = new MutationObserver(function () {
+      // Just guarantee our overlay exists; if Anki re-renders we don't
+      // duplicate (build() is idempotent via the .ba-cg presence check).
+      mount();
+    });
+    try { mo.observe(document.documentElement, { childList: true, subtree: true }); }
+    catch (_) {}
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { mount(); watch(); });
+  } else {
+    mount();
+    watch();
+  }
+})();

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -117,9 +117,30 @@ body.ba-with-side {
   align-items: center;
   gap: 12px;
   width: 100%;
-  background: transparent;
-  border: 0;
-  border-radius: 7px;
+  /* Anki's webview.css ships `.fancy button` (specificity 0,0,1,1) which
+     adds a 3-layer drop shadow + gradient background, and `.fancy button:hover`
+     (0,0,2,1) which swaps to a heavier hover shadow. Both beat a plain
+     `.ba-side-item` rule (0,0,1,0), so the sidebar rows pick up Anki's pill
+     chrome unless we override with at least equal specificity *and* cover
+     every interaction state — hence the `!important`s. Same pattern the
+     congrats overlay used; moving it here makes the sidebar tab-flat on
+     every page (deck browser, overview, reviewer, addcard) without each
+     page needing its own copy. */
+  --canvas: transparent;
+  background: transparent !important;
+  background-image: none !important;
+  border: 0 !important;
+  box-shadow: none !important;
+  /* Anki's `button { margin: 0 4px }` (in webview.css) was shrinking every
+     <button> row by 8px total — the New deck <div> wasn't affected, so it
+     was the only row whose hover/active fill reached the divider lines.
+     Zero the margin so every row is the same full width as the rules. */
+  margin: 0 !important;
+  /* Anki's `.fancy button` also sets `border-radius: var(--border-radius-large)`
+     (15px) which beats `.ba-side-item` on plain specificity, so the <button>
+     rows rendered as half-pills while the New deck <div> stayed at 7px.
+     !important here unifies the radius across both element types. */
+  border-radius: 7px !important;
   padding: 10px 12px;        /* more vertical space per item */
   /* Lock the item box so nothing — font-size overrides, sub-pixel
      rounding, browser default :hover styles — can change its height.
@@ -148,21 +169,14 @@ body.ba-with-side {
    change, no icon-color change, no font-weight, no transform. The bg fade
    alone signals interactivity without any optical weight shift. */
 .ba-side-item:hover {
-  background: var(--rf-row-hover);
+  background: var(--rf-row-hover) !important;
 }
 
 .ba-side-item[data-active="true"] {
   color: var(--rf-ink);
-  background: var(--rf-row-current);
+  background: var(--rf-row-current) !important;
 }
 .ba-side-item[data-active="true"] .ba-side-icon { color: var(--rf-ink); }
-.ba-side-item[data-active="true"]::before {
-  content: "";
-  position: absolute;
-  left: 0; top: 8px; bottom: 8px;
-  width: 2px; border-radius: 2px;
-  background: var(--rf-accent, #6c8cff);
-}
 
 /* Quick actions — slightly lighter weight to read as actions. The fixed
    height on .ba-side-item keeps these the same row height as the nav,


### PR DESCRIPTION
## Summary

- **Sidebar**: Anki's `webview.css` was applying `.fancy button` (3-layer drop shadow, 15px pill radius) and `button { margin: 0 4px }` on top of every `<button>` row — the New deck `<div>` was the only row that escaped, which is why it alone reached the divider edges. Reset bg/border/box-shadow/margin/radius on `.ba-side-item` with `!important` and dropped the absolute blue active-bar; every row now reads as a flat tab, same left edge, same width as the rules.
- **Congrats page**: replace Anki's stock Svelte "Congratulations!" panel with a session debrief (big-number stats, ease breakdown, click-to-jump "Keep going" deck tree). Hooked via `webview_did_inject_style_into_page` so the same `sidebar.css`/`sidebar.js` run on the Svelte route too.
- **Deck browser**: monkey-patch `DeckBrowser._render_deck_node` to flatten the in-memory collapse flags per render — the full hierarchy is always visible; the user's persisted collapse state in the backend is untouched.

## Test plan

- [ ] Deck browser: nav rows + quick actions + sync/settings all have the same left edge, same width as the dividers, no drop shadow, no pill chrome.
- [ ] Active row ("Decks" by default) reads as active via the subtle bg fill + ink-color shift — no blue bar.
- [ ] Finish a deck → redesigned Congrats page renders with the sidebar intact; shortcuts (D / A / B / T / ,) still navigate.
- [ ] Deck list: parents render with their children expanded; clicking the chevron in the backend (e.g. via the deck browser menu) doesn't desync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)