### PR TITLE
Expandable sub-decks on home + un-clip Add Card dropdowns

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -220,6 +220,10 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         # Whole-row click → study (skips the Overview page). Loaded
         # unconditionally on the deck browser, independent of sidebar.
         web_content.js.append(f"{WEB}/deckrow.js")
+        # Expand/collapse chevron on parent decks. Tree is forced fully
+        # expanded server-side (see _patch_deck_tree_always_expanded);
+        # this JS folds descendants client-side, session-only.
+        web_content.js.append(f"{WEB}/decktree.js")
         # Tag the deck browser's <center> so theme.css can scope the heavy
         # homepage layout to it alone — the Overview shares this stylesheet
         # and must keep its own simple layout (just palette + type).
@@ -2175,12 +2179,31 @@ def _dev_screenshot(request_path: str) -> None:
                 from aqt import dialogs
                 ac = dialogs._dialogs.get("AddCards", [None, None])[1]
                 if ac is None:
+                    try:
+                        from . import addcard_embed
+                        ac = addcard_embed._state.get("addcards")
+                    except Exception:
+                        ac = None
+                if ac is None or not getattr(ac, "editor", None):
                     return
                 web = ac.editor.web
-                web.eval(
-                    "(function(){var b=document.querySelector('#settings button');"
-                    "if(b)b.click();})();"
-                )
+                # Anki's Svelte popup listens for a real PointerEvent — .click()
+                # alone doesn't fire it. Dispatch pointerdown + mousedown + click
+                # so the floating-ui library actually toggles the dropdown.
+                web.eval("""
+                  (function(){
+                    var btn = document.querySelector('#settings button');
+                    if (!btn) return;
+                    function fire(name) {
+                      var ev = new MouseEvent(name, {bubbles:true, cancelable:true, view:window, button:0});
+                      btn.dispatchEvent(ev);
+                    }
+                    fire('pointerdown');
+                    fire('mousedown');
+                    fire('mouseup');
+                    fire('click');
+                  })();
+                """)
             except Exception:
                 pass
         if click_cog:

