### PR TITLE
Inline Browse, Stats, and Settings — embedded next to the sidebar

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -724,7 +724,23 @@ def _mark_sidebar_active(state: Optional[str] = None) -> None:
 
 
 def _open_settings() -> None:
-    """Open the Anki Design settings dialog."""
+    """Open the Anki Design settings — embedded inline if possible,
+    standalone Preferences dialog otherwise."""
+    # Tear down any other embed that might be up; only one inline view
+    # at a time.
+    for mod in ("addcard_embed", "browse_embed", "stats_embed"):
+        try:
+            from importlib import import_module
+            import_module("." + mod, __name__).close_inline()
+        except Exception:
+            pass
+    try:
+        from . import settings_embed
+        settings_embed.open_inline(mw)
+        return
+    except Exception:
+        pass
+    # Fallback: standalone Preferences dialog with Anki Design tab.
     try:
         from .settings import open_settings
         open_settings(mw)
@@ -769,34 +785,69 @@ def _on_js_message(handled, message, context):
                 pass
             return (True, None)
         if cmd == "decks":
-            # If we're in the embedded Add view, close it first so the deck
-            # browser becomes visible again. The Add embed is an overlay
-            # painted *on top of* the deck browser — mw.state stays
-            # "deckBrowser" the whole time it's open. Calling moveToState
-            # while already in deckBrowser state triggers a full re-render
-            # of the deck list HTML (deckBrowser.show()), which reads as a
-            # disorienting flash when switching tabs. Only move state when
-            # we're actually somewhere else (reviewer, overview, etc.).
-            try:
-                from . import addcard_embed
-                addcard_embed.close_inline()
-            except Exception:
-                pass
+            # If we're in any embedded view (Add, Browse, Stats,
+            # Settings), close it first so the deck browser becomes
+            # visible again. The embeds are overlays painted *on top
+            # of* the deck browser — mw.state stays "deckBrowser" the
+            # whole time. Calling moveToState while already in
+            # deckBrowser state triggers a full re-render of the deck
+            # list HTML (deckBrowser.show()), which reads as a
+            # disorienting flash when switching tabs. Only move state
+            # when we're actually somewhere else (reviewer, overview,
+            # etc.).
+            for mod in (
+                "addcard_embed", "browse_embed", "stats_embed", "settings_embed",
+            ):
+                try:
+                    from importlib import import_module
+                    import_module("." + mod, __name__).close_inline()
+                except Exception:
+                    pass
             if getattr(mw, "state", None) != "deckBrowser":
                 mw.moveToState("deckBrowser")
         elif cmd == "add":
             # Open AddCards inside the main window (over the deck area, to
             # the right of the sidebar). Falls back to the standard window
-            # if the embed setup fails.
+            # if the embed setup fails. Tear other embeds down first.
+            for mod in ("browse_embed", "stats_embed", "settings_embed"):
+                try:
+                    from importlib import import_module
+                    import_module("." + mod, __name__).close_inline()
+                except Exception:
+                    pass
             try:
                 from . import addcard_embed
                 addcard_embed.open_inline(mw)
             except Exception:
                 mw.onAddCard()
         elif cmd == "browse":
-            mw.onBrowse()
+            # Open the Browser embedded in the main window, mirroring the
+            # Add embed. Tear other embeds down first.
+            for mod in ("addcard_embed", "stats_embed", "settings_embed"):
+                try:
+                    from importlib import import_module
+                    import_module("." + mod, __name__).close_inline()
+                except Exception:
+                    pass
+            try:
+                from . import browse_embed
+                browse_embed.open_inline(mw)
+            except Exception:
+                mw.onBrowse()
         elif cmd == "stats":
-            mw.onStats()
+            # Open Stats embedded in the main window. Tear other embeds
+            # down first.
+            for mod in ("addcard_embed", "browse_embed", "settings_embed"):
+                try:
+                    from importlib import import_module
+                    import_module("." + mod, __name__).close_inline()
+                except Exception:
+                    pass
+            try:
+                from . import stats_embed
+                stats_embed.open_inline(mw)
+            except Exception:
+                mw.onStats()
         elif cmd == "sync":
             mw.on_sync_button_clicked()
         elif cmd == "settings":
@@ -846,8 +897,9 @@ def _on_js_message(handled, message, context):
             else:
                 return handled
         elif cmd == "prefs":
+            # Same destination as ba:settings — route through the embed.
             try:
-                mw.onPrefs()
+                _open_settings()
             except Exception:
                 return handled
         elif cmd.startswith("deck:"):
@@ -1757,17 +1809,132 @@ def _setup_sidebar_shortcuts() -> None:
     except Exception:
         pass
 
