### PR TITLE
Reviewer: drop 1-of-N position counter; font-size scales chrome too

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -175,15 +175,22 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
     # Reviewer geometry — variables surface in reviewer.css.
     width_map = {"narrow": "640px", "medium": "780px", "wide": "920px",
                  "full": "100%"}
-    # Sizes tuned for the reviewer rebuild's reading column. "medium" matches
-    # the 25px the rebuild was designed against (see reviewer.css comment).
-    fontsize_map = {"small": "20px", "medium": "25px", "large": "30px",
-                    "x-large": "36px"}
+    # Sizes tuned for the reviewer rebuild's reading column.
+    fontsize_map = {"small": "22px", "medium": "28px", "large": "34px",
+                    "x-large": "40px"}
+    # Chrome (header + bottom buttons) scales with the same setting so the
+    # whole reviewer surface grows together. Multipliers track the card
+    # font-size ratios above (22/28/34/40 → 0.85/1.0/1.25/1.5) so chrome
+    # grows enough to stay in proportion with the larger card text.
+    chrome_scale_map = {"small": "0.85", "medium": "1", "large": "1.25",
+                        "x-large": "1.5"}
     card_width = width_map.get(card_width_choice, "780px")
-    card_font_size = fontsize_map.get(font_size_choice, "25px")
+    card_font_size = fontsize_map.get(font_size_choice, "28px")
+    chrome_scale = chrome_scale_map.get(font_size_choice, "1")
     reviewer_decl = (
         f"--rf-card-max-width:{card_width};"
         f"--rf-card-font-size:{card_font_size};"
+        f"--rf-chrome-scale:{chrome_scale};"
     )
 
     # Heatmap palette — emits its own rule block (light + dark variants),
