### PR TITLE
Light-mode UI fixes + anti-flash curtain for Add Card embed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -308,11 +308,42 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         # by Browser and Edit-Current; we don't want to overwrite their
         # chrome here. Anki's CSP blocks inline <script> in the editor page,
         # so the mode AND theme are communicated via a meta tag in the head
-        # that addcard.js reads (avoiding inline-script CSP).
+        # that addcard.js reads (avoiding inline-script CSP). Inline <style>
+        # IS allowed and runs synchronously before first paint, so we use it
+        # to suppress the open-time FOUC: the body starts at opacity 0 on a
+        # paper-colored canvas, then addcard.js fades it back in once the
+        # toolbar/field/tags settle. Without this, the user sees Anki's
+        # default editor briefly, then ours, then JS reshuffling tags and
+        # the gear into place — reads as a stack of flashes.
         em = getattr(context, "editorMode", None)
         if em == EditorMode.ADD_CARDS:
             theme_safe = theme_pref if theme_pref in ("light", "dark") else ""
+            # Resolve the actual paper color once, in Python — even when
+            # theme_pref is "system" — so the inline <style> can emit a
+            # single concrete bg color. If we instead used a CSS media
+            # query keyed to prefers-color-scheme, the bg would flip
+            # mid-load on system=dark + addon=light (because data-rf-theme
+            # isn't set until addcard.js runs), which itself reads as a
+            # flash. One concrete color = no flip.
+            try:
+                from . import addcard as _addcard
+                _pal, _ = _addcard._resolve_palette()
+                paper_color = _pal["paper"]
+            except Exception:
+                paper_color = "#f6f3ec"
             web_content.head += (
+                "<style>"
+                # !important: Anki's editor.css loads after our inline
+                # style and sets `body { background-color: var(--bs-body-bg) }`
+                # which resolves to a near-white in light mode (the default
+                # Bootstrap palette). Without !important Anki wins on source
+                # order and the page flashes white before our addcard.css
+                # eventually overrides body bg. !important here makes the
+                # paper bg stick from first paint.
+                f"html,body{{background:{paper_color}!important}}"
+                "body{opacity:0;transition:opacity 220ms ease}"
+                "html[data-ba-ready] body{opacity:1}"
+                "</style>"
                 f'<meta name="ba-editor-mode" content="add">'
                 f'<meta name="ba-theme" content="{theme_safe}">'
             )
@@ -726,15 +757,33 @@ def _on_js_message(handled, message, context):
         return handled
     cmd = message[3:]
     try:
+        if cmd == "embed-ready":
+            # addcard.js fires this from reveal() once the editor body is
+            # ready to fade in. We drop the anti-flash curtain that
+            # open_inline put up, so the user transitions straight from
+            # paper to faded-in editor with no intermediate state.
+            try:
+                from . import addcard_embed
+                addcard_embed.drop_curtain()
+            except Exception:
+                pass
+            return (True, None)
         if cmd == "decks":
             # If we're in the embedded Add view, close it first so the deck
-            # browser becomes visible again.
+            # browser becomes visible again. The Add embed is an overlay
+            # painted *on top of* the deck browser — mw.state stays
+            # "deckBrowser" the whole time it's open. Calling moveToState
+            # while already in deckBrowser state triggers a full re-render
+            # of the deck list HTML (deckBrowser.show()), which reads as a
+            # disorienting flash when switching tabs. Only move state when
+            # we're actually somewhere else (reviewer, overview, etc.).
             try:
                 from . import addcard_embed
                 addcard_embed.close_inline()
             except Exception:
                 pass
-            mw.moveToState("deckBrowser")
+            if getattr(mw, "state", None) != "deckBrowser":
+                mw.moveToState("deckBrowser")
         elif cmd == "add":
             # Open AddCards inside the main window (over the deck area, to
             # the right of the sidebar). Falls back to the standard window

--- a/addcard.py
+++ b/addcard.py
@@ -461,9 +461,18 @@ def _redress(addcards: AddCards) -> None:
     except Exception:
         pass
 
-    # Build our root container.
+    # Build our root container. Palette + autoFillBackground paints it
+    # opaque paper from the very first frame, beating the QSS pass which
+    # can lag by one frame and otherwise shows as a white flash on dark
+    # mode when the embed is first shown.
     root = QWidget()
     root.setObjectName("ba-root")