+    # Same dance for Browse (B key + mw.onBrowse).
+    try:
+        _orig_on_browse = mw.onBrowse
+
+        def _patched_on_browse(*args, **kwargs):
+            try:
+                from . import browse_embed
+                browse_embed.open_inline(mw)
+            except Exception:
+                _orig_on_browse(*args, **kwargs)
+
+        mw.onBrowse = _patched_on_browse  # type: ignore[assignment]
+    except Exception:
+        pass
+
+    try:
+        from aqt.qt import QShortcut, QKeySequence
+        target_seq_b = QKeySequence("b")
+
+        def _open_inline_b() -> None:
+            try:
+                from . import browse_embed
+                browse_embed.open_inline(mw)
+            except Exception:
+                try:
+                    from aqt import dialogs
+                    dialogs.open("Browser", mw)
+                except Exception:
+                    pass
+
+        for sc in mw.findChildren(QShortcut):
+            try:
+                if sc.key().toString() == target_seq_b.toString():
+                    try:
+                        sc.activated.disconnect()
+                    except Exception:
+                        pass
+                    sc.activated.connect(_open_inline_b)
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    # Same dance for Stats (T key + mw.onStats). Shift+T (legacy
+    # DeckStats) is left alone — it falls through to the standalone
+    # window; only the modern NewDeckStats gets embedded.
+    try:
+        _orig_on_stats = mw.onStats
+
+        def _patched_on_stats(*args, **kwargs):
+            try:
+                from aqt.utils import KeyboardModifiersPressed
+                want_old = KeyboardModifiersPressed().shift
+                if want_old:
+                    _orig_on_stats(*args, **kwargs)
+                    return
+            except Exception:
+                pass
+            try:
+                from . import stats_embed
+                stats_embed.open_inline(mw)
+            except Exception:
+                _orig_on_stats(*args, **kwargs)
+
+        mw.onStats = _patched_on_stats  # type: ignore[assignment]
+    except Exception:
+        pass
+
+    try:
+        from aqt.qt import QShortcut, QKeySequence
+        target_seq_t = QKeySequence("t")
+
+        def _open_inline_t() -> None:
+            try:
+                from . import stats_embed
+                stats_embed.open_inline(mw)
+            except Exception:
+                try:
+                    from aqt import dialogs
+                    dialogs.open("NewDeckStats", mw)
+                except Exception:
+                    pass
+
+        for sc in mw.findChildren(QShortcut):
+            try:
+                if sc.key().toString() == target_seq_t.toString():
+                    try:
+                        sc.activated.disconnect()
+                    except Exception:
+                        pass
+                    sc.activated.connect(_open_inline_t)
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    # Same dance for Preferences: patch mw.onPrefs so the Tools menu
+    # entry (and any code path that goes through mw.onPrefs()) opens
+    # the inline embed instead of the standalone window.
+    try:
+        _orig_on_prefs = mw.onPrefs
+
+        def _patched_on_prefs(*args, **kwargs):
+            try:
+                _open_settings()
+            except Exception:
+                _orig_on_prefs(*args, **kwargs)
+
+        mw.onPrefs = _patched_on_prefs  # type: ignore[assignment]
+    except Exception:
+        pass
+
     # Patch moveToState so leaving the deck-area context (e.g., D from
-    # inside the inline-Add embed) closes the embed before the navigation.
+    # inside an inline embed) closes the embed before the navigation.
     try:
         _orig_move_to_state = mw.moveToState
 
         def _patched_move_to_state(state, *args, **kwargs):
-            try:
-                from . import addcard_embed
-                addcard_embed.close_inline()
-            except Exception:
-                pass
+            for mod in (
+                "addcard_embed", "browse_embed", "stats_embed", "settings_embed",
+            ):
+                try:
+                    from importlib import import_module
+                    import_module("." + mod, __name__).close_inline()
+                except Exception:
+                    pass
             return _orig_move_to_state(state, *args, **kwargs)
 
         mw.moveToState = _patched_move_to_state  # type: ignore[assignment]

