### PR TITLE
Reviewer: inline field editing replaces EditCurrent dialog

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -836,6 +836,37 @@ def _on_js_message(handled, message, context):
             except Exception:
                 pass
             return (True, None)
+        if cmd.startswith("edit-save:"):
+            payload = cmd[len("edit-save:"):]
+            try:
+                from . import editreviewer
+                editreviewer.handle_edit_save(payload)
+            except Exception:
+                pass
+            return (True, None)
+        if cmd.startswith("edit-full"):
+            # Either "edit-full" (no payload) or "edit-full:<json>".
+            payload = ""
+            if cmd.startswith("edit-full:"):
+                payload = cmd[len("edit-full:"):]
+            try:
+                from . import editreviewer
+                editreviewer.handle_edit_full(payload)
+            except Exception:
+                pass
+            return (True, None)
+        if cmd.startswith("edit-state:"):
+            # JS enter/exit signal — toggles whether the reviewer's Qt
+            # shortcuts are active. While editing they're disabled so the
+            # user can type normally (including letters like e/m, plus
+            # ⌘+Backspace which Anki normally maps to delete-note).
+            on = cmd[len("edit-state:"):] == "on"
+            try:
+                from . import editreviewer
+                editreviewer.set_edit_active(on)
+            except Exception:
+                pass
+            return (True, None)
         if cmd == "decks":
             # If we're in any embedded view (Add, Browse, Stats,
             # Settings), close it first so the deck browser becomes
@@ -2024,6 +2055,17 @@ try:
 except Exception as _e:
     try:
         print(f"[anki-design] addcard register failed: {_e}", flush=True)
+    except Exception:
+        pass
+
+
+# Inline reviewer editing — replaces the EditCurrent dialog.
+try:
+    from . import editreviewer as _editreviewer
+    _editreviewer.register()
+except Exception as _e:
+    try:
+        print(f"[anki-design] editreviewer register failed: {_e}", flush=True)
     except Exception:
         pass
 