+    root.setAutoFillBackground(True)
+    _root_pal = root.palette()
+    _root_pal.setColor(
+        QPalette.ColorRole.Window, QColor(palette["paper"])
+    )
+    root.setPalette(_root_pal)
     root_layout = QVBoxLayout(root)
     root_layout.setContentsMargins(0, 0, 0, 0)
     root_layout.setSpacing(0)
@@ -714,6 +723,35 @@ def _redress(addcards: AddCards) -> None:
         pass
     try:
         addcards.setCentralWidget(root)
+    except Exception:
+        pass
+
+    # Pre-paint the editor webview's default page background to match our
+    # paper color. Anki's webview.py already calls setBackgroundColor with
+    # its own theme-aware CANVAS color (#f5f5f5 in light, #2c2c2c in dark)
+    # — if the user's Anki app is in light mode but the addon is in dark
+    # mode, that means the page bg is near-white. Overriding it here keeps
+    # the webview painting paper-dark from the very first frame.
+    # Also paint the Qt widget itself (the backing store under the
+    # Chromium compositor) so anything that briefly paints before the GPU
+    # layer is uploaded shows paper, not the default widget white.
+    try:
+        web = getattr(addcards.editor, "web", None)
+        if web is not None:
+            page = web.page()
+            if page is not None:
+                page.setBackgroundColor(QColor(palette["paper"]))
+            try:
+                web.setStyleSheet(
+                    f"QWidget {{ background: {palette['paper']}; }}"
+                )
+                web.setAutoFillBackground(True)
+                _wp = web.palette()
+                _wp.setColor(QPalette.ColorRole.Window, QColor(palette["paper"]))
+                _wp.setColor(QPalette.ColorRole.Base, QColor(palette["paper"]))
+                web.setPalette(_wp)
+            except Exception:
+                pass
     except Exception:
         pass
 

--- a/addcard_embed.py
+++ b/addcard_embed.py
@@ -32,16 +32,20 @@ from typing import Any, Optional
 
 from aqt import mw
 from aqt.qt import (
+    QApplication,
+    QColor,
     QEvent,
     QFrame,
     QHBoxLayout,
     QKeySequence,
     QLabel,
     QObject,
+    QPalette,
     QPushButton,
     QShortcut,
     QSize,
     Qt,
+    QTimer,
     QVBoxLayout,
     QWidget,
 )
@@ -106,6 +110,21 @@ class _EmbedFilter(QObject):
 _state: dict = {"addcards": None, "overlay": None, "filter": None}
 
 
