### PR TITLE
Sidebar: New Deck submit icon + per-icon hover animations

### DIFF
--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -192,12 +192,122 @@ body.ba-with-side {
 
 /* Streak block + lifetime stats moved out of the sidebar; styles deleted. */
 
+/* ---------------------------- ICON HOVER ANIMATIONS ----------------------------
+   Each row's icon gets a small, on-hover gesture matched to its glyph:
+   layers lift, plus rotates, search wiggles, bars rise, arrows bob,
+   sync spins, gear turns. Animations target inner <g class="ba-i-*">
+   hooks set in sidebar.js so the parent .ba-side-icon's own color
+   transition stays clean. `transform-box: fill-box` makes
+   transform-origin compute against the group's own bounding box rather
+   than the SVG's outer canvas — without it, rotations pivot around the
+   (0,0) corner instead of the glyph center. Focus-visible mirrors hover
+   so keyboard nav gets the same gesture. */
+
+.ba-i-decks-top, .ba-i-decks-mid, .ba-i-decks-bot,
+.ba-i-plus, .ba-i-search-lens, .ba-i-bar,
+.ba-i-import, .ba-i-sync, .ba-i-gear {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 260ms cubic-bezier(.2, .8, .2, 1);
+}
+
+/* DECKS — top card peels up, middle nudges a touch — reads as lifting
+   a sheet off the stack. */
+.ba-side-item[data-cmd="decks"]:hover .ba-i-decks-top,
+.ba-side-item[data-cmd="decks"]:focus-visible .ba-i-decks-top {
+  transform: translateY(-2px);
+}
+.ba-side-item[data-cmd="decks"]:hover .ba-i-decks-mid,
+.ba-side-item[data-cmd="decks"]:focus-visible .ba-i-decks-mid {
+  transform: translateY(-0.5px);
+}
+
+/* ADD / CREATE (idle) — plus rotates 90° (briefly an "x"). */
+.ba-side-item[data-cmd="add"]:hover .ba-i-plus,
+.ba-side-item[data-cmd="add"]:focus-visible .ba-i-plus,
+.ba-side-newdeck[data-state="idle"]:hover .ba-i-plus,
+.ba-side-newdeck[data-state="idle"]:focus-visible .ba-i-plus {
+  transform: rotate(90deg);
+}
+
+/* BROWSE — magnifying lens scans (rotates left, then right). */
+.ba-side-item[data-cmd="browse"]:hover .ba-i-search-lens,
+.ba-side-item[data-cmd="browse"]:focus-visible .ba-i-search-lens {
+  animation: ba-i-search-scan 700ms ease-in-out;
+}
+@keyframes ba-i-search-scan {
+  0%, 100% { transform: rotate(0); }
+  30%      { transform: rotate(-12deg); }
+  70%      { transform: rotate(12deg); }
+}
+
+/* STATS — bars rise from their base, staggered 70ms apart. */
+.ba-i-bar { transform-origin: center bottom; }
+.ba-side-item[data-cmd="stats"]:hover .ba-i-bar-1,
+.ba-side-item[data-cmd="stats"]:focus-visible .ba-i-bar-1 {
+  animation: ba-i-bar-rise 520ms cubic-bezier(.2, .8, .2, 1) 0ms;
+}
+.ba-side-item[data-cmd="stats"]:hover .ba-i-bar-2,
+.ba-side-item[data-cmd="stats"]:focus-visible .ba-i-bar-2 {
+  animation: ba-i-bar-rise 520ms cubic-bezier(.2, .8, .2, 1) 70ms;
+}
+.ba-side-item[data-cmd="stats"]:hover .ba-i-bar-3,
+.ba-side-item[data-cmd="stats"]:focus-visible .ba-i-bar-3 {
+  animation: ba-i-bar-rise 520ms cubic-bezier(.2, .8, .2, 1) 140ms;
+}
+@keyframes ba-i-bar-rise {
+  0%   { transform: scaleY(0.55); }
+  60%  { transform: scaleY(1.18); }
+  100% { transform: scaleY(1); }
+}
+
+/* IMPORT — arrow bobs upward, overshoots a touch, then settles. */
+.ba-side-item[data-cmd="import"]:hover .ba-i-import,
+.ba-side-item[data-cmd="import"]:focus-visible .ba-i-import {
+  animation: ba-i-import-bob 580ms cubic-bezier(.2, .8, .2, 1);
+}
+@keyframes ba-i-import-bob {
+  0%   { transform: translateY(0); }
+  40%  { transform: translateY(-2.5px); }
+  70%  { transform: translateY(0.5px); }
+  100% { transform: translateY(0); }
+}
+
+/* SYNC — one full 360° turn on hover. Skipped while the row is already
+   spinning for an active sync, so the two animations don't fight. */
+.ba-side-item[data-cmd="sync"]:not(.ba-sync-active):hover .ba-i-sync,
+.ba-side-item[data-cmd="sync"]:not(.ba-sync-active):focus-visible .ba-i-sync {
+  animation: ba-i-sync-spin 720ms cubic-bezier(.4, 0, .2, 1);
+}
+@keyframes ba-i-sync-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* SETTINGS — gear turns a quarter rotation, the classic gear gesture. */
+.ba-side-item[data-cmd="settings"]:hover .ba-i-gear,
+.ba-side-item[data-cmd="settings"]:focus-visible .ba-i-gear {
+  transform: rotate(90deg);
+  transition: transform 600ms cubic-bezier(.4, 0, .2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ba-i-decks-top, .ba-i-decks-mid, .ba-i-decks-bot,
+  .ba-i-plus, .ba-i-search-lens, .ba-i-bar,
+  .ba-i-import, .ba-i-sync, .ba-i-gear {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
 /* ---------------------------- NEW DECK ROW ----------------------------
    Morphing inline-create row. Idle: same shape as .ba-side-act. Active:
    the label slot swaps for a borderless text input — Enter creates the
-   deck via pycmd("ba:create:<name>"). The icon is the only stable
-   anchor; everything else cross-fades in the same flex slot so nothing
-   in the row moves. State is held on the row via data-state. */
+   deck via pycmd("ba:create:<name>"). The icon column anchors the swap,
+   but is itself a two-glyph cross-fade: a plus in idle and a submit
+   (right-arrow) in active. Clicking the submit icon is equivalent to
+   pressing Enter from the input. State is held on the row via
+   data-state. */
 .ba-side-newdeck { cursor: pointer; }
 .ba-side-newdeck[data-state="active"] { cursor: text; }
 .ba-side-newdeck:focus-visible { outline: none; }
@@ -266,18 +376,62 @@ body.ba-with-side {
   pointer-events: auto;
   transform: translateX(0);
 }
-.ba-side-newdeck[data-state="active"] .ba-side-icon {
-  color: var(--rf-accent, #6c8cff);
-  transform: rotate(0deg) scale(1.08);
-  transition: color 220ms ease, transform 220ms cubic-bezier(.2, .8, .2, 1);
+
+/* Icon slot — a fixed 14×14 box that holds the plus and submit SVGs
+   stacked on top of each other. They cross-fade as data-state flips.
+   Their shared horizontal stroke creates the morph illusion: the
+   vertical arm of the plus dissolves and the arrowhead grows in. */
+.ba-side-newdeck-icons {
+  position: relative;
+  flex: none;
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  color: var(--rf-ink-faint);
+  transition: color 220ms ease, transform 180ms cubic-bezier(.2, .8, .2, 1);
 }
-.ba-side-newdeck .ba-side-icon {
-  transition: color 220ms ease, transform 220ms cubic-bezier(.2, .8, .2, 1);
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-icons {
+  color: var(--rf-accent, #6c8cff);
+  cursor: pointer;
+}
+/* Tactile feedback when the icon is acting as a submit button. */
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-icons:hover {
+  transform: scale(1.18);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-icons:active {
+  transform: scale(0.92);
+}
+.ba-side-newdeck-icon--plus,
+.ba-side-newdeck-icon--submit {
+  position: absolute;
+  inset: 0;
+  width: 14px;
+  height: 14px;
+  transition: opacity 200ms ease,
+              transform 260ms cubic-bezier(.2, .8, .2, 1);
+}
+.ba-side-newdeck[data-state="idle"] .ba-side-newdeck-icon--plus {
+  opacity: 1;
+  transform: scale(1);
+}
+.ba-side-newdeck[data-state="idle"] .ba-side-newdeck-icon--submit {
+  opacity: 0;
+  transform: scale(0.7);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-icon--plus {
+  opacity: 0;
+  transform: scale(0.7);
+}
+.ba-side-newdeck[data-state="active"] .ba-side-newdeck-icon--submit {
+  opacity: 1;
+  transform: scale(1.08);
 }
 @media (prefers-reduced-motion: reduce) {
   .ba-side-newdeck-label,
   .ba-side-newdeck-input,
-  .ba-side-newdeck .ba-side-icon {
+  .ba-side-newdeck-icons,
+  .ba-side-newdeck-icon--plus,
+  .ba-side-newdeck-icon--submit {
     transition: none;
   }
 }

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -14,20 +14,61 @@
 
   // ---- icons (inline SVG, stroke uses currentColor) -------------------- //
   // Lightweight stroke set tuned to feel editorial, not iconographic.
+  // Each icon is structured so the parts most worth animating on hover are
+  // wrapped in groups with stable class hooks (see sidebar.css).
   var ICONS = {
-    decks:    '<path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 12l9 4 9-4"/><path d="M3 17l9 4 9-4"/>',
-    add:      '<path d="M12 5v14"/><path d="M5 12h14"/>',
-    browse:   '<circle cx="11" cy="11" r="6.5"/><path d="M20 20l-4.3-4.3"/>',
-    stats:    '<path d="M4 19V9"/><path d="M10 19V5"/><path d="M16 19v-8"/><path d="M22 19h-22"/>',
-    create:   '<path d="M12 5v14"/><path d="M5 12h14"/>',
-    "import": '<path d="M12 4v12"/><path d="M6 10l6-6 6 6"/><path d="M4 20h16"/>',
-    sync:     '<path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/>',
-    settings: '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5 1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h0a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h0a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v0a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/>',
+    decks:
+      '<g class="ba-i-decks-top"><path d="M3 7l9-4 9 4-9 4-9-4z"/></g>' +
+      '<g class="ba-i-decks-mid"><path d="M3 12l9 4 9-4"/></g>' +
+      '<g class="ba-i-decks-bot"><path d="M3 17l9 4 9-4"/></g>',
+    add:
+      '<g class="ba-i-plus">' +
+        '<path d="M12 5v14"/><path d="M5 12h14"/>' +
+      '</g>',
+    browse:
+      '<g class="ba-i-search-lens">' +
+        '<circle cx="11" cy="11" r="6.5"/>' +
+      '</g>' +
+      '<g class="ba-i-search-handle">' +
+        '<path d="M20 20l-4.3-4.3"/>' +
+      '</g>',
+    stats:
+      '<g class="ba-i-bars">' +
+        '<path class="ba-i-bar ba-i-bar-1" d="M4 19V9"/>' +
+        '<path class="ba-i-bar ba-i-bar-2" d="M10 19V5"/>' +
+        '<path class="ba-i-bar ba-i-bar-3" d="M16 19v-8"/>' +
+      '</g>' +
+      '<path d="M22 19h-22"/>',
+    create:
+      '<g class="ba-i-plus">' +
+        '<path d="M12 5v14"/><path d="M5 12h14"/>' +
+      '</g>',
+    submit:
+      '<g class="ba-i-submit">' +
+        '<path d="M5 12h14"/><path d="M13 6l6 6-6 6"/>' +
+      '</g>',
+    "import":
+      '<g class="ba-i-import">' +
+        '<path class="ba-i-import-stem"  d="M12 4v12"/>' +
+        '<path class="ba-i-import-head"  d="M6 10l6-6 6 6"/>' +
+      '</g>' +
+      '<path d="M4 20h16"/>',
+    sync:
+      '<g class="ba-i-sync">' +
+        '<path d="M21 12a9 9 0 1 1-3-6.7"/>' +
+        '<path d="M21 4v5h-5"/>' +
+      '</g>',
+    settings:
+      '<g class="ba-i-gear">' +
+        '<circle cx="12" cy="12" r="3"/>' +
+        '<path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5 1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h0a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h0a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v0a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/>' +
+      '</g>',
   };
-  function iconSVG(name) {
+  function iconSVG(name, extraClass) {
     var body = ICONS[name];
     if (!body) return "";
-    return '<svg class="ba-side-icon" viewBox="0 0 24 24" width="14" height="14" '
+    var cls = "ba-side-icon" + (extraClass ? " " + extraClass : "");
+    return '<svg class="' + cls + '" viewBox="0 0 24 24" width="14" height="14" '
          + 'fill="none" stroke="currentColor" stroke-width="1.7" '
          + 'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
          + body + '</svg>';
@@ -60,10 +101,18 @@
     row.className = "ba-side-item ba-side-act ba-side-newdeck";
     row.setAttribute("data-cmd", "create");
     row.setAttribute("data-state", "idle");
-    // Label + input share a single flex slot so they overlap in place;
+    // The icon slot holds two SVGs stacked in the same 14×14 box: the
+    // idle plus and the active submit (right arrow). They cross-fade as
+    // the state changes — the shared horizontal stroke of both glyphs
+    // makes the swap read as a morph rather than a flicker.
+    //
+    // Label + input share their own flex slot so they overlap in place;
     // CSS fades one in as the other fades out — no layout shift.
     row.innerHTML =
-      iconSVG("create") +
+      '<span class="ba-side-newdeck-icons" aria-hidden="true">' +
+        iconSVG("create", "ba-side-newdeck-icon--plus") +
+        iconSVG("submit", "ba-side-newdeck-icon--submit") +
+      '</span>' +
       '<span class="ba-side-newdeck-swap">' +
         '<span class="ba-side-newdeck-label">New deck</span>' +
         '<input type="text" class="ba-side-newdeck-input" autocomplete="off" ' +
@@ -71,6 +120,7 @@
       '</span>';
 
     var input = row.querySelector(".ba-side-newdeck-input");
+    var iconBtn = row.querySelector(".ba-side-newdeck-icons");
 
     function open() {
       if (row.getAttribute("data-state") === "active") { input.focus(); return; }
@@ -93,7 +143,7 @@
       close();
     }
 
-    // Click on the row (outside the input) opens it.
+    // Click on the row (outside the input/icon) opens it.
     row.addEventListener("click", function (e) {
       if (row.getAttribute("data-state") === "active") return;
       e.preventDefault();
@@ -119,6 +169,20 @@
       setTimeout(function () {
         if (document.activeElement !== input) close();
       }, 80);
+    });
+
+    // In active state the icon doubles as a submit affordance — clicking
+    // it is equivalent to pressing Enter from the input. mousedown's
+    // preventDefault keeps the input focused so the submit reads its
+    // current value (and avoids the blur-then-close race).
+    iconBtn.addEventListener("mousedown", function (e) {
+      if (row.getAttribute("data-state") === "active") e.preventDefault();
+    });
+    iconBtn.addEventListener("click", function (e) {
+      if (row.getAttribute("data-state") !== "active") return; // idle: let it bubble
+      e.preventDefault();
+      e.stopPropagation();
+      submit();
     });
 
     // Public hook used by the Python handler when "ba:create" comes from a


### PR DESCRIPTION
## Summary
- The New Deck row's `+` cross-fades to a right-arrow submit glyph when the row opens; clicking the arrow runs the same `submit()` path as pressing Enter (mousedown `preventDefault` keeps the input focused so the value is read before blur).
- Each sidebar icon gains a small on-hover (and `:focus-visible`) gesture matched to its glyph: decks lift, plus rotates, lens scans, bars rise, arrow bobs, sync spins 360°, gear turns 90°. Inner `<g class="ba-i-*">` hooks were added so animations target sub-parts without disturbing the parent's color transition.
- `prefers-reduced-motion` disables all of the above.

## Test plan
- [ ] Click `+` on the New Deck row — icon morphs to arrow; type a name and click the arrow → deck is created (same as Enter).
- [ ] Click `+`, type nothing, click the arrow → row closes (matches Enter behavior).
- [ ] Press Esc / click outside → row closes, icon morphs back to `+`.
- [ ] Hover each sidebar row and confirm the icon gesture plays; keyboard-focus a row and confirm the same gesture fires.
- [ ] Trigger an active sync and confirm the hover-spin yields to the existing continuous spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)