--- a/browse_embed.py
+++ b/browse_embed.py
@@ -1,0 +1,384 @@
+"""Anki Design — embed the card Browser inside the main window as a "tab".
+
+Mirrors `addcard_embed.py` exactly. The user wants Browse to behave like a
+tab next to the sidebar instead of opening as a separate QMainWindow:
+
+  - The sidebar's `ba:browse` pycmd calls `open_inline(mw)` (see
+    `__init__.py`) instead of `mw.onBrowse()`.
+  - `open_inline` constructs a Browser instance (we no-op `.show()` on
+    a subclass so its standalone window never flashes on screen).
+  - We grab its `centralWidget` and reparent it onto an overlay QFrame
+    placed on top of `mw.form.centralwidget`, offset by the sidebar width
+    so the sidebar rendered inside `mw.web` stays visible to the left.
+  - The Browser window itself stays hidden (its widgets remain alive, so
+    all menubar actions, shortcuts, and add-on hooks continue to work).
+  - The overlay resizes with the main window via an installed event
+    filter.
+  - We register our instance with `aqt.dialogs` so any other code path
+    that does `aqt.dialogs.open("Browser", ...)` finds our existing
+    Browser and calls `reopen()` on it instead of opening a second one.
+
+This is a first cut: the chrome is whatever Anki's stock browser uses.
+Visual redesign is intentionally deferred — the user wants the layout
+moved in as-is first.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aqt import mw
+from aqt.qt import (
+    QApplication,
+    QColor,
+    QDockWidget,
+    QEvent,
+    QFrame,
+    QKeySequence,
+    QObject,
+    QPalette,
+    QShortcut,
+    QSplitter,
+    Qt,
+    QTimer,
+    QVBoxLayout,
+)
+
+
+SIDEBAR_W = 264  # px — matches --rf-side-w in web/theme.css; same as addcard_embed
+
+
+def _palette_styles() -> str:
+    """QSS for the overlay frame. The Browser's own internals carry their
+    Qt-native styles — we just paint the wrapper paper-colored so the gap
+    between sidebar and embed reads as one continuous page."""
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    return (
+        "QFrame#ba-browse-embed { background: " + palette["paper"] + "; "
+        "border-left: 1px solid " + palette["line"] + "; }"
+    )
+
+
+class _EmbedFilter(QObject):
+    """Re-positions the embed overlay whenever the main window is resized."""
+
+    def __init__(self, overlay: QFrame) -> None:
+        super().__init__(overlay)
+        self._overlay = overlay
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize:
+            try:
+                cw = mw.form.centralwidget
+                self._overlay.setGeometry(
+                    SIDEBAR_W,
+                    0,
+                    cw.width() - SIDEBAR_W,
+                    cw.height(),
+                )
+            except Exception:
+                pass
+        return False
+
+
+_state: dict = {"browser": None, "overlay": None, "filter": None}
+
+
+def drop_curtain() -> None:
+    """Tear down the anti-flash curtain. Safe to call multiple times."""
+    c = _state.pop("curtain", None)
+    if c is not None:
+        try:
+            c.deleteLater()
+        except Exception:
+            pass
+
+
+def close_inline() -> None:
+    """Tear down the embedded Browser and restore the deck browser.
+
+    No-op if there is no embed currently open — callers (state-change
+    monkey-patches, sidebar `decks` pycmd) can call this cheaply on
+    every navigation event."""
+    overlay = _state.get("overlay")
+    br = _state.get("browser")
+    flt = _state.get("filter")
+    if overlay is None and br is None and flt is None:
+        return
+
+    # Clear state FIRST so anything that re-enters via a close callback
+    # returns immediately.
+    _state["browser"] = None
+    _state["overlay"] = None
+    _state["filter"] = None
+    cw_palette = _state.pop("cw_palette", None)
+    curtain = _state.pop("curtain", None)
+    if curtain is not None:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+
+    if overlay is not None:
+        try:
+            if flt is not None:
+                mw.form.centralwidget.removeEventFilter(flt)
+        except Exception:
+            pass
+        try:
+            overlay.deleteLater()
+        except Exception:
+            pass
+    if cw_palette is not None:
+        try:
+            mw.form.centralwidget.setPalette(cw_palette)
+        except Exception:
+            pass
+
+    if br is not None:
+        # Synchronous cleanup. Browser's `_closeWindow()` is the same
+        # path its closeEvent ends up taking after the
+        # call_after_note_saved roundtrip — we skip the roundtrip
+        # because we don't have a webview-driven submit flow here.
+        try:
+            br._closeWindow()  # type: ignore[attr-defined]
+        except Exception:
+            try:
+                br.close()
+            except Exception:
+                pass
+
+    # Restore the sidebar's active tab.
+    try:
+        w = getattr(mw, "web", None)
+        if w is not None:
+            w.eval("window.__baSetActive && window.__baSetActive('decks');")
+    except Exception:
+        pass
+
+
+def open_inline(parent_mw: Any = None) -> None:
+    """Open the Browser embedded in the main window's content area.
+
+    Falls back to the standalone Browser window if the embed setup
+    fails for any reason."""
+    parent_mw = parent_mw or mw
+    if _state.get("overlay") is not None:
+        # Already open — bring it forward.
+        try:
+            _state["overlay"].raise_()
+        except Exception:
+            pass
+        return
+    if _state.get("curtain") is not None:
+        # A curtain is up — we're already mid-open from a previous call.
+        return
+
+    # --- Curtain ----------------------------------------------------
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    paper_qc = QColor(palette["paper"])
+    cw = parent_mw.form.centralwidget
+
+    curtain = QFrame(cw)
+    curtain.setObjectName("ba-browse-curtain")
+    curtain.setAutoFillBackground(True)
+    _cu_pal = curtain.palette()
+    _cu_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+    curtain.setPalette(_cu_pal)
+    curtain.setStyleSheet(
+        "QFrame#ba-browse-curtain { background: " + palette["paper"] + "; }"
+    )
+    curtain.setGeometry(SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height())
+    curtain.show()
+    curtain.raise_()
+    _state["curtain"] = curtain
+    try:
+        curtain.repaint()
+        QApplication.processEvents()
+    except Exception:
+        pass
+
+    try:
+        from aqt.browser import Browser
+        # Anki's Browser.__init__ ends with `self.show()`, which would
+        # flash the standalone QMainWindow on screen for one paint.
+        # Subclassing to no-op `show()` keeps it invisible.
+        class _EmbeddedBrowser(Browser):  # type: ignore[misc, valid-type]
+            def show(self) -> None:  # noqa: D401 — Qt override
+                pass
+        br = _EmbeddedBrowser(parent_mw)
+    except Exception:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+        _state["curtain"] = None
+        try:
+            parent_mw.onBrowse()
+        except Exception:
+            pass
+        return
+
+    try:
+        # Register with the dialog manager so future
+        # `aqt.dialogs.open("Browser", ...)` calls reopen() our instance
+        # instead of creating a second Browser. _closeWindow() (called
+        # from close_inline) calls dialogs.markClosed("Browser") which
+        # tears this registration down.
+        try:
+            import aqt as _aqt
+            _aqt.dialogs._dialogs["Browser"][1] = br  # type: ignore[index]
+        except Exception:
+            pass
+
+        central = br.centralWidget()
+
+        # Browser attaches its sidebar tree (decks / tags / saved searches)
+        # as a QDockWidget directly to the QMainWindow, NOT inside
+        # centralwidget. Discover every QDockWidget child so add-ons that
+        # add their own docks are also brought along, and group them by
+        # the dock area Browser placed them in.
+        left_docks: list = []
+        right_docks: list = []
+        for dock in br.findChildren(QDockWidget):
+            try:
+                area = br.dockWidgetArea(dock)
+            except Exception:
+                area = Qt.DockWidgetArea.LeftDockWidgetArea
+            inner = dock.widget()
+            if inner is None:
+                continue
+            if area == Qt.DockWidgetArea.RightDockWidgetArea:
+                right_docks.append(inner)
+            else:
+                # Treat anything that isn't explicitly right (left, top,
+                # bottom, no-area) as left, matching the Browser's stock
+                # placement of the sidebar.
+                left_docks.append(inner)
+
+        overlay = QFrame(parent_mw.form.centralwidget)
+        overlay.setObjectName("ba-browse-embed")
+        overlay.setAutoFillBackground(True)
+        _ov_pal = overlay.palette()
+        _ov_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+        overlay.setPalette(_ov_pal)
+        overlay.setStyleSheet(_palette_styles())
+
+        v = QVBoxLayout(overlay)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
+
+        # Layout: [left docks] | [centralwidget: search+table | editor] |
+        # [right docks], wrapped in a QSplitter so each boundary stays
+        # drag-resizable — matching the QDockWidget UX in native Browser.
+        central.setParent(None)
+        central.setWindowFlags(Qt.WindowType.Widget)
+
+        if left_docks or right_docks:
+            splitter = QSplitter(Qt.Orientation.Horizontal, overlay)
+            splitter.setChildrenCollapsible(False)
+            splitter.setHandleWidth(1)
+            for inner in left_docks:
+                inner.setParent(None)
+                splitter.addWidget(inner)
+            splitter.addWidget(central)
+            for inner in right_docks:
+                inner.setParent(None)
+                splitter.addWidget(inner)
+            # Stretch only the central pane; docks keep their preferred
+            # widths. Initial sizes default to ~240px for each dock and
+            # the rest to central.
+            sizes: list[int] = []
+            for i in range(splitter.count()):
+                if splitter.widget(i) is central:
+                    splitter.setStretchFactor(i, 1)
+                    sizes.append(800)
+                else:
+                    splitter.setStretchFactor(i, 0)
+                    sizes.append(240)
+            splitter.setSizes(sizes)
+            v.addWidget(splitter, 1)
+            _state["splitter"] = splitter
+        else:
+            central.setParent(overlay)
+            v.addWidget(central, 1)
+
+        # Hide the original Browser QMainWindow.
+        br.setVisible(False)
+
+        # Tint mw.centralwidget paper so any Qt-painted gap is invisible.
+        try:
+            _state["cw_palette"] = QPalette(cw.palette())
+            _cw_pal = cw.palette()
+            _cw_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+            cw.setPalette(_cw_pal)
+        except Exception:
+            pass
+
+        overlay.setGeometry(
+            SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height()
+        )
+        overlay.show()
+        overlay.raise_()
+        try:
+            curtain.raise_()
+        except Exception:
+            pass
+
+        # Curtain drop: backstop on editor webview load + grace, hard cap.
+        try:
+            web = getattr(br.editor, "web", None) if br.editor else None
+            if web is not None:
+                page = web.page()
+                if page is not None:
+                    def _on_loaded(_ok: bool) -> None:
+                        QTimer.singleShot(280, drop_curtain)
+                    page.loadFinished.connect(_on_loaded)
+        except Exception:
+            pass
+        QTimer.singleShot(900, drop_curtain)
+
+        flt = _EmbedFilter(overlay)
+        cw.installEventFilter(flt)
+
+        # Esc closes the embed. Browser binds its own Esc inside
+        # keyPressEvent on the QMainWindow, but our QMainWindow is
+        # hidden so it never gets focus events.
+        try:
+            esc = QShortcut(QKeySequence("Escape"), overlay)
+            esc.setAutoRepeat(False)
+            esc.setContext(Qt.ShortcutContext.WindowShortcut)
+            esc.activated.connect(close_inline)
+        except Exception:
+            pass
+
+        _state["browser"] = br
+        _state["overlay"] = overlay
+        _state["filter"] = flt
+
+        # Highlight "Browse" in the sidebar.
+        try:
+            w = getattr(parent_mw, "web", None)
+            if w is not None:
+                w.eval(
+                    "window.__baSetActive && window.__baSetActive('browse');"
+                )
+        except Exception:
+            pass
+    except Exception as e:
+        import traceback
+        print(
+            f"[anki-design.browse_embed] failed: {e}\n"
+            f"{traceback.format_exc()}",
+            flush=True,
+        )
+        try:
+            close_inline()
+        except Exception:
+            pass
+        try:
+            br.show()
+        except Exception:
+            pass

--- a/settings_embed.py
+++ b/settings_embed.py
@@ -1,0 +1,354 @@
+"""Anki Design — embed Anki's Preferences (with our Anki Design tab
+pre-selected) inside the main window as a "tab".
+
+Mirrors `stats_embed.py`. The "Settings" sidebar item already opens
+Anki's `Preferences` QDialog with our `AnkiDesignSettingsPage` injected
+as a tab. We want it to live inline next to the sidebar instead of
+opening as a separate window.
+
+Preferences is a QDialog, so we reparent the whole dialog into our
+overlay as a `Qt.WindowType.Widget`. That carries everything along
+automatically: the `tabWidget` (Basic, Scheduling, Network, Backups,
+the Anki Design tab, plus any other add-on tabs), the bottom
+`buttonBox` (Help / Close — which `install_into_preferences()` hides
+while our tab is current), and any widgets attached by add-ons via
+the `setupOptions` hook.
+
+Close path is async. Native `Preferences.reject()` chains into
+`accept_with_callback()` which kicks off a background `set_preferences`
+op; the completion callback reads form widgets again
+(`update_profile`, `update_global`) and finally calls `done(0)` +
+`markClosed("Preferences")`. We hand the overlay teardown to that
+callback so the widgets stay alive until the save completes. If the
+collection is gone, we skip the save and tear down immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aqt import mw
+from aqt.qt import (
+    QApplication,
+    QColor,
+    QEvent,
+    QFrame,
+    QKeySequence,
+    QObject,
+    QPalette,
+    QShortcut,
+    Qt,
+    QTimer,
+    QVBoxLayout,
+)
+
+
+SIDEBAR_W = 264  # px — matches --rf-side-w in web/theme.css; same as the other embeds
+
+
+class _EmbedFilter(QObject):
+    """Re-positions the embed overlay whenever the main window is resized."""
+
+    def __init__(self, overlay: QFrame) -> None:
+        super().__init__(overlay)
+        self._overlay = overlay
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize:
+            try:
+                cw = mw.form.centralwidget
+                self._overlay.setGeometry(
+                    SIDEBAR_W,
+                    0,
+                    cw.width() - SIDEBAR_W,
+                    cw.height(),
+                )
+            except Exception:
+                pass
+        return False
+
+
+_state: dict = {
+    "prefs": None,
+    "overlay": None,
+    "filter": None,
+    "closing": False,
+}
+
+
+def drop_curtain() -> None:
+    """Tear down the anti-flash curtain. Safe to call multiple times."""
+    c = _state.pop("curtain", None)
+    if c is not None:
+        try:
+            c.deleteLater()
+        except Exception:
+            pass
+
+
+def _teardown_now() -> None:
+    """Synchronous overlay teardown. Called as the callback after
+    `accept_with_callback` finishes saving, or directly when the
+    collection isn't available."""
+    overlay = _state.get("overlay")
+    flt = _state.get("filter")
+
+    _state["prefs"] = None
+    _state["overlay"] = None
+    _state["filter"] = None
+    _state["closing"] = False
+    cw_palette = _state.pop("cw_palette", None)
+    curtain = _state.pop("curtain", None)
+    if curtain is not None:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+
+    if overlay is not None:
+        try:
+            if flt is not None:
+                mw.form.centralwidget.removeEventFilter(flt)
+        except Exception:
+            pass
+        try:
+            overlay.deleteLater()
+        except Exception:
+            pass
+    if cw_palette is not None:
+        try:
+            mw.form.centralwidget.setPalette(cw_palette)
+        except Exception:
+            pass
+
+    try:
+        w = getattr(mw, "web", None)
+        if w is not None:
+            w.eval("window.__baSetActive && window.__baSetActive('decks');")
+    except Exception:
+        pass
+
+
+def close_inline() -> None:
+    """Kick off save + teardown of the embedded Preferences.
+
+    Async: returns immediately, teardown happens inside the
+    `accept_with_callback` completion callback so the form widgets
+    stay alive while `update_profile` / `update_global` read them."""
+    if _state.get("closing"):
+        return
+    sd = _state.get("prefs")
+    if sd is None and _state.get("overlay") is None:
+        return
+
+    _state["closing"] = True
+
+    if sd is None or not getattr(mw, "col", None):
+        # No dialog or no collection — skip the save chain and tear
+        # down immediately.
+        _teardown_now()
+        return
+
+    try:
+        sd.accept_with_callback(_teardown_now)
+    except Exception:
+        _teardown_now()
+
+
+def open_inline(parent_mw: Any = None) -> None:
+    """Open Preferences embedded in the main window's content area,
+    with the Anki Design tab pre-selected.
+
+    Falls back to the standalone window if anything goes wrong."""
+    parent_mw = parent_mw or mw
+    if _state.get("overlay") is not None:
+        try:
+            _state["overlay"].raise_()
+        except Exception:
+            pass
+        return
+    if _state.get("curtain") is not None:
+        return
+
+    # --- Curtain ----------------------------------------------------
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    paper_qc = QColor(palette["paper"])
+    cw = parent_mw.form.centralwidget
+
+    curtain = QFrame(cw)
+    curtain.setObjectName("ba-settings-curtain")
+    curtain.setAutoFillBackground(True)
+    _cu_pal = curtain.palette()
+    _cu_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+    curtain.setPalette(_cu_pal)
+    curtain.setStyleSheet(
+        "QFrame#ba-settings-curtain { background: " + palette["paper"] + "; }"
+    )
+    curtain.setGeometry(SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height())
+    curtain.show()
+    curtain.raise_()
+    _state["curtain"] = curtain
+    try:
+        curtain.repaint()
+        QApplication.processEvents()
+    except Exception:
+        pass
+
+    # Make sure our Anki Design tab has been installed BEFORE we
+    # construct Preferences — the patched `setupOptions` injects the
+    # tab during `__init__`.
+    try:
+        from .settings import install_into_preferences, _select_anki_design_tab
+        install_into_preferences()
+    except Exception:
+        _select_anki_design_tab = None  # type: ignore[assignment]
+
+    try:
+        from aqt.preferences import Preferences
+        # Preferences.__init__ ends with self.show(). Subclass to no-op
+        # so the standalone window never flashes.
+        class _EmbeddedPreferences(Preferences):  # type: ignore[misc, valid-type]
+            def show(self) -> None:  # noqa: D401 — Qt override
+                pass
+
+            def activateWindow(self) -> None:  # noqa: D401 — Qt override
+                pass
+
+        sd = _EmbeddedPreferences(parent_mw)
+    except Exception:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+        _state["curtain"] = None
+        try:
+            from .settings import open_settings
+            open_settings(parent_mw)
+        except Exception:
+            pass
+        return
+
+    try:
+        # Register with the dialog manager so other code paths that do
+        # `aqt.dialogs.open("Preferences", ...)` find our instance
+        # instead of opening a second window. `accept_with_callback`
+        # (run on close) calls `markClosed("Preferences")` which
+        # clears the registration.
+        try:
+            import aqt as _aqt
+            _aqt.dialogs._dialogs["Preferences"][1] = sd  # type: ignore[index]
+        except Exception:
+            pass
+
+        # Pre-select the Anki Design tab so the embed opens on our page.
+        if _select_anki_design_tab is not None:
+            try:
+                _select_anki_design_tab(sd)
+            except Exception:
+                pass
+
+        overlay = QFrame(parent_mw.form.centralwidget)
+        overlay.setObjectName("ba-settings-embed")
+        overlay.setAutoFillBackground(True)
+        _ov_pal = overlay.palette()
+        _ov_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+        overlay.setPalette(_ov_pal)
+        overlay.setStyleSheet(
+            "QFrame#ba-settings-embed { background: " + palette["paper"] + "; "
+            "border-left: 1px solid " + palette["line"] + "; }"
+        )
+
+        v = QVBoxLayout(overlay)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
+
+        # Reparent the whole dialog. tabWidget, buttonBox, our injected
+        # Anki Design tab, and any add-on-injected tabs all come along
+        # because they're parented to the dialog.
+        sd.setParent(overlay)
+        sd.setWindowFlags(Qt.WindowType.Widget)
+        sd.setVisible(True)
+        v.addWidget(sd, 1)
+
+        # Hijack the Close button (buttonBox.rejected → Dialog.reject):
+        # close_inline runs the same save chain (via
+        # accept_with_callback) but also tears down our overlay in the
+        # completion callback.
+        try:
+            bb = sd.form.buttonBox
+            try:
+                bb.rejected.disconnect()
+            except Exception:
+                pass
+            bb.rejected.connect(close_inline)
+        except Exception:
+            pass
+
+        # Tint mw.centralwidget paper so any first-frame Qt gap is invisible.
+        try:
+            _state["cw_palette"] = QPalette(cw.palette())
+            _cw_pal = cw.palette()
+            _cw_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+            cw.setPalette(_cw_pal)
+        except Exception:
+            pass
+
+        overlay.setGeometry(
+            SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height()
+        )
+        overlay.show()
+        overlay.raise_()
+        try:
+            curtain.raise_()
+        except Exception:
+            pass
+
+        # Preferences is all native Qt widgets — first paint is
+        # essentially immediate. A short timer is plenty.
+        QTimer.singleShot(200, drop_curtain)
+
+        flt = _EmbedFilter(overlay)
+        cw.installEventFilter(flt)
+
+        # Esc closes the embed. Preferences's own Esc shortcut (added
+        # via add_close_shortcut(self)) might still be active on the
+        # dialog widget, but it would call reject() which goes through
+        # the same chain — having both is redundant but harmless.
+        try:
+            esc = QShortcut(QKeySequence("Escape"), overlay)
+            esc.setAutoRepeat(False)
+            esc.setContext(Qt.ShortcutContext.WindowShortcut)
+            esc.activated.connect(close_inline)
+        except Exception:
+            pass
+
+        _state["prefs"] = sd
+        _state["overlay"] = overlay
+        _state["filter"] = flt
+        _state["closing"] = False
+
+        # Highlight "Settings" in the sidebar.
+        try:
+            w = getattr(parent_mw, "web", None)
+            if w is not None:
+                w.eval(
+                    "window.__baSetActive && window.__baSetActive('settings');"
+                )
+        except Exception:
+            pass
+    except Exception as e:
+        import traceback
+        print(
+            f"[anki-design.settings_embed] failed: {e}\n"
+            f"{traceback.format_exc()}",
+            flush=True,
+        )
+        try:
+            _teardown_now()
+        except Exception:
+            pass
+        try:
+            sd.show()
+        except Exception:
+            pass

