### PR TITLE
Deck page: remove streak/stats band; heatmap months drop the year

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -465,13 +465,12 @@ def build_heatmap_html(weeks: int = 53) -> str:
 
     cells = []
     month_spans = []  # [label, span_in_columns]
-    prev_month = prev_year = None
+    prev_month = None
     for w in range(columns):
         cd = date_for(grid_start + w * 7)  # the column's Sunday
         if cd.month != prev_month:
-            year = f" {cd.year}" if cd.year != prev_year else ""
-            month_spans.append([_MONTHS[cd.month - 1] + year, 1])
-            prev_month, prev_year = cd.month, cd.year
+            month_spans.append([_MONTHS[cd.month - 1], 1])
+            prev_month = cd.month
         else:
             month_spans[-1][1] += 1
 
@@ -591,14 +590,8 @@ def on_deck_browser_will_render_content(
             hero = _single_deck_hero()
     except Exception:
         pass
-    # Wrap the streak / today / all-time stats together with the heatmap so
-    # they read as a single integrated "practice record" band on the page.
-    try:
-        practice_head = _practice_header_html()
-    except Exception:
-        practice_head = ""
     practice = (
-        f'<section class="ba-practice">{practice_head}{heatmap}</section>'
+        f'<section class="ba-practice">{heatmap}</section>'
         if heatmap else ""
     )
     content.stats = hero + content.stats + practice
@@ -971,62 +964,6 @@ def _start_studying(did: int) -> None:
             mw.moveToState("overview")
         except Exception:
             pass
-
-
-def _practice_header_html() -> str:
-    """Streak + today/minutes/all-time as a header band above the heatmap.
-    These stats used to live in the sidebar; they fit better here next to
-    the visual record of activity. The streak block is suppressed when
-    ``show_streak`` is False so users who don't track streaks aren't
-    pressured by a count they don't care about."""
-    try:
-        s = _standing()
-    except Exception:
-        return ""
-    streak = int(s.get("streak", 0) or 0)
-    today_n = int(s.get("today", 0) or 0)
-    today_min = _minutes_today()
-    total = int(s.get("total", 0) or 0)
-    streak_html = ""
-    if _config().get("show_streak", True):
-        # Phosphor-inspired flame: tall body + a small inner highlight that
-        # reads as the cool core of the fire.
-        flame = (
-            '<svg class="ba-flame" viewBox="0 0 24 24" '
-            'fill="currentColor" aria-hidden="true">'
-            '<path d="M12 2c.5 3 2 4.5 3.5 6.2C17 10 18.5 12 18.5 14.5'
-            '  c0 3.6-2.9 6.5-6.5 6.5s-6.5-2.9-6.5-6.5c0-1.6.6-2.9 1.5-3.8'
-            '  C8 11.6 9 12 10 12c0-2 0-4.5 2-10z"/>'
-            '<path d="M12.5 17.5c-1.4 0-2.5-1.1-2.5-2.5c0-.9.4-1.6 1.2-2'
-            '  c.7-.4 1.6-.8 1.9-1.7c.5 1 1.3 1.7 1.6 2.6c.1.4.2.8.2 1.2'
-            '  c0 1.4-1.1 2.4-2.4 2.4z" opacity=".55"/>'
-            '</svg>'
-        )
-        streak_html = f"""
-        <div class="ba-practice-streak" title="Consecutive days reviewed">
-            {flame}
-            <span class="ba-practice-streak-n">{streak}</span>
-            <span class="ba-practice-streak-l">day streak</span>
-        </div>"""
-    return f"""
-    <header class="ba-practice-head">
-      {streak_html}
-      <div class="ba-practice-meta">
-        <div class="ba-practice-stat">
-          <span class="n">{today_n:,}</span>
-          <span class="l">today</span>
-        </div>
-        <div class="ba-practice-stat">
-          <span class="n">{today_min}</span>
-          <span class="l">minutes</span>
-        </div>
-        <div class="ba-practice-stat">
-          <span class="n">{total:,}</span>
-          <span class="l">all-time</span>
-        </div>
-      </div>
-    </header>
-    """
 
 
 def _single_deck_hero() -> str:

--- a/web/theme.css
+++ b/web/theme.css
@@ -232,7 +232,7 @@ body::before {
   }
 }
 