--- a/editreviewer.py
+++ b/editreviewer.py
@@ -1,0 +1,318 @@
+"""Anki Design — inline reviewer editing.
+
+Replaces the standalone `EditCurrent` QMainWindow with editing-in-place:
+the card's field text becomes contenteditable directly inside the reviewer
+webview, with a small floating toolbar (Done / Cancel / Open in full editor
+/ basic formatting). The card stays exactly where it was; only the field
+spans gain an outline and a caret.
+
+How it works
+============
+
+1.  `card_will_show` post-processes the rendered Q/A HTML, wrapping each
+    non-empty field's value in `<span data-ba-field="Name">…</span>`.
+    Wrapping happens longest-first via placeholder substitution so a short
+    field's value can't accidentally match inside a longer field.
+
+2.  `pycmd('edit')` is captured by intercepting `mw.onEditCurrent` (the
+    one entry point both the pencil button and the `e` shortcut go
+    through after our `state_shortcuts_will_change` rewrite). The patched
+    function asks the reviewer webview to enter inline edit mode.
+
+3.  Inside the webview, `web/reviewer.js`:
+      • flips every `[data-ba-field]` span to `contenteditable="true"`
+      • shows a floating toolbar at the bottom (Cmd+Return saves)
+      • captures escape / cmd+s / cmd+enter / cmd+. as save/cancel
+      • disables the click-to-reveal handler while editing
+
+4.  On save, JS collects each span's `innerHTML` and posts back via
+    `pycmd('ba:edit-save:<json>')`. We update the note, persist via
+    `mw.col.update_note`, then re-render the current card so the changes
+    are visible in the rendered template too.
+
+5.  The "Open in full editor" button posts `pycmd('ba:edit-full')`, which
+    saves any pending inline changes and then opens Anki's native
+    `EditCurrent` dialog as the escape hatch.
+
+Fallbacks
+---------
+Fields that don't appear literally in the rendered template (cloze,
+`{{type:Field}}`, `{{tts:Field}}`, etc.) are silently skipped during
+wrapping. JS notices when no `[data-ba-field]` spans exist and routes
+straight to the full editor instead of presenting an empty edit mode.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import Dict, List, Tuple
+
+from aqt import gui_hooks, mw
+
+
+# --------------------------------------------------------------------------- #
+# Render-time: wrap field values so JS can locate them.
+# --------------------------------------------------------------------------- #
+def _field_pairs(card) -> List[Tuple[str, str]]:
+    """Return [(field_name, field_value), …] for the current note, longest
+    value first so substring-overlapping fields wrap in a safe order."""
+    try:
+        note = card.note()
+    except Exception:
+        return []
+    try:
+        keys = list(note.keys())
+    except Exception:
+        return []
+    pairs: List[Tuple[str, str]] = []
+    for name in keys:
+        try:
+            val = note[name]
+        except Exception:
+            continue
+        if val:
+            pairs.append((str(name), str(val)))
+    pairs.sort(key=lambda kv: -len(kv[1]))
+    return pairs
+
+
+def _wrap_fields(text: str, card, kind: str) -> str:
+    """For each non-empty field, wrap its FIRST literal occurrence in the
+    rendered HTML with a marker div. Idempotent: if the wrap is already
+    present (we re-render after a save) we skip that field.
+
+    Strategy: substitute each field's value with a unique placeholder in
+    a single first pass, then swap placeholders for the wrapped divs in
+    a second pass. This stops nested matches (Field B's value contains
+    Field A's value as a substring) from producing wrap-inside-wrap.
+    """
+    if kind not in ("reviewQuestion", "reviewAnswer", "previewQuestion",
+                    "previewAnswer"):
+        return text
+    if not text or not card:
+        return text
+
+    pairs = _field_pairs(card)
+    if not pairs:
+        return text
+
+    placeholders: Dict[str, Tuple[str, str]] = {}
+    for idx, (name, val) in enumerate(pairs):
+        marker = f"\x00BA_FIELD_{idx}\x00"
+        pos = text.find(val)
+        if pos < 0:
+            continue
+        text = text[:pos] + marker + text[pos + len(val):]
+        placeholders[marker] = (name, val)
+
+    for marker, (name, val) in placeholders.items():
+        safe_name = html.escape(name, quote=True)
+        # We wrap with a DIV (not SPAN) because Anki's webview.js
+        # registers a document-level keydown handler that calls
+        # preventDefault on Backspace unless the event target is an
+        # <input>, <textarea>, or a contenteditable <div>. A
+        # contenteditable <span> doesn't satisfy that check, so Backspace
+        # gets swallowed and editing feels broken. The CSS forces inline
+        # flow so the layout reads the same as the original span wrap.
+        wrapped = (
+            f'<div data-ba-field="{safe_name}" '
+            f'class="ba-rv-field">{val}</div>'
+        )
+        text = text.replace(marker, wrapped)
+    return text
+
+
+# --------------------------------------------------------------------------- #
+# Shortcut rewrite: route "e" / "ㄷ" to our inline editor.
+# --------------------------------------------------------------------------- #
+def _on_state_shortcuts_will_change(state: str, shortcuts: list) -> None:
+    if state != "review":
+        return
+    try:
+        for i, item in enumerate(shortcuts):
+            if not isinstance(item, tuple) or len(item) != 2:
+                continue
+            key, _fn = item
+            if key in ("e", "ㄷ"):
+                shortcuts[i] = (key, _enter_inline_edit)
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Enter / exit edit mode.
+# --------------------------------------------------------------------------- #
+def _enter_inline_edit() -> None:
+    """Ask the reviewer webview to enter inline edit mode. If anything
+    goes wrong (no reviewer, no card, or the JS hasn't loaded yet) we
+    fall back to Anki's native EditCurrent dialog."""
+    rv = getattr(mw, "reviewer", None)
+    if rv is None or getattr(rv, "card", None) is None:
+        _open_full_editor()
+        return
+    web = getattr(rv, "web", None)
+    if web is None:
+        _open_full_editor()
+        return
+    try:
+        web.eval(
+            "(function(){"
+            "if (window.__baEnterEdit) { window.__baEnterEdit(); }"
+            "else { pycmd('ba:edit-full'); }"
+            "})();"
+        )
+    except Exception:
+        _open_full_editor()
+
+
+def _open_full_editor() -> None:
+    """Open Anki's native EditCurrent dialog (the escape hatch)."""
+    try:
+        # Call the ORIGINAL onEditCurrent — not our patched one or we'd
+        # bounce straight back to inline edit and never reach the dialog.
+        orig = getattr(mw, "_ba_orig_on_edit_current", None)
+        if orig is not None:
+            orig()
+        else:
+            mw.onEditCurrent()
+    except Exception:
+        pass
+
+
+def _patch_on_edit_current() -> None:
+    """Replace `mw.onEditCurrent` with our inline launcher. The original
+    is stashed at `mw._ba_orig_on_edit_current` so the escape hatch can
+    still get to it."""
+    try:
+        if getattr(mw, "_ba_orig_on_edit_current", None) is not None:
+            return  # already patched
+        mw._ba_orig_on_edit_current = mw.onEditCurrent  # type: ignore
+        mw.onEditCurrent = _enter_inline_edit  # type: ignore[assignment]
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Save / cancel / open-full handlers, dispatched from _on_js_message.
+# --------------------------------------------------------------------------- #
+def handle_edit_save(payload: str) -> bool:
+    """Apply field updates from the JS payload. Returns True if anything
+    actually changed. The JS sends a JSON object of {field_name: html, …}
+    — only the names we recognise on the current note are applied."""
+    rv = getattr(mw, "reviewer", None)
+    if rv is None or getattr(rv, "card", None) is None:
+        return False
+    try:
+        data = json.loads(payload or "{}")
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    try:
+        note = rv.card.note()
+    except Exception:
+        return False
+
+    changed = False
+    try:
+        keys = set(note.keys())
+    except Exception:
+        return False
+    for name, val in data.items():
+        if not isinstance(name, str) or name not in keys:
+            continue
+        if not isinstance(val, str):
+            continue
+        try:
+            if note[name] != val:
+                note[name] = val
+                changed = True
+        except Exception:
+            continue
+    if not changed:
+        return False
+    try:
+        mw.col.update_note(note)
+    except Exception:
+        try:
+            note.flush()
+        except Exception:
+            return False
+    # The reviewer caches the rendered card output on the Card object —
+    # _showQuestion / _showAnswer would happily re-display that cached
+    # render even though the underlying field values have changed. Bust
+    # the cache so the next render pulls fresh from the (now updated)
+    # note. card.note() also stays in sync because we modified rv.card._note
+    # in place above.
+    try:
+        rv.card._render_output = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    try:
+        if getattr(rv, "state", "") == "answer":
+            rv._showAnswer()
+        else:
+            rv._showQuestion()
+    except Exception:
+        pass
+    return True
+
+
+def handle_edit_full(payload: str) -> None:
+    """User asked to escalate to the full editor. Save anything pending
+    first (so the dialog opens with current state), then open it."""
+    if payload:
+        handle_edit_save(payload)
+    _open_full_editor()
+
+
+def set_edit_active(active: bool) -> None:
+    """JS calls this on edit-mode enter/exit. While editing, Anki's reviewer
+    state shortcuts must be disabled — otherwise typing 'e' re-triggers
+    edit, 'm' opens the More menu, ⌘+Backspace deletes the note, etc.
+    QShortcuts intercept keys at the Qt level before Chromium dispatches
+    them to the contenteditable, so JS handlers alone can't make this work.
+
+    Stash the original enabled flag on each shortcut so a stray double
+    enter/exit doesn't permanently disable anything."""
+    try:
+        shortcuts = list(getattr(mw, "stateShortcuts", []) or [])
+    except Exception:
+        return
+    for sc in shortcuts:
+        try:
+            if active:
+                if not hasattr(sc, "_ba_orig_enabled"):
+                    sc._ba_orig_enabled = sc.isEnabled()  # type: ignore
+                sc.setEnabled(False)
+            else:
+                orig = getattr(sc, "_ba_orig_enabled", True)
+                sc.setEnabled(bool(orig))
+                try:
+                    delattr(sc, "_ba_orig_enabled")
+                except Exception:
+                    pass
+        except Exception:
+            continue
+
+
+# --------------------------------------------------------------------------- #
+# Registration.
+# --------------------------------------------------------------------------- #
+def register() -> None:
+    try:
+        gui_hooks.card_will_show.append(_wrap_fields)
+    except Exception:
+        pass
+    try:
+        gui_hooks.state_shortcuts_will_change.append(
+            _on_state_shortcuts_will_change
+        )
+    except Exception:
+        pass
+    try:
+        gui_hooks.main_window_did_init.append(_patch_on_edit_current)
+    except Exception:
+        # Fallback: try to patch immediately (mw might already be ready).
+        _patch_on_edit_current()

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -481,3 +481,187 @@ hr#answer {
   z-index: 200 !important;
   display: none !important;  /* superseded by .ba-rv-back in the header */
 }
+
+/* ---------------------------------------------------------------------- *
+ * Inline edit mode
+ *
+ * The field spans (server-side wrap of {{Field}} renderings) carry
+ * `[data-ba-field="Name"]` and the .ba-rv-field class. In idle reviewer
+ * state we leave them invisible — the underlying note-type CSS keeps the
+ * card looking exactly as it did before our wrap. Edit mode flips
+ * `body.ba-editing`, which:
+ *   • outlines each editable span with a soft hairline + paper-tinted fill
+ *   • turns the caret on, draws a focus halo
+ *   • hides the ease selector (no rating mid-edit)
+ *   • shows the floating toolbar at the bottom
+ * ---------------------------------------------------------------------- */
+
+/* Invisible by default — the wrap is just a marker. The reviewer renders
+   exactly as-is until edit mode flips on. We use a <div> wrap (not span)
+   so Anki's webview.js Backspace filter accepts the contenteditable as a
+   real editable target; `display: inline` keeps the layout unchanged. */
+.ba-rv-field {
+  display: inline;
+  transition: text-decoration-color 160ms ease;
+}
+
+/* While editing, ease selector + click-to-reveal go away. */
+body.ba-editing .ba-rv-ease { display: none !important; }
+body.ba-editing #qa { cursor: text; }
+
+/* Editing affordance: the text stays exactly where it sat in idle render
+   (no boxes, no fills, no padding shift). A single dashed underline is the
+   only persistent cue that something is editable; it turns solid + accent-
+   coloured when the field has the caret, so the user can always tell which
+   one they're typing into. */
+body.ba-editing .ba-rv-field {
+  cursor: text;
+  caret-color: var(--rf-accent);
+  text-decoration: underline dashed var(--rf-ink-faint);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 6px;
+  outline: none;
+}
+body.ba-editing .ba-rv-field:hover {
+  text-decoration-color: var(--rf-ink-dim);
+}
+body.ba-editing .ba-rv-field:focus {
+  outline: none;
+  text-decoration: underline solid var(--rf-accent);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 6px;
+}
+
+/* Floating toolbar — pinned to the bottom of the viewport, centered. It
+   rises into view when ba-edit-bar--open is added (in tandem with
+   body.ba-editing) and stays out of the way of the rest of the chrome. */
+#ba-edit-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translate(-50%, 8px);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 7px 10px 7px 12px;
+  background: var(--rf-paper);
+  border: 1px solid var(--rf-line-2);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.22),
+              0 1px 2px rgba(0, 0, 0, 0.06);
+  font-family: var(--rf-sans);
+  font-size: 13px;
+  color: var(--rf-ink);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 10000;
+  transition: opacity 180ms ease, transform 220ms cubic-bezier(.2,.7,.2,1);
+}
+#ba-edit-bar.ba-edit-bar--open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+:root[data-rf-theme="dark"] #ba-edit-bar,
+:root.night-mode #ba-edit-bar {
+  background: color-mix(in oklab, var(--rf-paper) 88%, var(--rf-ink) 12%);
+  box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.55),
+              0 1px 2px rgba(0, 0, 0, 0.30);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-rf-theme="light"]) #ba-edit-bar {
+    background: color-mix(in oklab, var(--rf-paper) 88%, var(--rf-ink) 12%);
+    box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.55),
+                0 1px 2px rgba(0, 0, 0, 0.30);
+  }
+}
+
+/* Formatting cluster on the left — small monospaced-ish initials. */
+.ba-edit-fmt {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.ba-edit-fmt button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--rf-ink-dim);
+  font-family: var(--rf-sans);
+  font-size: 13px;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 140ms ease, background-color 140ms ease;
+}
+.ba-edit-fmt button b,
+.ba-edit-fmt button i,
+.ba-edit-fmt button u { font-style: normal; font-weight: 600; }
+.ba-edit-fmt button b { font-weight: 700; }
+.ba-edit-fmt button i { font-style: italic; font-weight: 500; }
+.ba-edit-fmt button u { text-decoration: underline; font-weight: 500; }
+.ba-edit-fmt button:hover {
+  color: var(--rf-ink);
+  background: var(--rf-row-hover);
+}
+.ba-edit-fmt button:active {
+  background: color-mix(in oklab, var(--rf-ink) 8%, transparent);
+}
+/* Actions cluster on the right. */
+.ba-edit-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 6px;
+  border-left: 1px solid var(--rf-line);
+}
+.ba-edit-actions button {
+  appearance: none;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--rf-ink-dim);
+  font-family: var(--rf-sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding: 6px 12px;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: color 140ms ease, background-color 140ms ease,
+              border-color 140ms ease;
+}
+.ba-edit-actions button:hover {
+  color: var(--rf-ink);
+  background: var(--rf-row-hover);
+}
+.ba-edit-actions .ba-edit-link {
+  color: var(--rf-ink-faint);
+  text-decoration: none;
+  padding: 6px 6px;
+}
+.ba-edit-actions .ba-edit-link:hover {
+  color: var(--rf-ink-dim);
+  background: transparent;
+}
+.ba-edit-actions .ba-edit-primary {
+  color: var(--rf-paper);
+  background: var(--rf-ink);
+  border-color: var(--rf-ink);
+  font-weight: 600;
+}
+.ba-edit-actions .ba-edit-primary:hover {
+  background: var(--rf-ink-dim);
+  border-color: var(--rf-ink-dim);
+  color: var(--rf-paper);
+}
+
+/* When edit mode is active, dim everything outside the card area so the
+   eye lands on the editable fields. We dim the header lightly — it's
+   still useful context (deck name, position) but shouldn't compete. */
+body.ba-editing .ba-rv-head { opacity: 0.55; }
+body.ba-editing .ba-rv-head .ba-rv-icon-btn { pointer-events: none; }