--- a/stats_embed.py
+++ b/stats_embed.py
@@ -1,0 +1,342 @@
+"""Anki Design — embed the Stats (NewDeckStats) dialog inside the main
+window as a "tab".
+
+Mirrors `addcard_embed.py` and `browse_embed.py`. Native Anki opens stats
+as a separate QDialog window via `aqt.dialogs.open("NewDeckStats", mw)`.
+We want it to behave like a tab next to the sidebar.
+
+Stats is a QDialog (not a QMainWindow), so unlike Browser there's no
+centralWidget / menubar / dockWidget split: everything the user sees is
+attached to the dialog itself. The cleanest reparent is therefore the
+whole dialog — set its window flags to `Widget` and add it to our
+overlay's layout. All form widgets (the SvelteKit graphs webview, the
+deck chooser, the Close / Save-PDF button row) plus anything add-ons
+attach via `gui_hooks.stats_dialog_will_show` come along automatically.
+
+Cleanup is one-shot: `NewDeckStats.reject()` does `self.form.web = None`
+and double-calling it crashes, so we guard with a `cleaned` flag.
+
+`Shift+T` (legacy `DeckStats`) is not embedded — it falls through to
+the standalone window. The sidebar's Stats item always opens the modern
+one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aqt import mw
+from aqt.qt import (
+    QApplication,
+    QColor,
+    QEvent,
+    QFrame,
+    QKeySequence,
+    QObject,
+    QPalette,
+    QShortcut,
+    Qt,
+    QTimer,
+    QVBoxLayout,
+)
+
+
+SIDEBAR_W = 264  # px — matches --rf-side-w in web/theme.css; same as the other embeds
+
+
+class _EmbedFilter(QObject):
+    """Re-positions the embed overlay whenever the main window is resized."""
+
+    def __init__(self, overlay: QFrame) -> None:
+        super().__init__(overlay)
+        self._overlay = overlay
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
+        if event.type() == QEvent.Type.Resize:
+            try:
+                cw = mw.form.centralwidget
+                self._overlay.setGeometry(
+                    SIDEBAR_W,
+                    0,
+                    cw.width() - SIDEBAR_W,
+                    cw.height(),
+                )
+            except Exception:
+                pass
+        return False
+
+
+_state: dict = {"stats": None, "overlay": None, "filter": None, "cleaned": False}
+
+
+def drop_curtain() -> None:
+    """Tear down the anti-flash curtain. Safe to call multiple times."""
+    c = _state.pop("curtain", None)
+    if c is not None:
+        try:
+            c.deleteLater()
+        except Exception:
+            pass
+
+
+def _run_stats_cleanup(sd: Any) -> None:
+    """Run NewDeckStats.reject() once. The method is not idempotent —
+    it sets `self.form.web = None` and the second call would crash on
+    NoneType.cleanup(). We track a single `cleaned` flag in `_state`."""
+    if _state.get("cleaned"):
+        return
+    _state["cleaned"] = True
+    try:
+        sd.reject()
+    except Exception:
+        try:
+            sd.close()
+        except Exception:
+            pass
+
+
+def close_inline() -> None:
+    """Tear down the embedded Stats dialog and restore the deck browser.
+
+    No-op if there is no embed currently open."""
+    overlay = _state.get("overlay")
+    sd = _state.get("stats")
+    flt = _state.get("filter")
+    if overlay is None and sd is None and flt is None:
+        return
+
+    _state["stats"] = None
+    _state["overlay"] = None
+    _state["filter"] = None
+    cw_palette = _state.pop("cw_palette", None)
+    curtain = _state.pop("curtain", None)
+    if curtain is not None:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+
+    if overlay is not None:
+        try:
+            if flt is not None:
+                mw.form.centralwidget.removeEventFilter(flt)
+        except Exception:
+            pass
+        try:
+            overlay.deleteLater()
+        except Exception:
+            pass
+    if cw_palette is not None:
+        try:
+            mw.form.centralwidget.setPalette(cw_palette)
+        except Exception:
+            pass
+
+    if sd is not None:
+        _run_stats_cleanup(sd)
+
+    # Reset the cleaned flag for the next open.
+    _state["cleaned"] = False
+
+    # Restore the sidebar's active tab.
+    try:
+        w = getattr(mw, "web", None)
+        if w is not None:
+            w.eval("window.__baSetActive && window.__baSetActive('decks');")
+    except Exception:
+        pass
+
+
+def open_inline(parent_mw: Any = None) -> None:
+    """Open NewDeckStats embedded in the main window's content area.
+
+    Falls back to the standalone window if anything goes wrong."""
+    parent_mw = parent_mw or mw
+    if _state.get("overlay") is not None:
+        try:
+            _state["overlay"].raise_()
+        except Exception:
+            pass
+        return
+    if _state.get("curtain") is not None:
+        return
+
+    # --- Curtain ----------------------------------------------------
+    from . import addcard as _addcard
+    palette, _ = _addcard._resolve_palette()
+    paper_qc = QColor(palette["paper"])
+    cw = parent_mw.form.centralwidget
+
+    curtain = QFrame(cw)
+    curtain.setObjectName("ba-stats-curtain")
+    curtain.setAutoFillBackground(True)
+    _cu_pal = curtain.palette()
+    _cu_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+    curtain.setPalette(_cu_pal)
+    curtain.setStyleSheet(
+        "QFrame#ba-stats-curtain { background: " + palette["paper"] + "; }"
+    )
+    curtain.setGeometry(SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height())
+    curtain.show()
+    curtain.raise_()
+    _state["curtain"] = curtain
+    try:
+        curtain.repaint()
+        QApplication.processEvents()
+    except Exception:
+        pass
+
+    try:
+        from aqt.stats import NewDeckStats
+        # NewDeckStats.__init__ ends with self.show() + self.activateWindow().
+        # Subclass to no-op both so the standalone dialog never flashes.
+        class _EmbeddedStats(NewDeckStats):  # type: ignore[misc, valid-type]
+            def show(self) -> None:  # noqa: D401 — Qt override
+                pass
+
+            def activateWindow(self) -> None:  # noqa: D401 — Qt override
+                pass
+
+        sd = _EmbeddedStats(parent_mw)
+    except Exception:
+        try:
+            curtain.deleteLater()
+        except Exception:
+            pass
+        _state["curtain"] = None
+        try:
+            parent_mw.onStats()
+        except Exception:
+            pass
+        return
+
+    try:
+        # Register with the dialog manager so other code paths that do
+        # `aqt.dialogs.open("NewDeckStats", ...)` find our instance
+        # instead of opening a second one. `reject()` (run on close)
+        # calls `aqt.dialogs.markClosed("NewDeckStats")` which clears
+        # the registration.
+        try:
+            import aqt as _aqt
+            _aqt.dialogs._dialogs["NewDeckStats"][1] = sd  # type: ignore[index]
+        except Exception:
+            pass
+
+        overlay = QFrame(parent_mw.form.centralwidget)
+        overlay.setObjectName("ba-stats-embed")
+        overlay.setAutoFillBackground(True)
+        _ov_pal = overlay.palette()
+        _ov_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+        overlay.setPalette(_ov_pal)
+        overlay.setStyleSheet(
+            "QFrame#ba-stats-embed { background: " + palette["paper"] + "; "
+            "border-left: 1px solid " + palette["line"] + "; }"
+        )
+
+        v = QVBoxLayout(overlay)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
+
+        # Reparent the WHOLE dialog as an embedded widget. Everything the
+        # form put on it (web, deck chooser, button box) and anything
+        # add-ons attached via stats_dialog_will_show comes along — no
+        # need to walk children individually.
+        sd.setParent(overlay)
+        sd.setWindowFlags(Qt.WindowType.Widget)
+        sd.setVisible(True)
+        v.addWidget(sd, 1)
+
+        # Hijack the Close button (buttonBox.rejected normally routes to
+        # NewDeckStats.reject) so clicking Close tears the embed down
+        # rather than just closing the inner widget. `close_inline`
+        # itself calls reject() during teardown so the cleanup chain
+        # still runs.
+        try:
+            bb = sd.form.buttonBox
+            try:
+                bb.rejected.disconnect()
+            except Exception:
+                pass
+            bb.rejected.connect(close_inline)
+        except Exception:
+            pass
+
+        # Tint mw.centralwidget paper so any first-frame Qt gap is invisible.
+        try:
+            _state["cw_palette"] = QPalette(cw.palette())
+            _cw_pal = cw.palette()
+            _cw_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+            cw.setPalette(_cw_pal)
+        except Exception:
+            pass
+
+        overlay.setGeometry(
+            SIDEBAR_W, 0, cw.width() - SIDEBAR_W, cw.height()
+        )
+        overlay.show()
+        overlay.raise_()
+        try:
+            curtain.raise_()
+        except Exception:
+            pass
+
+        # Curtain drop: hook the stats webview's loadFinished + grace,
+        # with a hard cap. NewDeckStats also calls
+        # `web.hide_while_preserving_layout()` in __init__ which keeps
+        # the web blank until the SvelteKit graphs page is ready, so the
+        # curtain just covers the very first paint.
+        try:
+            web = getattr(sd.form, "web", None) if sd.form else None
+            if web is not None:
+                page = web.page()
+                if page is not None:
+                    def _on_loaded(_ok: bool) -> None:
+                        QTimer.singleShot(280, drop_curtain)
+                    page.loadFinished.connect(_on_loaded)
+        except Exception:
+            pass
+        QTimer.singleShot(1500, drop_curtain)
+
+        flt = _EmbedFilter(overlay)
+        cw.installEventFilter(flt)
+
+        # Esc closes the embed (NewDeckStats's add_close_shortcut(self)
+        # binds Esc to self.close() inside the dialog, but the dialog as
+        # an embedded widget no longer receives the same focus chain).
+        try:
+            esc = QShortcut(QKeySequence("Escape"), overlay)
+            esc.setAutoRepeat(False)
+            esc.setContext(Qt.ShortcutContext.WindowShortcut)
+            esc.activated.connect(close_inline)
+        except Exception:
+            pass
+
+        _state["stats"] = sd
+        _state["overlay"] = overlay
+        _state["filter"] = flt
+        _state["cleaned"] = False
+
+        # Highlight "Stats" in the sidebar.
+        try:
+            w = getattr(parent_mw, "web", None)
+            if w is not None:
+                w.eval(
+                    "window.__baSetActive && window.__baSetActive('stats');"
+                )
+        except Exception:
+            pass
+    except Exception as e:
+        import traceback
+        print(
+            f"[anki-design.stats_embed] failed: {e}\n"
+            f"{traceback.format_exc()}",
+            flush=True,
+        )
+        try:
+            close_inline()
+        except Exception:
+            pass
+        try:
+            sd.show()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

- Three new embed modules (`browse_embed.py`, `stats_embed.py`, `settings_embed.py`) mirror `addcard_embed.py` so Browse, Stats, and Preferences open inline next to the sidebar instead of as separate windows. Each no-ops the dialog's `.show()`, reparents everything that hangs off the native window into a paper-tinted overlay over `mw.form.centralwidget`, drops an anti-flash curtain, installs a resize filter, binds Esc, and registers with `aqt.dialogs` so other code paths re-use the embedded instance via `reopen()`.
- Browser-specific: the decks/tags/saved-searches tree is a `QDockWidget` on the QMainWindow, not in `centralwidget`. The embed discovers all docks via `findChildren(QDockWidget)`, groups by dock area, and lays them out beside `centralwidget` in a `QSplitter` so the drag-resize boundary matches native.
- Settings-specific: `Preferences.reject()` chains into an async `accept_with_callback` that reads form widgets in its completion callback, so `close_inline` waits for that callback before tearing the overlay down — otherwise scheduling/network/backup/uiScale settings wouldn't persist. The embed also installs our Anki Design tab and pre-selects it.
- `__init__.py` wires every entry point: pycmd handlers tear down sibling embeds before opening; `mw.onAddCard` / `onBrowse` / `onStats` / `onPrefs` are monkey-patched and the `a` / `b` / `t` global `QShortcut`s are rebound so the Tools menu, keyboard shortcuts, and add-on manager Config button all route to the embeds; `_patched_move_to_state` tears down all four on any state transition. Shift+T still opens legacy `DeckStats` standalone.

## Test plan

- [ ] `make run`; from the deck browser, click each sidebar item (Decks, Add, Browse, Stats, Settings) and verify the embed appears next to the sidebar with no white flash, then click Decks to return.
- [ ] In the Browser embed, confirm the left dock tree (decks / tags / saved searches) is present, drag-resizes against the table, right-click context menus work, and double-clicking a row opens the editor pane.
- [ ] In the Stats embed, confirm graphs render, the deck chooser switches scope, and Save PDF still works.
- [ ] In the Settings embed, verify the Anki Design tab is selected by default; change a scheduling cutoff, close via sidebar nav, reopen — value persists.
- [ ] Verify `a` / `b` / `t` / `,` keyboard shortcuts open the corresponding embeds, and Esc closes each. Shift+T still opens the legacy stats window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)