-/* order: hero (single-deck) or deck list (multi) → practice section */
+/* order: hero (single-deck) or deck list → practice section (stats + heatmap) */
 .ba-home .ba-hero { order: 0; }
 .ba-home > table { order: 1; }
 .ba-home .ba-practice { order: 2; }
@@ -371,82 +371,12 @@ body::before {
 .ba-home tr.deck:hover img.gears { opacity: 0.45; }
 .ba-home td.opts a:hover img.gears { opacity: 0.95; }
 
-/* ---------------- PRACTICE — streak + stats + heatmap as ONE band ---------------- */
+/* ---------------- PRACTICE — heatmap-only section below the decks --------- */
 .ba-practice {
-  order: 2;
   width: 100%;
   max-width: var(--rf-measure);
   margin: 36px auto 0;
 }
-.ba-practice-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 0 4px;
-  margin-bottom: 20px;
-  flex-wrap: wrap;
-}
-/* Streak — a fire-icon pill so it reads as its own little badge. */
-.ba-practice-streak {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 13px 6px 10px;
-  background: rgba(108, 140, 255, 0.10);
-  background: color-mix(in srgb, var(--rf-accent, #6c8cff) 11%, transparent);
-  border: 1px solid rgba(108, 140, 255, 0.28);
-  border-color: color-mix(in srgb, var(--rf-accent, #6c8cff) 32%, transparent);
-  border-radius: 999px;
-  line-height: 1;
-}
-.ba-flame {
-  width: 13px;
-  height: 14px;
-  color: var(--rf-accent, #6c8cff);
-  flex: none;
-  transform: translateY(-0.5px);
-}
-.ba-practice-streak-n {
-  font: 600 15px/1 var(--rf-sans);
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum" 1, "lnum" 1;
-  letter-spacing: -0.01em;
-  color: var(--rf-accent, #6c8cff);
-}
-.ba-practice-streak-l {
-  font: 500 11px/1 var(--rf-sans);
-  letter-spacing: 0.04em;
-  color: var(--rf-ink-dim);
-}
-.ba-practice-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 22px;
-  flex-wrap: wrap;
-}
-@media (max-width: 720px) {
-  .ba-practice-head { gap: 12px; }
-  .ba-practice-meta { gap: 14px; }
-}
-.ba-practice-stat {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
-}
-.ba-practice-stat .n {
-  font: 600 14px/1 var(--rf-sans);
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum" 1, "lnum" 1;
-  color: var(--rf-ink);
-}
-.ba-practice-stat .l {
-  font: 500 10.5px/1 var(--rf-sans);
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--rf-ink-faint);
-}
-
 /* Heatmap inside the practice section — no panel chrome, just the grid. */
 .ba-home .ba-practice .rf-heatmap {
   background: transparent !important;
@@ -464,7 +394,7 @@ body::before {
   color: var(--rf-ink-faint);
 }
 
-/* Anki's "Studied N cards today" caption — folded into the practice header. */
+/* Anki's "Studied N cards today" caption — hide; superfluous next to deck list. */
 .ba-home #studiedToday { display: none !important; }
 
 /* ============================ SINGLE-DECK HERO ============================ */


### PR DESCRIPTION
## Summary
- Pull the practice-header band (streak pill + today/minutes/all-time meta) off the deck homepage — the page now reads as decks → heatmap, with no band in between.
- Heatmap month strip drops the trailing year, so `Jan 2026` reads as just `Jan` (year changes are still clear from the grid's left-to-right month sequence).
- Tidies a stale ordering comment and a dead `order: 2` declaration on `.ba-practice`.

## Test plan
- [ ] Open the deck browser: confirm the streak/today/minutes/all-time band is gone and the page reads as decks → heatmap.
- [ ] Confirm the heatmap month strip never shows a year (scroll across a January boundary if you have one).
- [ ] Single-deck mode still renders the hero card correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)