@@ -1582,13 +1589,9 @@ def _current_card_type() -> str:
 
 def _reviewer_header_html() -> str:
     """Header above the card: back chevron + deck name on the left, the
-    count breakdown + position on the right, and Edit + More icon buttons
-    next to them (Anki's More menu already covers flag/mark/undo)."""
+    count breakdown on the right, and Edit + More icon buttons next to
+    them (Anki's More menu already covers flag/mark/undo)."""
     name = html.escape(_current_deck_name() or "Studying")
-    rem = _remaining()
-    total = _session["total"] or rem or 1
-    done = max(0, total - rem)
-    pos = min(done + 1, total)
     new_n = learn_n = rev_n = 0
     try:
         c = mw.col.sched.counts()
@@ -1626,12 +1629,6 @@ def _reviewer_header_html() -> str:
                 title="Cards in learning"><b id="ba-rv-c-learn">{learn_n}</b><i>learn</i></span>
           <span class="ba-rv-count ba-rv-c-due"
                 title="Review cards due today"><b id="ba-rv-c-due">{rev_n}</b><i>due</i></span>
-        </span>
-        <span class="ba-rv-sep" aria-hidden="true"></span>
-        <span class="ba-rv-pos">
-          <b id="ba-rv-pos-now">{pos}</b>
-          <span>of</span>
-          <b id="ba-rv-pos-total">{total}</b>
         </span>
         <button class="ba-rv-icon-btn" type="button"
                 onclick="pycmd('edit')" title="Edit card (E)"
@@ -1673,7 +1670,6 @@ def _push_progress() -> None:
     total = _session["total"] or 1
     done = max(0, total - rem)
     pct = min(100, int(done * 100 / total))
-    pos = min(done + 1, total)
     new_n = learn_n = rev_n = 0
     try:
         c = mw.col.sched.counts()
@@ -1692,8 +1688,6 @@ def _push_progress() -> None:
         mw.reviewer.web.eval(
             f"window.__reforgeProgress && window.__reforgeProgress({pct},{done},{rem});"
             f"var $=function(id){{return document.getElementById(id);}};"
-            f"var n=$('ba-rv-pos-now'),t=$('ba-rv-pos-total');"
-            f"if(n)n.textContent={pos};if(t)t.textContent={total};"
             f"var cn=$('ba-rv-c-new'),cl=$('ba-rv-c-learn'),cd=$('ba-rv-c-due');"
             f"if(cn)cn.textContent={new_n};if(cl)cl.textContent={learn_n};"
             f"if(cd)cd.textContent={rev_n};"

--- a/web/reviewer-bottom.css
+++ b/web/reviewer-bottom.css
@@ -146,6 +146,7 @@ button {
   margin: 0 !important;
   color: var(--rf-ink-dim) !important;
   font: 500 11.5px/1 var(--rf-sans) !important;
+  font-size: calc(11.5px * var(--rf-chrome-scale, 1)) !important;
   letter-spacing: 0.06em !important;
   cursor: pointer !important;
   box-shadow: none !important;
@@ -160,8 +161,8 @@ button:active { transform: translateY(1px) !important; }
    font-size: 0 on the parent. */
 button[onclick*="'edit'"],
 button[onclick*="'more'"] {
-  width: 28px !important;
-  height: 28px !important;
+  width: calc(28px * var(--rf-chrome-scale, 1)) !important;
+  height: calc(28px * var(--rf-chrome-scale, 1)) !important;
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
@@ -183,8 +184,8 @@ button[onclick*="'more'"]:hover {
 }
 button[onclick*="'edit'"]::before {
   content: "";
-  width: 16px;
-  height: 16px;
+  width: calc(16px * var(--rf-chrome-scale, 1));
+  height: calc(16px * var(--rf-chrome-scale, 1));
   display: inline-block;
   background-color: currentColor;
   -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'><path d='M12 20h9'/><path d='M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z'/></svg>") no-repeat center / contain;
@@ -193,8 +194,8 @@ button[onclick*="'edit'"]::before {
 
 button[onclick*="'more'"]::before {
   content: "";
-  width: 16px;
-  height: 16px;
+  width: calc(16px * var(--rf-chrome-scale, 1));
+  height: calc(16px * var(--rf-chrome-scale, 1));
   display: inline-block;
   background-color: currentColor;
   -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='5' cy='12' r='1.6'/><circle cx='12' cy='12' r='1.6'/><circle cx='19' cy='12' r='1.6'/></svg>") no-repeat center / contain;
@@ -278,6 +279,7 @@ button[onclick*="'more'"] #time { display: none !important; }
   border-radius: 6px !important;
   color: var(--rf-ink-dim) !important;
   font: 500 0/24px var(--rf-sans) !important;  /* font-size 0 hides Anki's label */
+  line-height: calc(24px * var(--rf-chrome-scale, 1)) !important;
   letter-spacing: 0 !important;
   text-transform: none !important;
   white-space: nowrap !important;
@@ -293,11 +295,13 @@ button[onclick*="'more'"] #time { display: none !important; }
   content: counter(ba-ease);
   display: inline-block;
   vertical-align: middle;
-  width: 20px;
-  height: 20px;
+  width: calc(20px * var(--rf-chrome-scale, 1));
+  height: calc(20px * var(--rf-chrome-scale, 1));
   margin-right: 8px;
   border-radius: 5px;
   font: 700 13px/20px var(--rf-sans);
+  font-size: calc(13px * var(--rf-chrome-scale, 1));
+  line-height: calc(20px * var(--rf-chrome-scale, 1));
   font-variant-numeric: tabular-nums;
   text-align: center;
   color: var(--rf-paper);
@@ -325,6 +329,8 @@ button[onclick*="'more'"] #time { display: none !important; }
   display: inline-block !important;
   vertical-align: middle !important;
   font: 500 12px/18px var(--rf-sans) !important;
+  font-size: calc(12px * var(--rf-chrome-scale, 1)) !important;
+  line-height: calc(18px * var(--rf-chrome-scale, 1)) !important;
   font-weight: 500 !important;
   letter-spacing: 0 !important;
   text-transform: none !important;

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -69,10 +69,9 @@ body {
   color: var(--rf-ink) !important;
   text-align: center;
   line-height: 1.5;
-  /* Honor the user's reviewer-font-size setting (small/medium/large/
-     x-large maps to 16/19/22/26 in __init__.py); default to 25 to match
-     the reviewer rebuild's reading column. */
-  font-size: var(--rf-card-font-size, 25px);
+  /* Honor the user's reviewer-font-size setting (Settings → Reviewer →
+     Font size); the value comes through as --rf-card-font-size. */
+  font-size: var(--rf-card-font-size, 28px);
   box-sizing: border-box;
 }
 
@@ -87,7 +86,7 @@ body.card { max-width: none !important; }
 :not(body).card {
   max-width: var(--rf-card-max-width, 720px);
   margin: 0 auto;
-  font-size: var(--rf-card-font-size, 25px);
+  font-size: var(--rf-card-font-size, 28px);
   line-height: 1.55;
   color: var(--rf-ink);
 }
@@ -103,6 +102,7 @@ body.card { max-width: none !important; }
   gap: 16px;
   padding: 14px 28px 12px;
   font: 500 12px/1 var(--rf-sans);
+  font-size: calc(12px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
   color: var(--rf-ink-faint);
 }
@@ -117,7 +117,7 @@ body.card { max-width: none !important; }
 .ba-rv-deck {
   color: var(--rf-ink-dim);
   font-weight: 600;
-  font-size: 13px;
+  font-size: calc(13px * var(--rf-chrome-scale, 1));
   max-width: 38ch;
   overflow: hidden;
   white-space: nowrap;
@@ -126,6 +126,7 @@ body.card { max-width: none !important; }
 .ba-rv-type {
   display: inline-block;
   font: 500 11px/1 var(--rf-sans);
+  font-size: calc(11px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
   color: var(--rf-ink-faint);
   max-width: 18ch;
@@ -138,14 +139,15 @@ body.card { max-width: none !important; }
    width/height AND min/max so no hover state, focus, or active state
    can stretch the box. transform stays at none too — no scale pulses. */
 .ba-rv-back {
-  flex: 0 0 28px;
+  --rf-icon-btn-size: calc(28px * var(--rf-chrome-scale, 1));
+  flex: 0 0 var(--rf-icon-btn-size);
   box-sizing: border-box;
-  width: 28px;
-  height: 28px;
-  min-width: 28px;
-  max-width: 28px;
-  min-height: 28px;
-  max-height: 28px;
+  width: var(--rf-icon-btn-size);
+  height: var(--rf-icon-btn-size);
+  min-width: var(--rf-icon-btn-size);
+  max-width: var(--rf-icon-btn-size);
+  min-height: var(--rf-icon-btn-size);
+  max-height: var(--rf-icon-btn-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -156,6 +158,7 @@ body.card { max-width: none !important; }
   border-radius: 999px;
   color: var(--rf-ink-faint);
   font: 500 18px/1 var(--rf-sans);
+  font-size: calc(18px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
   cursor: pointer;
   transform: none;
@@ -173,30 +176,9 @@ body.card { max-width: none !important; }
   box-shadow: none;
   transform: none;
   padding: 0;
-  width: 28px;
-  height: 28px;
+  width: var(--rf-icon-btn-size);
+  height: var(--rf-icon-btn-size);
 }
-.ba-rv-sep {
-  display: inline-block;
-  width: 1px;
-  height: 12px;
-  background: var(--rf-line-2);
-  margin: 0 2px;
-}
-.ba-rv-pos {
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0;
-  color: var(--rf-ink-faint);
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-}
-.ba-rv-pos b {
-  color: var(--rf-ink-dim);
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-.ba-rv-pos span { color: var(--rf-ink-faint); font-size: 11px; }
 
 /* Header counts breakdown — three quiet "N · label" units, dot-prefixed.
    Each pair sits on a row, vertically centered, with a faint colored dot. */
@@ -210,6 +192,7 @@ body.card { max-width: none !important; }
   align-items: baseline;
   gap: 5px;
   font: 500 12px/1 var(--rf-sans);
+  font-size: calc(12px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
   color: var(--rf-ink-faint);
   position: relative;
@@ -231,7 +214,7 @@ body.card { max-width: none !important; }
   color: var(--rf-ink-dim);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  font-size: 13px;
+  font-size: calc(13px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
 }
 .ba-rv-count i {
@@ -256,14 +239,15 @@ body.card { max-width: none !important; }
 /* Header icon buttons (Edit, More). All sizing is locked: width, height,
    min/max, box-sizing, padding — so hover/focus/active never resize. */
 .ba-rv-icon-btn {
-  flex: 0 0 28px;
+  --rf-icon-btn-size: calc(28px * var(--rf-chrome-scale, 1));
+  flex: 0 0 var(--rf-icon-btn-size);
   box-sizing: border-box;
-  width: 28px;
-  height: 28px;
-  min-width: 28px;
-  max-width: 28px;
-  min-height: 28px;
-  max-height: 28px;
+  width: var(--rf-icon-btn-size);
+  height: var(--rf-icon-btn-size);
+  min-width: var(--rf-icon-btn-size);
+  max-width: var(--rf-icon-btn-size);
+  min-height: var(--rf-icon-btn-size);
+  max-height: var(--rf-icon-btn-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -278,7 +262,11 @@ body.card { max-width: none !important; }
   transform: none;
   transition: color 160ms ease, opacity 160ms ease;
 }
-.ba-rv-icon-btn svg { width: 15px; height: 15px; display: block; }
+.ba-rv-icon-btn svg {
+  width: calc(15px * var(--rf-chrome-scale, 1));
+  height: calc(15px * var(--rf-chrome-scale, 1));
+  display: block;
+}
 .ba-rv-icon-btn:hover,
 .ba-rv-icon-btn:focus,
 .ba-rv-icon-btn:focus-visible,
@@ -290,8 +278,8 @@ body.card { max-width: none !important; }
   box-shadow: none;
   transform: none;
   padding: 0;
-  width: 28px;
-  height: 28px;
+  width: var(--rf-icon-btn-size);
+  height: var(--rf-icon-btn-size);
 }
 .ba-rv-icon-btn[hidden] { display: none !important; }
 
@@ -354,11 +342,16 @@ body.card { max-width: none !important; }
   text-decoration: none !important;
 }
 .ba-rv-ease-key {
-  /* Roomy padding = bigger click target. Visual text remains the same. */
-  padding: 14px 28px;
+  /* Roomy padding = bigger click target. Padding and font scale together
+     so the whole chip grows with the reviewer-font-size setting. */
+  padding: calc(14px * var(--rf-chrome-scale, 1))
+           calc(28px * var(--rf-chrome-scale, 1));
   margin: 0;
   cursor: pointer;
-  font: 500 14px/1 var(--rf-sans);
+  font-family: var(--rf-sans);
+  font-weight: 500;
+  font-size: calc(14px * var(--rf-chrome-scale, 1));
+  line-height: 1;
   letter-spacing: 0;
   color: var(--ba-key, var(--rf-ink-faint));
   background: transparent;
@@ -395,7 +388,7 @@ body.card { max-width: none !important; }
   margin: 0 auto;
   box-sizing: border-box;
   min-height: 0;
-  font-size: var(--rf-card-font-size, 25px);
+  font-size: var(--rf-card-font-size, 28px);
   line-height: 1.5;
   letter-spacing: -0.005em;
   overflow-y: auto;
@@ -409,8 +402,8 @@ body.card { max-width: none !important; }
   color: var(--rf-ink) !important;
   background: transparent !important;
   /* Override note-type's 20px default with the user's chosen size from
-     Settings (reviewer_font_size). Default 25 keeps the rebuild look. */
-  font-size: var(--rf-card-font-size, 25px) !important;
+     Settings (reviewer_font_size). */
+  font-size: var(--rf-card-font-size, 28px) !important;
 }
 
 /* The answer divider — a quiet hairline, no caption. Anki's internal


### PR DESCRIPTION
## Summary
- Removed the "1 of 18" position indicator from the reviewer header (HTML element + the JS that updated it + the now-unused `.ba-rv-sep` / `.ba-rv-pos` CSS).
- Bumped the reviewer card font-size tiers from `20/25/30/36` to `22/28/34/40` (small/medium/large/x-large) so the default reading column feels less cramped.
- Introduced `--rf-chrome-scale` (driven by the same `reviewer_font_size` config) so the top header (deck name, count chips, back/Edit/More icon buttons) and the bottom ease chips scale alongside the card body.

## Test plan
- [x] Reviewer header no longer shows the "1 of 18" position counter.
- [x] Studying screen at Small / Medium / Large / XL all scale together: card text, header chips, and bottom ease chips.
- [ ] Switching font size in Settings → Reviewer → Font size takes effect on next reviewer entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)