### PR TITLE
build: exclude out/ dev screenshots from shipped addon

### DIFF
--- a/build.py
+++ b/build.py
@@ -17,7 +17,7 @@ OUT_DIR = os.path.join(ROOT, "dist")
 OUT = os.path.join(OUT_DIR, "anki-design.ankiaddon")
 
 # Anything matching these (path-relative-to-root) is never shipped.
-EXCLUDE_DIRS = {".git", "dist", "__pycache__", "scripts", ".context"}
+EXCLUDE_DIRS = {".git", "dist", "__pycache__", "scripts", ".context", "out"}
 EXCLUDE_FILES = {
     "meta.json",
     ".DS_Store",


### PR DESCRIPTION
## Summary
- Add `out` to `EXCLUDE_DIRS` in `build.py` so the directory of dev-time browse/deck screenshots isn't packaged into the published `.ankiaddon`.

The `out/` directory accumulated ~24 PNGs used during PR review (browse layout iterations, deck home reference shots, etc.). They were getting zipped into the addon, ballooning it from ~155K to ~5.3M with no user-facing benefit — Anki never loads them, they just sit on disk.

After this change a local rebuild produces a 175K `.ankiaddon`.

## Test plan
- [x] `make build` produces `dist/anki-design.ankiaddon` with no `out/` entries
- [x] Addon size returns to ~175K (vs. 5.3M before)