--- a/web/addcard.css
+++ b/web/addcard.css
@@ -72,19 +72,10 @@ html[data-ba-editor="add"] .image-overlay:empty {
  *   1. Icon buttons are uniformly sized (square) so the row reads as a
  *      coherent strip, not a jumble of variable rectangles.
  *   2. Hover background fully contains each icon — no clipping at the top.
- *   3. The row scrolls horizontally when it doesn't fit (overflow-x:auto)
- *      while leaving dropdowns free to escape vertically (overflow-y:clip
- *      with negative-margin scroll-padding so the popups stay visible).
- *
- * The gear's popup menu lives inside .button-group#settings (positioned by
- * Popper). When toolbar overflow-x is on, Popper's `position: absolute`
- * panel is clipped. We use `overflow-y: visible` on the outer .editor-toolbar
- * and put `overflow-x: auto` on the inner .button-toolbar; the popup is
- * elevated via z-index and any vertical clipping is avoided because the
- * popup expands DOWN and the toolbar's bottom edge is the scroll axis.
- * For horizontal scroll, we accept that popups too wide for the viewport
- * will follow the scroll — acceptable since the gear is anchored to its
- * button which scrolls with it.
+ *   3. Dropdown popups (eraser palette, gear settings, color pickers) can
+ *      extend DOWN past the toolbar without being clipped. See the overflow
+ *      block on .button-toolbar below for the spec-level reason this is
+ *      `overflow-x: clip` rather than `overflow-x: auto`.
  */
 html[data-ba-editor="add"] .editor-toolbar {
   background: var(--ba-panel) !important;
@@ -98,7 +89,17 @@ html[data-ba-editor="add"] .button-toolbar.btn-toolbar {
   --buttons-size: 1.85rem !important;
   --buttons-wrap: nowrap !important;
   flex-wrap: nowrap !important;
-  overflow-x: auto !important;
+  /* CRITICAL: per the CSS Overflow spec, mixing overflow-x: auto with
+     overflow-y: visible forces BOTH axes to auto — which clips the eraser /
+     settings / color picker dropdowns at the bottom edge of the toolbar.
+     `overflow-x: clip` + `overflow-y: visible` is the one combination the
+     spec explicitly preserves, so the popups can extend down freely while
+     horizontal overflow is still hidden. The trade-off: if a user squeezes
+     the window narrow enough that the toolbar can't fit, trailing buttons
+     get cut off with no scrollbar. That's the right call here — the buttons
+     row is already short and dropdown popups are far more important than a
+     rarely-used horizontal scroll. */
+  overflow-x: clip !important;
   overflow-y: visible !important;
   align-items: center !important;
   padding: 6px 24px !important;
@@ -244,15 +245,15 @@ html[data-ba-editor="add"] #notetype .label-button:hover {
 /* Gear: push to the very end via flex order. */
 html[data-ba-editor="add"] .item#settings { order: 99 !important; }
 html[data-ba-editor="add"] .item#notetype { order: -1 !important; }
-/* Dropdown panels (Popper-based "floating" elements) live inside the
-   toolbar's DOM tree. Their default visibility is toggled by Anki; we just
-   ensure they stack above other content when shown and don't get clipped.
+/* Dropdown panels (Popper-based "floating" elements). Anki's stylesheet
+   already puts them at z-index 890 — high enough to clear the sidebar
+   (z-index 50) and the editor's own canvas-elevated chrome (z-index 60).
+   We must NOT override that with our own z-index: a previous `z-index: 50
+   !important` here was actually demoting the popups *below* the sidebar,
+   making them invisible when the eraser / settings dropdowns opened.
    IMPORTANT: don't add a background/border unconditionally — when the panel
    is closed it's still in the DOM and our styles would draw a visible
    "circle" around every chevron-button in the toolbar. */
-html[data-ba-editor="add"] .floating {
-  z-index: 50 !important;
-}
 html[data-ba-editor="add"] .floating[data-show],
 html[data-ba-editor="add"] .floating[style*="display: block"],
 html[data-ba-editor="add"] .floating[style*="display:flex"] {

--- a/web/decktree.js
+++ b/web/decktree.js
@@ -1,0 +1,174 @@
+/* Anki Design — expandable parent decks on the homepage.
+
+   Anki's tree is always rendered fully expanded by us
+   (see _patch_deck_tree_always_expanded in __init__.py), so every row
+   is in the DOM. This script identifies parent rows (those whose
+   immediately-following rows are indented deeper), replaces Anki's
+   `+ / -` text toggle with a chevron button, and folds descendants
+   in-place. State is session-only (sessionStorage) — we don't touch
+   the backend collapse flags. */
+(function () {
+  "use strict";
+  if (window.__adDeckTreeWired) return;
+  window.__adDeckTreeWired = true;
+
+  var STORAGE_KEY = "__adCollapsedDecks";
+
+  // Down-pointing chevron at rest (matches existing chevron-down.svg).
+  // CSS rotates it -90° to point right when .ad-collapsed.
+  var CHEV_SVG =
+    '<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" ' +
+    'stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" ' +
+    'aria-hidden="true"><polyline points="3,4.6 6,7.6 9,4.6"/></svg>';
+
+  function loadState() {
+    try {
+      var raw = sessionStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch (_) { return {}; }
+  }
+  function saveState(s) {
+    try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(s)); }
+    catch (_) {}
+  }
+
+  // Anki indents children with `&nbsp;` * 6 * (level-1). The nbsps live
+  // in the leading text node of td.decktd; counting them gives the row
+  // its depth.
+  function levelOf(row) {
+    var td = row.querySelector("td.decktd");
+    if (!td) return 0;
+    var text = "";
+    for (var n = td.firstChild; n; n = n.nextSibling) {
+      if (n.nodeType === 3) { text += n.nodeValue; continue; }
+      break;
+    }
+    var nbsp = (text.match(/ /g) || []).length;
+    return Math.floor(nbsp / 6);
+  }
+
+  // Build per-row metadata: level, direct kids (used to detect "is parent"),
+  // and immediate parent (used to walk the ancestor chain for visibility).
+  function buildIndex(rows) {
+    var meta = [];
+    for (var i = 0; i < rows.length; i++) {
+      meta.push({ row: rows[i], level: levelOf(rows[i]), kids: [], parent: null });
+    }
+    var stack = [];
+    for (var i = 0; i < meta.length; i++) {
+      while (stack.length && meta[stack[stack.length - 1]].level >= meta[i].level) {
+        stack.pop();
+      }
+      if (stack.length) {
+        var p = stack[stack.length - 1];
+        meta[i].parent = meta[p].row;
+        meta[p].kids.push(meta[i].row);
+      }
+      stack.push(i);
+    }
+    return meta;
+  }
+
+  // A row is hidden iff any ancestor has state[id] === truthy. This keeps
+  // nested collapses correct: grandparent expanded + parent collapsed
+  // should still hide the grandchild.
+  function applyVisibility(meta, state) {
+    var parentMap = new Map();
+    for (var i = 0; i < meta.length; i++) parentMap.set(meta[i].row, meta[i].parent);
+    for (var i = 0; i < meta.length; i++) {
+      var row = meta[i].row;
+      var hide = false;
+      var p = parentMap.get(row);
+      while (p) {
+        if (state[p.id]) { hide = true; break; }
+        p = parentMap.get(p);
+      }
+      row.classList.toggle("ad-hidden", hide);
+    }
+  }
+
+  function makeChevron(did, collapsed) {
+    var a = document.createElement("a");
+    a.className = "collapse ad-chev" + (collapsed ? " ad-collapsed" : "");
+    a.href = "#";
+    a.setAttribute("role", "button");
+    a.setAttribute("tabindex", "-1");
+    a.setAttribute("aria-label",
+                   collapsed ? "Expand sub-decks" : "Collapse sub-decks");
+    a.setAttribute("data-did", did);
+    a.innerHTML = CHEV_SVG;
+    return a;
+  }
+
+  // Idempotent: safe to run repeatedly. Looks at the row's current state
+  // and brings it in line with the desired classification (parent vs leaf).
+  // The wire pass can be triggered by the MutationObserver before Anki has
+  // finished appending child rows — so a row's parent/leaf status may flip
+  // between passes. Don't cache a "wired" flag; reconcile every time.
+  function wireRow(entry, state, onToggle) {
+    var row = entry.row;
+    var col = row.querySelector(
+      ":scope > td.decktd > a.collapse, :scope > td.decktd > span.collapse"
+    );
+    if (!col) return;
+
+    var isParent = entry.kids.length > 0;
+    var hasChev = col.classList.contains("ad-chev");
+    var hasSpacer = col.classList.contains("ad-spacer");
+
+    if (isParent) {
+      if (hasChev) return;                      // already a chevron parent
+      var did = row.id;
+      var btn = makeChevron(did, !!state[did]);
+      col.replaceWith(btn);
+      btn.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var s = loadState();
+        var now = !s[did];
+        if (now) s[did] = 1; else delete s[did];
+        saveState(s);
+        btn.classList.toggle("ad-collapsed", now);
+        btn.setAttribute("aria-label",
+                         now ? "Expand sub-decks" : "Collapse sub-decks");
+        onToggle(s);
+      });
+      return;
+    }
+
+    // Leaf.
+    if (hasSpacer && !hasChev) return;
+    col.classList.remove("ad-chev", "ad-collapsed");
+    col.classList.add("ad-spacer");
+  }
+
+  function wire() {
+    var rows = document.querySelectorAll("tr.deck");
+    if (!rows.length) return;
+    var meta = buildIndex(rows);
+    var state = loadState();
+    function onToggle(newState) { applyVisibility(meta, newState); }
+    for (var i = 0; i < meta.length; i++) wireRow(meta[i], state, onToggle);
+    applyVisibility(meta, state);
+  }
+
+  function init() {
+    wire();
+    if (window.MutationObserver) {
+      // Anki re-renders the deck browser after operations (study, rename,
+      // etc.). Coalesce mutations into one rAF tick before re-wiring.
+      var pending = 0;
+      var mo = new MutationObserver(function () {
+        if (pending) return;
+        pending = requestAnimationFrame(function () { pending = 0; wire(); });
+      });
+      mo.observe(document.body, { childList: true, subtree: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/web/theme.css
+++ b/web/theme.css
@@ -327,10 +327,68 @@ body::before {
   color: var(--rf-accent, #6c8cff) !important;
   font-style: italic;
 }
-/* Collapse indicator (`+` / `-`) on parent decks. Hidden: clicking the
-   row goes straight to studying, so the toggle has no place here. */
-.ba-home a.collapse,
-.ba-home span.collapse { display: none !important; }
+/* Parent-deck chevron — decktree.js replaces Anki's `+/-` text toggle
+   with .ad-chev on parent rows and .ad-spacer on leaf rows so deck
+   names align across siblings. Anything still carrying just `.collapse`
+   (a transient pre-wire state, or a future Anki rendering) is hidden
+   so nothing leaks through. */
+.ba-home a.collapse:not(.ad-chev),
+.ba-home span.collapse:not(.ad-spacer) { display: none !important; }
+
+.ba-home a.collapse.ad-chev {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin: 0 6px 0 -2px;
+  vertical-align: middle;
+  border-radius: 6px;
+  color: var(--rf-ink-faint);
+  background: transparent;
+  text-decoration: none !important;
+  -webkit-user-select: none;
+  user-select: none;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    transform 240ms cubic-bezier(.2, .8, .2, 1);
+}
+.ba-home a.collapse.ad-chev svg {
+  width: 12px;
+  height: 12px;
+  transform: rotate(0deg);
+  transform-origin: 50% 50%;
+  transition: transform 240ms cubic-bezier(.2, .8, .2, 1);
+}
+/* Default state (expanded) → chevron points down (matches chevron-down.svg).
+   Collapsed → rotate -90° so it points right (closed disclosure). */
+.ba-home a.collapse.ad-chev.ad-collapsed svg { transform: rotate(-90deg); }
+/* The row itself also gets a (very faint) hover background; the chevron
+   needs to read above that, so we use --rf-line for a noticeable lift. */
+.ba-home a.collapse.ad-chev:hover {
+  color: var(--rf-ink-strong);
+  background: var(--rf-line);
+}
+.ba-home a.collapse.ad-chev:active svg { transform: scale(.88); }
+.ba-home a.collapse.ad-chev.ad-collapsed:active svg {
+  transform: rotate(-90deg) scale(.88);
+}
+
+/* Leaf rows get a transparent placeholder sized to the chevron so deck
+   names at the same level line up whether or not the sibling is a parent. */
+.ba-home span.collapse.ad-spacer {
+  display: inline-block;
+  width: 22px;
+  margin: 0 6px 0 -2px;
+  vertical-align: middle;
+}
+
+/* Hidden descendant rows — collapsed instantly (table-row height
+   transitions are not reliable in tables). The chevron rotation carries
+   the visual feedback. */
+.ba-home tr.deck.ad-hidden { display: none; }
+
 /* Whole row is a study target — make that intent visible on hover. */
 .ba-home tr.deck { cursor: pointer; }
 .ba-home tr.deck td.opts,


### PR DESCRIPTION
## Summary
- **Expandable parent decks** on the homepage. Anki renders the tree fully expanded (our existing `_patch_deck_tree_always_expanded` patch); a new `web/decktree.js` adds a chevron in the indent gutter of every parent row that folds descendants in-place. State is per-session via `sessionStorage`, so the backend collapse flags are never touched and re-renders (study, rename, etc.) reapply the user's view. Idempotent `wireRow` reconciles parent vs leaf on every pass, so rows that get classified late (children appended after the first DOM tick) still pick up the chevron. New chevron styles in `web/theme.css` rotate 90° between expanded and collapsed with a leaf-row spacer so deck names stay aligned across siblings.
- **Add Card dropdown popups** (eraser palette, gear settings, color pickers) were rendering hidden behind neighboring chrome. Two bugs stacked: (1) a stale `.floating { z-index: 50 !important }` was *demoting* Anki's native `z-index: 890` to 50 — below the sidebar; (2) mixing `overflow-x: auto` with `overflow-y: visible` on `.button-toolbar.btn-toolbar` is normalized by the CSS Overflow spec to `overflow: auto` on both axes, clipping the popup vertically. Removed the z-index override and switched to `overflow-x: clip + overflow-y: visible` — the one combination the spec preserves — so popups extend down freely. Verified visually: settings dropdown now renders fully above all editor content.
- Minor dev infra: `_dev_screenshot`'s `_click_cog` now finds the embedded AddCards via `addcard_embed._state` and dispatches a real pointer/mouse event sequence so the Svelte popup actually toggles.

## Test plan
- [ ] Deck homepage with mixed parent/leaf decks: chevron appears only on parents, rotates on click, hides descendants instantly, persists across re-renders within the session.
- [ ] Add Card: click the gear, the eraser ▾, and the color picker chevrons — each popup renders fully visible above the fields area.
- [ ] Verify saved backend collapse state is unaffected by our session toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)