### PR TITLE
Stats embed: editorial header, pill filters, lifted cards

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1406,13 +1406,66 @@ def _is_congrats_url(url: str) -> bool:
     return False
 
 
+def _is_graphs_url(url: str) -> bool:
+    if not url:
+        return False
+    # Anki serves the SvelteKit stats page at <serverURL>/graphs (with an
+    # optional `#night` fragment). The page is loaded by NewDeckStats via
+    # `web.load_sveltekit_page("graphs")`.
+    low = url.lower()
+    if low.endswith("/graphs") or low.endswith("/graphs/"):
+        return True
+    if "/graphs#" in low or "/graphs?" in low:
+        return True
+    return False
+
+
+def _inject_graphs_overrides(webview) -> None:
+    """Style the SvelteKit graphs page with our palette + typography.
+
+    The page uses Anki's `--canvas` / `--fg` / etc tokens; web/stats.css
+    re-maps those to our `--rf-*` tokens. tokens.css must load first so
+    the `--rf-*` variables are defined when stats.css consumes them."""
+    cfg = _config()
+    accent = cfg.get("accent", "#6c8cff")
+    theme_pref = cfg.get("theme", "system")
+    theme_attr = ""
+    if theme_pref in ("light", "dark"):
+        import json as _json
+        theme_attr = (
+            f"document.documentElement.dataset.rfTheme="
+            f"{_json.dumps(theme_pref)};"
+        )
+    accent_style = (
+        f"var st=document.createElement('style');"
+        f"st.textContent=':root,body{{--rf-accent:{accent};}}';"
+        f"document.head.appendChild(st);"
+    )
+    css_files = ["tokens.css", "theme.css", "stats.css"]
+    css_inject = ""
+    for f in css_files:
+        css_inject += (
+            f"(function(){{var l=document.createElement('link');"
+            f"l.rel='stylesheet';l.href='{WEB}/{f}';"
+            f"document.head.appendChild(l);}})();"
+        )
+    try:
+        webview.eval(theme_attr + accent_style + css_inject)
+    except Exception:
+        pass
+
+
 def on_webview_did_inject_style_into_page(webview) -> None:
-    """Detect Anki's congrats Svelte page after its dynamic styling finishes,
-    then graft our sidebar + redesign on top. Idempotent (the JS bails if it
-    already initialised), so re-firing on theme changes is harmless."""
+    """Detect Anki's congrats / graphs Svelte pages after their dynamic
+    styling finishes, then graft our redesign on top. Idempotent (the
+    style/script appends bail if they already ran), so re-firing on theme
+    changes is harmless."""
     try:
         url = webview.page().url().toString()
     except Exception:
+        return
+    if _is_graphs_url(url):
+        _inject_graphs_overrides(webview)
         return
     if not _is_congrats_url(url):
         return
@@ -2285,9 +2338,17 @@ def _dev_screenshot(request_path: str) -> None:
             # complete before the 2000ms grab.
             _QT.singleShot(1000, _hover_add)
         mw_width = req.get("mw_width")
+        mw_height = req.get("mw_height")
         if isinstance(mw_width, int) and mw_width > 200:
             try:
-                mw.resize(mw_width, mw.height())
+                h = mw_height if isinstance(mw_height, int) and mw_height > 200 else mw.height()
+                mw.resize(mw_width, h)
+                QApplication.processEvents()
+            except Exception:
+                pass
+        elif isinstance(mw_height, int) and mw_height > 200:
+            try:
+                mw.resize(mw.width(), mw_height)
                 QApplication.processEvents()
             except Exception:
                 pass
@@ -2495,6 +2556,14 @@ def _dev_dump(request_path: str) -> None:
                     ac = None
             if ac is not None and getattr(ac, "editor", None):
                 web = ac.editor.web
+        elif target_kind == "stats-embed":
+            try:
+                from . import stats_embed
+                sd = stats_embed._state.get("stats")
+                if sd is not None and getattr(sd, "form", None):
+                    web = getattr(sd.form, "web", None)
+            except Exception:
+                pass
         # 2) `main`/`mw`: pin to mw.web. mw has multiple QWebEngineViews
         # (toolbarWeb, web, bottomWeb); findChild() returns the first one
         # constructed (usually the toolbar) which gives a useless 1-line