+def drop_curtain() -> None:
+    """Tear down the anti-flash curtain put up by open_inline.
+
+    Called from the `ba:embed-ready` pycmd that addcard.js fires from
+    its reveal() once the editor body has had a chance to settle. Safe
+    to call multiple times — second+ calls are no-ops."""
+    c = _state.pop("curtain", None)
+    _state.pop("drop_curtain", None)
+    if c is not None:
+        try:
+            c.deleteLater()
+        except Exception:
+            pass
+
+
 def close_inline() -> None:
     """Tear down the embedded view and restore the deck browser.
 
@@ -123,6 +142,17 @@ def close_inline() -> None:
     _state["addcards"] = None
     _state["overlay"] = None
     _state["filter"] = None
+    cw_palette = _state.pop("cw_palette", None)
+    # Drop the anti-flash curtain if it's still up (close_inline can fire
+    # before the editor finished loading, e.g. user hits Esc immediately
+    # after clicking Add).
+    curtain = _state.pop("curtain", None)
+    if curtain is not None:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+    _state.pop("drop_curtain", None)
 
     if overlay is not None:
         try:
@@ -132,6 +162,14 @@ def close_inline() -> None:
             pass
         try:
             overlay.deleteLater()
+        except Exception:
+            pass
+    # Restore the centralwidget's original palette (we tinted it paper
+    # while the embed was open so any first-frame Qt gap painted dark
+    # instead of the default white).
+    if cw_palette is not None:
+        try:
+            mw.form.centralwidget.setPalette(cw_palette)
         except Exception:
             pass
     if ac is not None:
@@ -172,12 +210,70 @@ def open_inline(parent_mw: Any = None) -> None:
         except Exception:
             pass
         return
+    if _state.get("curtain") is not None:
+        # A curtain is up — we're already mid-open from a previous call
+        # (processEvents below can re-enter on rapid double-click). Bail
+        # so we don't stack a second curtain + AddCards.
+        return
+
+    # --- Curtain (anti-flash) ---------------------------------------
+    # Slam an opaque paper-colored QFrame over the embed area BEFORE any
+    # of the AddCards / webview machinery runs. While the curtain is up,
+    # everything underneath (the QWebEngineView's default white page bg,
+    # any Qt widget that briefly paints with the wrong palette, the
+    # toolbar/tag DOM reshuffle inside the editor) is invisible. We pump
+    # one round of events to force the curtain's paint before we kick
+    # off the heavy AddCards work, then drop the curtain only after the
+    # editor's page loadFinished fires plus a small grace for the JS to
+    # settle.
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    paper_qc = QColor(palette["paper"])
+    cw = parent_mw.form.centralwidget
+
+    curtain = QFrame(cw)
+    curtain.setObjectName("ba-embed-curtain")
+    curtain.setAutoFillBackground(True)
+    _cu_pal = curtain.palette()
+    _cu_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+    curtain.setPalette(_cu_pal)
+    curtain.setStyleSheet(
+        "QFrame#ba-embed-curtain { background: " + palette["paper"] + "; }"
+    )
+    curtain.setGeometry(SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height())
+    curtain.show()
+    curtain.raise_()
+    _state["curtain"] = curtain
+    # Force the curtain to paint NOW (repaint is synchronous, processEvents
+    # pumps any pending events) so when the AddCards work below starts
+    # spinning up Chromium and mounting Svelte, the curtain is already
+    # covering the embed area and the user never sees what's underneath.
+    try:
+        curtain.repaint()
+        QApplication.processEvents()
+    except Exception:
+        pass
 
     try:
         from aqt.addcards import AddCards
-        ac = AddCards(parent_mw)
+        # Anki's AddCards.__init__ ends with `self.show()`, which would
+        # flash the standalone QMainWindow on screen for one paint before
+        # we reparent its central widget into the overlay and hide the
+        # window. Subclassing to no-op `show()` keeps it invisible from
+        # the start; everything else (geometry restore, hook firing,
+        # central-widget construction via _redress) still runs in the
+        # parent constructor.
+        class _EmbeddedAddCards(AddCards):  # type: ignore[misc, valid-type]
+            def show(self) -> None:  # noqa: D401 — Qt method override
+                pass
+        ac = _EmbeddedAddCards(parent_mw)
     except Exception:
         # Anki's normal flow as a last resort.
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+        _state["curtain"] = None
         try:
             parent_mw.onAddCard()
         except Exception:
@@ -186,11 +282,19 @@ def open_inline(parent_mw: Any = None) -> None:
 
     try:
         central = ac.centralWidget()
+
         # Build an overlay frame holding the redressed AddCards centralWidget.
         # No back button — the sidebar already has a "Decks" item, and we
         # mark "Add" as active there so the user knows what tab they're on.
         overlay = QFrame(parent_mw.form.centralwidget)
         overlay.setObjectName("ba-embed")
+        # Palette + autoFillBackground paints the QFrame opaque in the
+        # native paint path, beating any first-frame transparency before
+        # the QSS is committed.
+        overlay.setAutoFillBackground(True)
+        _ov_pal = overlay.palette()
+        _ov_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+        overlay.setPalette(_ov_pal)
         overlay.setStyleSheet(_palette_styles())
 
         v = QVBoxLayout(overlay)
@@ -208,11 +312,53 @@ def open_inline(parent_mw: Any = None) -> None:
 
         # Position over the right of the central area.
         cw = parent_mw.form.centralwidget
+        # Paint the main centralwidget paper for the duration of the
+        # embed. mw.web normally covers it, but during the brief frame
+        # where the overlay show triggers a layout pass on the main
+        # window, Qt can momentarily expose the centralwidget's palette
+        # bg — which on Anki-light + addon-dark is near-white, producing
+        # the white flash. Stash the original palette so we can restore
+        # it on close.
+        try:
+            _state["cw_palette"] = QPalette(cw.palette())
+            _cw_pal = cw.palette()
+            _cw_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+            cw.setPalette(_cw_pal)
+        except Exception:
+            pass
         overlay.setGeometry(
             SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height()
         )
         overlay.show()
         overlay.raise_()
+        # Curtain must stay on top of the overlay while everything inside
+        # the overlay (editor webview, Svelte mount, our addcard.js DOM
+        # shuffle) is still settling.
+        try:
+            curtain.raise_()
+        except Exception:
+            pass
+
+        # Drop the curtain when addcard.js fires ba:embed-ready from
+        # reveal() — that's the exact moment the editor body switches
+        # from opacity 0 to opacity 1 and starts its fade-in. Dropping
+        # then means the curtain (paper) gives way to the same paper
+        # bg of the editor body, with content fading in on top. No
+        # white/black/snap visible to the user.
+        # Backstop: if the pycmd never fires (very rare — JS error in
+        # the editor, sandboxed iframe, etc.), fall back to loadFinished
+        # plus a short grace, and a hard cap so the user is never
+        # stranded behind paper.
+        try:
+            page = ac.editor.web.page()
+
+            def _on_loaded(_ok: bool) -> None:
+                QTimer.singleShot(280, drop_curtain)
+
+            page.loadFinished.connect(_on_loaded)
+        except Exception:
+            pass
+        QTimer.singleShot(2000, drop_curtain)
 
         # Resize the overlay with the main window.
         flt = _EmbedFilter(overlay)

--- a/web/addcard.css
+++ b/web/addcard.css
@@ -42,13 +42,39 @@ html[data-ba-editor="add"] {
 html[data-ba-editor="add"][data-rf-theme="dark"] {
   --ba-paper: #0b0c0f;
   --ba-panel: #15171c;
-  --ba-field: #f6f3ec;
+  --ba-field: #15171c;
   --ba-ink: #eceae2;
   --ba-ink-dim: #9b978a;
   --ba-ink-faint: #5d5a51;
   --ba-line: rgba(236, 234, 226, 0.10);
   --ba-line-strong: rgba(236, 234, 226, 0.20);
   --ba-hover: rgba(236, 234, 226, 0.05);
+}
+
+/* Re-map Anki's editor tokens onto our theme. Anki's editor.css defines
+   --fg, --canvas-elevated, --fg-subtle etc. and toggles them via the
+   .night-mode class on <html>. If the user has Anki Design's theme set
+   to "light" but Anki itself is in night mode (or vice versa), Anki's
+   tokens leak into Svelte field contents — most visibly as near-white
+   --fg text on our white field. Re-binding the tokens to our --ba-*
+   variables keeps the field readable regardless of which mode Anki is
+   in. CSS variables inherit across shadow DOM boundaries, so this
+   reaches inside the Svelte rich-text-input / plain-text-input. */
+html[data-ba-editor="add"] {
+  --fg: var(--ba-ink);
+  --fg-subtle: var(--ba-ink-faint);
+  --fg-disabled: var(--ba-ink-faint);
+  --fg-faint: var(--ba-ink-faint);
+  --bs-body-color: var(--ba-ink);
+  --bs-body-bg: var(--ba-paper);
+  --canvas: var(--ba-paper);
+  --canvas-elevated: var(--ba-field);
+  --canvas-inset: var(--ba-paper);
+  --canvas-overlay: var(--ba-panel);
+  --canvas-code: var(--ba-field);
+  --border: var(--ba-line-strong);
+  --border-subtle: var(--ba-line);
+  --border-strong: var(--ba-ink-faint);
 }
 
 html[data-ba-editor="add"], html[data-ba-editor="add"] body {

--- a/web/addcard.js
+++ b/web/addcard.js
@@ -43,7 +43,6 @@
     if (!nt) return false;
     var btns = nt.querySelectorAll(".label-button");
     if (!btns.length) return false;
-    var any = false;
     btns.forEach(function (b) {
       // The label text lives in a leaf text node; walk to find it.
       var walker = document.createTreeWalker(b, NodeFilter.SHOW_TEXT, null);
@@ -54,11 +53,14 @@
         var stripped = txt.replace(/[…]+|\.{2,}/g, "").trim();
         if (stripped !== txt) {
           n.nodeValue = stripped;
-          any = true;
         }
       }
     });
-    return any;
+    // Truthy = setup ran (buttons present) regardless of whether dots
+    // were actually stripped this pass. settleAndReveal needs this so
+    // the reveal doesn't wait for a "did work" signal that never comes
+    // when the labels are already clean from a prior pass.
+    return true;
   }
 
   // Tag editor never collapses — we want the tags input always visible so
@@ -124,11 +126,38 @@
     }, 200);
   }
 
-  reorderToolbar();
-  poll(reorderToolbar, 30);
-  poll(cleanFieldsCardsLabels, 30);
-  poll(keepTagsOpen, 30);
-  poll(moveTagsIntoFields, 30);
+  // Fade the body in once the DOM has been rearranged — the inline <style>
+  // in head starts it at opacity 0 so the FOUC + the toolbar/tag shuffle
+  // never reach the user. Reveal as soon as the first pass of each setup
+  // function succeeds, or after a hard timeout (so a failed setup never
+  // leaves the user staring at a blank pane).
+  function reveal() {
+    if (document.documentElement.dataset.baReady === "1") return;
+    document.documentElement.dataset.baReady = "1";
+    // Tell Python the editor body is ready to be revealed — this drops
+    // the open-time curtain that addcard_embed.open_inline put up to
+    // hide the webview's load-time white flash. Wrapped in try since
+    // pycmd may not be available in every embedding context.
+    try { pycmd("ba:embed-ready"); } catch (_) {}
+  }
+  function settleAndReveal() {
+    var ok = true;
+    ok = reorderToolbar() && ok;
+    ok = cleanFieldsCardsLabels() && ok;
+    ok = keepTagsOpen() && ok;
+    ok = moveTagsIntoFields() && ok;
+    if (ok) reveal();
+    return ok;
+  }
+  // First pass right after this script runs — if the editor is already
+  // ready (often the case), this reveals on the next frame with no flash.
+  // Otherwise keep trying until everything succeeds or we hit the cap.
+  if (!settleAndReveal()) {
+    poll(settleAndReveal, 30);
+  }
+  // Safety net: 700ms after script start, reveal unconditionally so a
+  // partial init never traps the user in a blank pane.
+  setTimeout(reveal, 700);
 
   // Re-apply whenever the toolbar mutates (Anki re-renders on field focus
   // change, notetype switch, etc.).

--- a/web/theme.css
+++ b/web/theme.css
@@ -539,77 +539,18 @@ body::before {
   text-align: left;
   cursor: pointer;
   overflow: hidden;
-  transition: border-color 240ms ease, transform 160ms ease,
-              box-shadow 280ms ease;
+  transition: background 180ms ease, border-color 180ms ease;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
 }
 
-/* Hover — accent border + a soft top-anchored glow + a feather-light
-   elevation. Earlier versions used a heavy 22% accent drop shadow that
-   read as a dark blue blot on light paper; this version stays subtle
-   in both themes (theme-specific tweaks live below). */
-.ba-hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(120% 80% at 50% 0%,
-              color-mix(in srgb, var(--rf-accent, #6c8cff) 9%, transparent),
-              transparent 70%);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 260ms ease;
-}
-.ba-hero:hover::before,
-.ba-hero.is-hover::before { opacity: 1; }
+/* Hover — a single calm background tint composed onto the panel.
+   Earlier versions stacked an accent border, ring shadow, drop glow,
+   gradient overlay, and translateY lift; together those read as a
+   heavy dark blot on warm paper. */
 .ba-hero:hover,
 .ba-hero.is-hover {
-  border-color: var(--rf-accent, #6c8cff);
-  transform: translateY(-1px);
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 14%, transparent),
-    0 10px 22px color-mix(in srgb, var(--rf-accent, #6c8cff) 10%, transparent);
+  background: color-mix(in srgb, var(--rf-ink) 4%, var(--rf-panel));
 }
-/* Light mode shadows read heavier on warm paper — dial them back further. */
-@media (prefers-color-scheme: light) {
-  :root:not([data-rf-theme="dark"]) .ba-hero:hover,
-  :root:not([data-rf-theme="dark"]) .ba-hero.is-hover {
-    box-shadow:
-      0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 16%, transparent),
-      0 6px 16px color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent);
-  }
-  :root:not([data-rf-theme="dark"]) .ba-hero::before {
-    background: radial-gradient(120% 80% at 50% 0%,
-                color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent),
-                transparent 70%);
-  }
-}
-:root[data-rf-theme="light"] .ba-hero:hover,
-:root[data-rf-theme="light"] .ba-hero.is-hover {
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--rf-accent, #6c8cff) 16%, transparent),
-    0 6px 16px color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent);
-}
-:root[data-rf-theme="light"] .ba-hero::before {
-  background: radial-gradient(120% 80% at 50% 0%,
-              color-mix(in srgb, var(--rf-accent, #6c8cff) 7%, transparent),
-              transparent 70%);
-}
-/* Dark mode benefits from a slightly stronger sweep — the dark panel
-   would otherwise absorb the gradient. */
-:root[data-rf-theme="dark"] .ba-hero::before {
-  background: radial-gradient(120% 80% at 50% 0%,
-              color-mix(in srgb, var(--rf-accent, #6c8cff) 12%, transparent),
-              transparent 70%);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-rf-theme="light"]) .ba-hero::before {
-    background: radial-gradient(120% 80% at 50% 0%,
-                color-mix(in srgb, var(--rf-accent, #6c8cff) 12%, transparent),
-                transparent 70%);
-  }
-}
-.ba-hero:active { transform: translateY(0); }
 .ba-hero:focus-visible {
   outline: 2px solid var(--rf-accent, #6c8cff);
   outline-offset: 4px;
@@ -618,15 +559,10 @@ body::before {
   cursor: default;
   border-color: var(--rf-line);
 }
-.ba-hero.ba-hero--done::before { display: none; }
 .ba-hero.ba-hero--done:hover {
-  border-color: var(--rf-line);
-  transform: none;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  background: var(--rf-panel);
 }
 
-/* Hover Study pill removed — the card's accent border + glow already
-   signal interactivity, and the user didn't want an inline cue. */
 .ba-hero.ba-hero--done .ba-hero-go { display: none; }
 .ba-hero-arrow {
   font-family: var(--rf-sans);
@@ -641,7 +577,6 @@ body::before {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
   align-items: end;
-  position: relative; /* sit above the ::before gradient */
 }
 .ba-hero-stat {
   display: flex;


### PR DESCRIPTION
## Summary

- **Add Card editor text**: fix white-on-white field text by remapping Anki's editor tokens (`--fg`, `--canvas-elevated`, `--bs-body-bg`, etc.) onto our `--ba-*` theme so the editor honors our theme even when Anki itself is in the opposite mode. Also fix `--ba-field` in the explicit `data-rf-theme=\"dark\"` block (was reusing the light paper color).
- **Single-deck hero hover**: replace heavy accent border + 2px ring shadow + drop glow + gradient overlay + translateY lift with a single calm background tint, matching the rest of the app's row hovers.
- **Add Card embed open**: opaque paper-colored `QFrame` curtain is raised over the embed area *before* any AddCards/webview machinery runs (with synchronous `repaint()` + `processEvents()` to force first paint); dropped only when `addcard.js`'s `reveal()` fires `pycmd(\"ba:embed-ready\")`. Backstops: `loadFinished`+280ms grace and a 2s hard cap. Also suppresses `AddCards.__init__`'s `self.show()` via subclass so the standalone QMainWindow never flashes, and skips `mw.moveToState(\"deckBrowser\")` in the `ba:decks` handler when already in that state (was re-rendering the deck list on every tab toggle).

## Test plan

- [ ] Decks → Add transition: no white/black flash in either light or dark mode (Anki app theme x addon theme matrix: light/light, light/dark, dark/light, dark/dark)
- [ ] Add Card field text is dark in light mode, light in dark mode
- [ ] Add → Decks transition: overlay drops away without re-rendering the deck list
- [ ] Single-deck hero hover: subtle bg tint, no accent ring / drop shadow / lift
- [ ] Esc immediately after clicking Add doesn't strand a curtain on screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)