--- a/web/reviewer.js
+++ b/web/reviewer.js
@@ -1,4 +1,7 @@
-// Anki Design — reviewer progress bar + body cleanup + answer-reveal wrap.
+// Anki Design — reviewer progress bar + body cleanup + answer-reveal wrap
+// + inline edit mode. Inline edit replaces Anki's EditCurrent dialog: the
+// field spans (wrapped server-side with data-ba-field) become
+// contenteditable in place, with a small floating toolbar at the bottom.
 (function () {
   function cleanupBody() {
     if (!document.body) return;
@@ -97,6 +100,8 @@
     var qa = document.getElementById("qa");
     if (!qa) return;
     qa.addEventListener("click", function (e) {
+      // Don't advance the card while the user is editing it.
+      if (document.body.classList.contains("ba-editing")) return;
       if (qa.querySelector(".ba-rv-answer")) return;  // already answered
       var t = e.target;
       while (t && t !== qa) {
@@ -119,6 +124,226 @@
     if (fill) fill.style.width = pct + "%";
     if (label) label.textContent = done + " / " + (done + rem);
   };
+
+  // ---------- Inline edit mode ----------------------------------------- //
+  // State held between enter / exit so Cancel can restore the original
+  // HTML even after the user has typed.
+  var editState = { active: false, originals: {}, triedReveal: false };
+
+  function fieldSpans() {
+    return Array.prototype.slice.call(
+      document.querySelectorAll("[data-ba-field]")
+    );
+  }
+
+  function ensureEditToolbar() {
+    var bar = document.getElementById("ba-edit-bar");
+    if (bar) return bar;
+    bar = document.createElement("div");
+    bar.id = "ba-edit-bar";
+    bar.setAttribute("role", "toolbar");
+    bar.setAttribute("aria-label", "Edit card");
+    // The toolbar lives outside the card so its buttons are reachable
+    // even when the card content scrolls. Format buttons on the left,
+    // primary actions on the right.
+    bar.innerHTML =
+        '<div class="ba-edit-fmt" role="group" aria-label="Formatting">'
+      +   '<button type="button" data-cmd="bold"      title="Bold (⌘B)"      aria-label="Bold"><b>B</b></button>'
+      +   '<button type="button" data-cmd="italic"    title="Italic (⌘I)"    aria-label="Italic"><i>I</i></button>'
+      +   '<button type="button" data-cmd="underline" title="Underline (⌘U)" aria-label="Underline"><u>U</u></button>'
+      + '</div>'
+      + '<div class="ba-edit-actions">'
+      +   '<button type="button" class="ba-edit-link" data-action="full" '
+      +           'title="Open Anki\'s full editor">Open full editor</button>'
+      +   '<button type="button" class="ba-edit-secondary" data-action="cancel" '
+      +           'title="Cancel (Esc)">Cancel</button>'
+      +   '<button type="button" class="ba-edit-primary" data-action="save" '
+      +           'title="Save (⌘↩)">Save</button>'
+      + '</div>';
+    document.body.appendChild(bar);
+
+    bar.addEventListener("mousedown", function (e) {
+      // Don't let the toolbar steal focus from the field — that wipes the
+      // selection before execCommand can act on it.
+      e.preventDefault();
+    });
+    bar.addEventListener("click", function (e) {
+      var t = e.target;
+      while (t && t !== bar) {
+        var cmd = t.getAttribute && t.getAttribute("data-cmd");
+        if (cmd) {
+          try { document.execCommand(cmd, false, null); } catch (_) {}
+          return;
+        }
+        var act = t.getAttribute && t.getAttribute("data-action");
+        if (act === "save") { exitEdit(true); return; }
+        if (act === "cancel") { exitEdit(false); return; }
+        if (act === "full") { openFullEditor(); return; }
+        t = t.parentNode;
+      }
+    });
+    return bar;
+  }
+
+  function focusFirstField(spans) {
+    if (!spans || !spans.length) return;
+    var first = spans[0];
+    try {
+      first.focus();
+      var range = document.createRange();
+      range.selectNodeContents(first);
+      range.collapse(false);
+      var sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch (_) {}
+  }
+
+  function collectPayload() {
+    var data = {};
+    fieldSpans().forEach(function (sp) {
+      var name = sp.getAttribute("data-ba-field");
+      if (name == null) return;
+      data[name] = sp.innerHTML;
+    });
+    return JSON.stringify(data);
+  }
+
+  function onEditKeydown(e) {
+    if (!editState.active) return;
+    var meta = e.metaKey || e.ctrlKey;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      exitEdit(false);
+      return;
+    }
+    if (meta && (e.key === "Enter" || e.key === "Return"
+                 || e.key === "s" || e.key === "S")) {
+      e.preventDefault();
+      exitEdit(true);
+      return;
+    }
+    // Block answer-card shortcuts so a stray Space/1-4 doesn't grade the
+    // card while the user is typing.
+    if (e.key === " " || e.key === "1" || e.key === "2"
+        || e.key === "3" || e.key === "4") {
+      // Don't preventDefault — typing a space should still type a space.
+      // We only need to stop the event from bubbling to Anki's shortcuts.
+      e.stopPropagation();
+    }
+  }
+
+  function hasAnswerRevealed() {
+    var qa = document.getElementById("qa");
+    if (!qa) return false;
+    return !!(qa.querySelector(".ba-rv-answer")
+              || qa.querySelector("hr#answer"));
+  }
+
+  window.__baEnterEdit = function () {
+    if (editState.active) return;
+    // Always edit with the back showing — front-only edits are confusing
+    // when the user can't see what the back currently says. Anki's
+    // question render doesn't contain the answer divider at all, so we
+    // can't statically detect whether this card has a back; just try to
+    // reveal, and short-circuit on the second pass if it didn't appear.
+    if (!hasAnswerRevealed() && !editState.triedReveal) {
+      editState.triedReveal = true;
+      try { pycmd("ans"); } catch (_) {}
+      var deadline = Date.now() + 2000;
+      var poll = function () {
+        if (hasAnswerRevealed() || Date.now() >= deadline) {
+          window.__baEnterEdit();
+        } else {
+          setTimeout(poll, 40);
+        }
+      };
+      setTimeout(poll, 40);
+      return;
+    }
+    editState.triedReveal = false;
+    var spans = fieldSpans();
+    if (!spans.length) {
+      // No editable fields detected — fall back to Anki's full editor.
+      try { pycmd("ba:edit-full"); } catch (_) {}
+      return;
+    }
+    editState.originals = {};
+    spans.forEach(function (sp) {
+      var name = sp.getAttribute("data-ba-field");
+      editState.originals[name] = sp.innerHTML;
+      sp.setAttribute("contenteditable", "true");
+      sp.setAttribute("spellcheck", "true");
+    });
+    editState.active = true;
+    document.body.classList.add("ba-editing");
+    ensureEditToolbar().classList.add("ba-edit-bar--open");
+    document.addEventListener("keydown", onEditKeydown, true);
+    // Tell Python to disable the reviewer's Qt shortcuts so typing letters
+    // and modifier+keys (⌘+Backspace, etc.) work as normal text editing
+    // instead of triggering Anki's review-mode bindings.
+    try { pycmd("ba:edit-state:on"); } catch (_) {}
+    focusFirstField(spans);
+  };
+
+  window.__baExitEdit = function (save) {
+    exitEdit(!!save);
+  };
+
+  function exitEdit(save) {
+    if (!editState.active) return;
+    var spans = fieldSpans();
+    if (save) {
+      var payload = collectPayload();
+      try { pycmd("ba:edit-save:" + payload); } catch (_) {}
+      // Python will re-render; we don't need to flip state ourselves —
+      // the new render replaces the body and our editState is reset by
+      // the watchBody MutationObserver picking up that ba-editing class
+      // is no longer on the new body. Belt-and-braces: clear locally too.
+    } else {
+      // Discard: restore each field's original innerHTML.
+      spans.forEach(function (sp) {
+        var name = sp.getAttribute("data-ba-field");
+        var orig = editState.originals[name];
+        if (orig != null) sp.innerHTML = orig;
+      });
+    }
+    spans.forEach(function (sp) {
+      sp.removeAttribute("contenteditable");
+      sp.removeAttribute("spellcheck");
+    });
+    editState.active = false;
+    editState.originals = {};
+    document.body.classList.remove("ba-editing");
+    var bar = document.getElementById("ba-edit-bar");
+    if (bar) bar.classList.remove("ba-edit-bar--open");
+    document.removeEventListener("keydown", onEditKeydown, true);
+    try { pycmd("ba:edit-state:off"); } catch (_) {}
+  }
+
+  function openFullEditor() {
+    if (!editState.active) {
+      try { pycmd("ba:edit-full:{}"); } catch (_) {}
+      return;
+    }
+    // Send pending field text so the full editor opens with our edits
+    // (Python applies the payload before opening EditCurrent).
+    var payload = collectPayload();
+    try { pycmd("ba:edit-full:" + payload); } catch (_) {}
+    // Local cleanup — the full editor takes over from here.
+    var spans = fieldSpans();
+    spans.forEach(function (sp) {
+      sp.removeAttribute("contenteditable");
+      sp.removeAttribute("spellcheck");
+    });
+    editState.active = false;
+    editState.originals = {};
+    document.body.classList.remove("ba-editing");
+    var bar = document.getElementById("ba-edit-bar");
+    if (bar) bar.classList.remove("ba-edit-bar--open");
+    document.removeEventListener("keydown", onEditKeydown, true);
+    try { pycmd("ba:edit-state:off"); } catch (_) {}
+  }
 
   function boot() {
     ensureBar();


### PR DESCRIPTION
## Summary
- Pencil / `e` now makes the card's field values contenteditable in place, with a floating toolbar (B/I/U + Open full editor / Cancel / Save) and the back side auto-revealed first so you're never editing only the front.
- Fields are wrapped in `<div data-ba-field>` via a `card_will_show` filter so Anki's `webview.js` Backspace gate accepts them as editable; Cancel restores originals, Save persists via `mw.col.update_note` + busts the Card render cache, Open full editor falls back to Anki's native `EditCurrent`.
- While editing, the reviewer's Qt state shortcuts are temporarily disabled so typed letters and `⌘+Backspace` behave as text input instead of triggering Anki's review-mode bindings (delete-note, etc.).

## Test plan
- [ ] Press `e` on a Basic card mid-review — back reveals, both fields outlined, caret in Front.
- [ ] Type, Backspace, Option+Backspace, ⌘+Backspace all behave as text editing (no delete-note prompt).
- [ ] Save → card re-renders with new field values; Cancel → fields restored.
- [ ] Open full editor → Anki's `EditCurrent` opens with pending edits applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)