--- a/stats_embed.py
+++ b/stats_embed.py
@@ -31,9 +31,12 @@ from aqt.qt import (
     QColor,
     QEvent,
     QFrame,
+    QHBoxLayout,
     QKeySequence,
+    QLabel,
     QObject,
     QPalette,
+    QPushButton,
     QShortcut,
     Qt,
     QTimer,
@@ -42,6 +45,117 @@ from aqt.qt import (
 
 
 SIDEBAR_W = 264  # px — matches --rf-side-w in web/theme.css; same as the other embeds
+
+
+SERIF = '"New York", "Hoefler Text", "Iowan Old Style", Charter, Georgia, serif'
+SANS = '"SF Pro Text", "Helvetica Neue", "Segoe UI", system-ui, sans-serif'
+
+
+def _chrome_qss(palette: dict, accent: str) -> str:
+    """QSS for the dialog chrome (everything outside the graphs webview).
+
+    The graphs webview itself gets its own CSS injection via
+    `webview_did_inject_style_into_page` in __init__.py so its fonts and
+    colors line up with the rest of the redesigned UI."""
+    return f"""
+QDialog, QFrame#ba-stats-embed {{
+    background: {palette['paper']};
+    color: {palette['ink']};
+    font-family: {SANS};
+}}
+
+/* Top header strip — "Statistics" title + the deck chooser inline. */
+QFrame#ba-stats-header {{
+    background: {palette['paper']};
+}}
+QLabel#ba-stats-title {{
+    color: {palette['ink']};
+    font-family: {SERIF};
+    font-size: 22pt;
+    font-weight: 500;
+    letter-spacing: -0.4px;
+    padding: 0;
+    background: transparent;
+}}
+QLabel#ba-stats-eyebrow {{
+    color: {palette['ink_faint']};
+    font-family: {SANS};
+    font-size: 8.5pt;
+    font-weight: 600;
+    letter-spacing: 1.8px;
+    text-transform: uppercase;
+    padding: 0;
+    background: transparent;
+}}
+
+/* The bottom strip (deck chooser + Save PDF / Close). */
+QDialog QWidget#deckArea, QWidget#deckArea {{
+    background: transparent;
+}}
+#deckArea QLabel {{
+    color: {palette['ink_faint']};
+    font-family: {SANS};
+    font-size: 9.5pt;
+    background: transparent;
+}}
+#deckArea QPushButton {{
+    background: transparent;
+    border: 1px solid {palette['line2']};
+    border-radius: 6px;
+    color: {palette['ink']};
+    font-family: {SANS};
+    font-size: 10.5pt;
+    font-weight: 500;
+    padding: 5px 12px;
+    min-height: 16px;
+    text-decoration: none;
+}}
+#deckArea QPushButton:hover {{
+    color: {accent};
+    background: {palette['hover']};
+    border-color: {palette['ink_faint']};
+}}
+#deckArea QPushButton:focus {{
+    outline: none;
+    border-color: {accent};
+    color: {accent};
+}}
+
+QDialogButtonBox {{
+    background: transparent;
+}}
+QDialogButtonBox QPushButton {{
+    background: transparent;
+    border: 1px solid {palette['line2']};
+    border-radius: 6px;
+    color: {palette['ink_dim']};
+    font-family: {SANS};
+    font-size: 10pt;
+    font-weight: 500;
+    padding: 6px 16px;
+    min-width: 86px;
+    min-height: 18px;
+}}
+QDialogButtonBox QPushButton:hover {{
+    color: {palette['ink']};
+    background: {palette['hover']};
+    border-color: {palette['ink_faint']};
+}}
+QDialogButtonBox QPushButton:focus {{
+    outline: none;
+    border-color: {accent};
+    color: {palette['ink']};
+}}
+QDialogButtonBox QPushButton:default {{
+    background: {palette['ink']};
+    color: {palette['paper']};
+    border-color: {palette['ink']};
+}}
+QDialogButtonBox QPushButton:default:hover {{
+    background: {palette['ink_dim']};
+    border-color: {palette['ink_dim']};
+}}
+"""
 
 
 class _EmbedFilter(QObject):
@@ -222,6 +336,9 @@ def open_inline(parent_mw: Any = None) -> None:
         except Exception:
             pass
 
+        cfg = _addcard._config()
+        accent = cfg.get("accent", "#6c8cff")
+
         overlay = QFrame(parent_mw.form.centralwidget)
         overlay.setObjectName("ba-stats-embed")
         overlay.setAutoFillBackground(True)
@@ -229,13 +346,40 @@ def open_inline(parent_mw: Any = None) -> None:
         _ov_pal.setColor(QPalette.ColorRole.Window, paper_qc)
         overlay.setPalette(_ov_pal)
         overlay.setStyleSheet(
-            "QFrame#ba-stats-embed { background: " + palette["paper"] + "; "
-            "border-left: 1px solid " + palette["line"] + "; }"
+            _chrome_qss(palette, accent)
+            + "\nQFrame#ba-stats-embed { border-left: 1px solid "
+            + palette["line"] + "; }"
         )
 
         v = QVBoxLayout(overlay)
         v.setContentsMargins(0, 0, 0, 0)
         v.setSpacing(0)
+
+        # Top header strip — eyebrow "STATISTICS" label over a serif title
+        # echoing the deck name. The title text is filled in once the deck
+        # chooser reports the current deck. Mirrors the editorial tone of
+        # the deck-browser/homepage header.
+        header = QFrame(overlay)
+        header.setObjectName("ba-stats-header")
+        header.setAutoFillBackground(True)
+        _hd_pal = header.palette()
+        _hd_pal.setColor(QPalette.ColorRole.Window, paper_qc)
+        header.setPalette(_hd_pal)
+        hl = QHBoxLayout(header)
+        hl.setContentsMargins(40, 28, 40, 22)
+        hl.setSpacing(0)
+
+        title_col = QVBoxLayout()
+        title_col.setContentsMargins(0, 0, 0, 0)
+        title_col.setSpacing(6)
+        eyebrow = QLabel("STATISTICS", header)
+        eyebrow.setObjectName("ba-stats-eyebrow")
+        title_col.addWidget(eyebrow)
+        title = QLabel("Your progress", header)
+        title.setObjectName("ba-stats-title")
+        title_col.addWidget(title)
+        hl.addLayout(title_col, 1)
+        v.addWidget(header)
 
         # Reparent the WHOLE dialog as an embedded widget. Everything the
         # form put on it (web, deck chooser, button box) and anything
@@ -245,6 +389,66 @@ def open_inline(parent_mw: Any = None) -> None:
         sd.setWindowFlags(Qt.WindowType.Widget)
         sd.setVisible(True)
         v.addWidget(sd, 1)
+
+        # Mirror the active deck name into the header title.
+        # `DeckChooser.selected_deck_name()` is the canonical accessor;
+        # we fall back to the chooser's button text if Anki's API moves.
+        def _refresh_title() -> None:
+            try:
+                name = ""
+                dc = getattr(sd, "deck_chooser", None)
+                if dc is not None:
+                    try:
+                        name = dc.selected_deck_name() or ""
+                    except Exception:
+                        name = ""
+                if not name:
+                    try:
+                        btn = sd.form.deckArea.findChild(QPushButton)
+                        if btn is not None:
+                            name = btn.text() or ""
+                    except Exception:
+                        pass
+                # The button label escapes ampersands as "&&" for Qt
+                # mnemonics — undo so the title reads naturally.
+                name = name.replace("&&", "&").strip()
+                title.setText(name or "Your progress")
+            except Exception:
+                pass
+
+        _refresh_title()
+        try:
+            dc = getattr(sd, "deck_chooser", None)
+            if dc is not None and hasattr(dc, "on_deck_changed"):
+                _orig_changed = dc.on_deck_changed
+                def _wrapped_deck_changed(deck_id, _orig=_orig_changed):
+                    try:
+                        _orig(deck_id)
+                    finally:
+                        QTimer.singleShot(0, _refresh_title)
+                dc.on_deck_changed = _wrapped_deck_changed  # type: ignore[assignment]
+        except Exception:
+            pass
+
+        # The DeckChooser auto-prepends a "Deck:" QLabel — hide it; the
+        # title up top already names what the user is looking at.
+        try:
+            da = sd.form.deckArea
+            for child in da.findChildren(QLabel):
+                child.hide()
+                break
+        except Exception:
+            pass
+
+        # The bottom strip (deck chooser + button box) defaults to a
+        # tight (16, 6, 16, 6) margin set in stats_qt6.py — bump it so
+        # the controls feel like part of an editorial layout, not a
+        # crammed dialog footer.
+        try:
+            sd.form.horizontalLayout_3.setContentsMargins(40, 16, 40, 18)
+            sd.form.horizontalLayout_3.setSpacing(14)
+        except Exception:
+            pass
 
         # Hijack the Close button (buttonBox.rejected normally routes to
         # NewDeckStats.reject) so clicking Close tears the embed down

--- a/web/stats.css
+++ b/web/stats.css
@@ -1,0 +1,335 @@
+/* Anki Design — overrides for the SvelteKit graphs ("/graphs") page.
+
+   The stats embed renders the standard graphs page inside our themed
+   wrapper (see stats_embed.py). Anki's own CSS uses these tokens:
+     --canvas, --fg, --fg-subtle, --fg-faint, --border, --border-subtle,
+     --fg-link, --font-size, --border-radius, ...
+   Mapping them to our palette via tokens.css (already injected before
+   this stylesheet) gives the graphs the same paper, ink, and divider
+   colors the rest of the app uses without rewriting any Svelte. */
+
+:root {
+  /* Anki's own variables, mapped to our --rf-* tokens. All "canvas"
+     variants point at the SAME paper so cards merge into the page. */
+  --canvas: var(--rf-paper);
+  --canvas-elevated: var(--rf-paper);
+  --canvas-inset: var(--rf-paper);
+  --canvas-overlay: var(--rf-paper);
+  --fg: var(--rf-ink);
+  --fg-subtle: var(--rf-ink-dim);
+  --fg-faint: var(--rf-ink-faint);
+  --fg-disabled: var(--rf-ink-faint);
+  --fg-link: var(--rf-accent, #6c8cff);
+  --border: var(--rf-line);
+  --border-subtle: var(--rf-line);
+  --border-strong: var(--rf-line-2);
+  --border-focus: var(--rf-accent, #6c8cff);
+  --shadow: transparent;
+  --shadow-inset: transparent;
+  --shadow-subtle: transparent;
+  --font-size: 14px;
+  --button-bg: transparent;
+  --button-gradient-start: transparent;
+  --button-gradient-end: transparent;
+  --button-hover-border: var(--rf-line-2);
+  --button-primary-bg: var(--rf-ink);
+  --button-primary-gradient-start: var(--rf-ink);
+  --button-primary-gradient-end: var(--rf-ink);
+}
+
+/* ------------------------ Type ------------------------ */
+html, body {
+  background: var(--rf-paper) !important;
+  color: var(--rf-ink);
+  font-family: var(--rf-sans);
+  -webkit-font-smoothing: antialiased;
+}
+body { margin: 0; padding: 0; }
+
+/* Graph card headings: editorial serif, no Anki-default underline. */
+.graphs-container h1,
+.graphs-container .title,
+h1, h2, h3 {
+  font-family: var(--rf-serif);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--rf-ink);
+  margin: 0 0 18px;
+  padding-bottom: 0;
+  border: 0;
+  border-bottom: 0 !important;
+}
+.graphs-container h1 { font-size: 17px; }
+
+/* Tabular figures for numbers across the page. */
+table, td, th {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+
+/* ============================ Range box ============================
+   Sticky top strip with deck/collection + range radios + the search
+   field. Defaults render as 1990s form controls — replace with pill
+   toggles and a quiet inline search. */
+.range-box,
+[class*="range-box"] {
+  background: var(--rf-paper) !important;
+  border-bottom: 0 !important;
+  color: var(--rf-ink) !important;
+  padding: 18px 36px 6px !important;
+  font-family: var(--rf-sans);
+  font-size: 12.5px;
+  display: flex !important;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 18px;
+}
+
+/* The deck-search text field at the right of the range box. */
+.range-box input[type="text"],
+.range-box input:not([type]),
+[class*="range-box"] input[type="text"],
+[class*="range-box"] input:not([type]) {
+  background: transparent !important;
+  border: 1px solid var(--rf-line-2) !important;
+  border-radius: 8px !important;
+  color: var(--rf-ink) !important;
+  font-family: var(--rf-sans) !important;
+  font-size: 12.5px !important;
+  padding: 6px 12px !important;
+  min-width: 180px;
+  outline: none !important;
+  box-shadow: none !important;
+  margin: 0 6px;
+}
+.range-box input[type="text"]:focus,
+.range-box input:not([type]):focus,
+[class*="range-box"] input[type="text"]:focus,
+[class*="range-box"] input:not([type]):focus {
+  border-color: var(--rf-accent, #6c8cff) !important;
+}
+
+/* ============================ Pill toggles ============================
+   Apply pill styling to ALL radio/checkbox <label>s on the page (range
+   box AND in-chart selectors like Backlog/1 month/3 months on Future
+   Due, Time/1 month/etc on Reviews, suspended-buried on Card Counts).
+   Hide the actual <input> and let the label do the work. */
+.range-box label,
+[class*="range-box"] label,
+.graphs-container label,
+[class*="graphs-container"] label {
+  display: inline-flex !important;
+  align-items: center;
+  padding: 5px 12px;
+  border-radius: 999px;
+  color: var(--rf-ink-dim);
+  font-family: var(--rf-sans);
+  font-weight: 500;
+  font-size: 12.5px;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  margin: 0;
+}
+.range-box label:hover,
+.graphs-container label:hover,
+[class*="range-box"] label:hover,
+[class*="graphs-container"] label:hover {
+  color: var(--rf-ink);
+  background: var(--rf-row-hover);
+}
+/* Selected radio/checkbox → ink-on-paper inverted pill. */
+.range-box label:has(input:checked),
+[class*="range-box"] label:has(input:checked),
+.graphs-container label:has(input:checked),
+[class*="graphs-container"] label:has(input:checked) {
+  color: var(--rf-paper) !important;
+  background: var(--rf-ink) !important;
+  border-color: var(--rf-ink) !important;
+}
+
+/* Hide the native radio/checkbox glyph — the pill IS the indicator. */
+.range-box input[type="radio"],
+.range-box input[type="checkbox"],
+[class*="range-box"] input[type="radio"],
+[class*="range-box"] input[type="checkbox"],
+.graphs-container input[type="radio"],
+.graphs-container input[type="checkbox"],
+[class*="graphs-container"] input[type="radio"],
+[class*="graphs-container"] input[type="checkbox"] {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  opacity: 0;
+  pointer-events: none;
+  margin: 0 !important;
+}
+
+/* ============================ Graphs grid ============================
+   Anki's defaults key column count off `100vw` — but our embed loses
+   ~264px to the sidebar, so its breakpoints fire too early and the
+   page collapses to a single column at typical window widths. Re-key
+   the grid off the embed's container so 1 / 2 / 3 columns track the
+   space the graphs actually have. Container queries would be cleaner
+   but require the .graphs-container itself to be the container; just
+   override the existing widths instead. */
+.graphs-container,
+[class*="graphs-container"] {
+  padding: 12px 36px 56px !important;
+  width: auto !important;
+  margin: 0 !important;
+  gap: 28px 36px !important;
+  align-items: start !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+}
+@media only screen and (max-width: 1500px) {
+  .graphs-container,
+  [class*="graphs-container"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+}
+@media only screen and (max-width: 1000px) {
+  .graphs-container,
+  [class*="graphs-container"] {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+/* Each individual graph card — a quiet panel tint (--rf-panel sits a
+   few percent above --rf-paper in both themes) with a hairline border
+   so cards lift off the page without shouting. No drop shadow; the
+   contrast does the work. */
+.graphs-container > div,
+[class*="graphs-container"] > div {
+  background: var(--rf-panel) !important;
+  border: 1px solid var(--rf-line) !important;
+  box-shadow: none !important;
+  border-radius: 12px !important;
+  padding: 20px 24px !important;
+}
+
+/* The .graph area inside each card defaults to flex-grow:1 +
+   justify-content:center, which centers the empty-state text in a huge
+   vertical void on charts with no data. Anchor content to the top of
+   the card so the page reads as a compact column. */
+.graph,
+[class*="svelte"].graph,
+.container .graph {
+  flex-grow: 0 !important;
+  justify-content: flex-start !important;
+  min-height: 0 !important;
+}
+.legend, [class*="legend"] {
+  text-align: left !important;
+}
+
+/* Hide the Bootstrap-reset hr inside graph cards (Anki ships <hr>
+   between title and chart on a few graphs). */
+.graphs-container hr,
+[class*="graphs-container"] hr { display: none !important; }
+
+/* SVG axis text inherits from the body but Anki's defaults render
+   slightly heavier than we want; pull contrast down on axis labels. */
+svg text {
+  fill: var(--rf-ink);
+  font-family: var(--rf-sans);
+}
+svg .tick text,
+svg .axis text {
+  fill: var(--rf-ink-dim);
+}
+
+/* Tables inside the graphs (counts, retention, true retention). */
+.graphs-container table,
+[class*="graphs-container"] table {
+  border-collapse: collapse;
+  color: var(--rf-ink);
+  font-size: 13px;
+}
+.graphs-container tr,
+[class*="graphs-container"] tr {
+  border-top: 1px solid var(--rf-line) !important;
+  border-bottom: 1px solid var(--rf-line) !important;
+}
+.graphs-container td,
+.graphs-container th {
+  padding: 6px 10px !important;
+}
+
+/* The "search this card" link rendered as a faux-link button on the
+   future-due chart. */
+.search-link {
+  color: var(--rf-ink-dim) !important;
+  background: transparent !important;
+  border: 0 !important;
+}
+.search-link:hover {
+  color: var(--rf-accent, #6c8cff) !important;
+}
+
+/* Calendar weekday labels (S M T W T F S) and axis ticks — Anki sets
+   `fill="black"` and `font-family="monospace"` as SVG attributes; CSS
+   overrides them. */
+svg .weekdays text,
+svg .x-ticks text,
+svg .y-ticks text,
+svg .y2-ticks text,
+svg .tick text,
+svg .domain {
+  fill: var(--rf-ink-dim) !important;
+  font-family: var(--rf-sans) !important;
+  font-size: 11px;
+}
+svg .weekdays text { font-size: 10px; }
+
+/* Bare <button>s — used by the Calendar widget for year navigation
+   (◄ ►). Inherit our chip-button look. */
+.graphs-container button:not(.search-link):not([class*="svelte-"]):not(.btn),
+[class*="graphs-container"] button:not(.search-link):not([class*="svelte-"]):not(.btn) {
+  -webkit-appearance: none;
+  background: transparent !important;
+  border: 1px solid var(--rf-line-2) !important;
+  border-radius: 6px !important;
+  box-shadow: none !important;
+  color: var(--rf-ink) !important;
+  font-family: var(--rf-sans) !important;
+  font-size: 12px !important;
+  padding: 2px 9px !important;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.graphs-container button:not(.search-link):not([class*="svelte-"]):not(.btn):hover,
+[class*="graphs-container"] button:not(.search-link):not([class*="svelte-"]):not(.btn):hover {
+  background: var(--rf-row-hover) !important;
+  border-color: var(--rf-ink-faint) !important;
+}
+.graphs-container button[disabled],
+[class*="graphs-container"] button[disabled] {
+  opacity: 0.4 !important;
+  cursor: not-allowed !important;
+}
+
+/* Chart subtitles (e.g. "The number of reviews due in the future.")
+   sit quietly under the title. Sans (not italic serif — that renders
+   as a calligraphic script in some serif stacks and gets unreadable
+   at this size). */
+.subtitle, [class*="subtitle"] {
+  color: var(--rf-ink-dim) !important;
+  font-family: var(--rf-sans) !important;
+  font-style: normal;
+  font-size: 12.5px !important;
+  font-weight: 400;
+  margin-bottom: 14px;
+  text-align: left;
+}
+
+/* Help-badge (small ? icon next to chart titles) — keep, just neutral. */
+.help-badge {
+  color: var(--rf-ink-faint) !important;
+  background: transparent !important;
+  border: 0 !important;
+}
+
+/* Print stays whatever Anki gave us — graphs are printed during Save PDF.
+   Don't override print rules so the PDF output keeps its known layout. */


### PR DESCRIPTION
## Summary
- Wrap the embedded `NewDeckStats` with a "STATISTICS" eyebrow + serif title that mirrors the active deck, restyles the deck chooser, and themes the Save PDF / Close button row.
- New `web/stats.css` injects into the SvelteKit `/graphs` page via `webview_did_inject_style_into_page`: maps Anki's `--canvas`/`--fg`/`--border` tokens to our `--rf-*` palette, replaces all range-box and in-chart radios with pill toggles, styles the calendar nav arrows, and gives each graph a quiet `--rf-panel` card so cards are visually distinct without heavy chrome.
- Re-keys the grid breakpoints to the embed's actual width (sidebar steals 264px from `100vw`) so the page favors 1- and 2-column at typical sizes and only opens to 3-column at very wide widths.

## Test plan
- [ ] `make demo VARIANT=single`, hit `t` — header reads `STATISTICS / <deck name>`, filter pills are ink-on-paper, cards lift with a subtle border, Esc closes.
- [ ] Verify in both light and dark themes.
- [ ] Resize the window: 1-col under ~1000px embed, 2-col through ~1500px, 3-col above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)