### PR TITLE
Reviewer: stop clipping descenders in deck/type chips

### DIFF
--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -118,6 +118,11 @@ body.card { max-width: none !important; }
   color: var(--rf-ink-dim);
   font-weight: 600;
   font-size: calc(13px * var(--rf-chrome-scale, 1));
+  /* line-height inherits 1 from .ba-rv-head — too tight to clear descenders
+     when overflow: hidden clips at the content box. 1.4 leaves room for
+     g/p/y to render fully without changing the header's visual height
+     (the 28px icon buttons still dominate the row). */
+  line-height: 1.4;
   max-width: 38ch;
   overflow: hidden;
   white-space: nowrap;
@@ -125,7 +130,7 @@ body.card { max-width: none !important; }
 }
 .ba-rv-type {
   display: inline-block;
-  font: 500 11px/1 var(--rf-sans);
+  font: 500 11px/1.4 var(--rf-sans);
   font-size: calc(11px * var(--rf-chrome-scale, 1));
   letter-spacing: 0;
   color: var(--rf-ink-faint);


### PR DESCRIPTION
## Summary
- The reviewer's deck-name chip (`.ba-rv-deck`) and card-type chip (`.ba-rv-type`) inherited `line-height: 1` from the header and paired it with `overflow: hidden` (needed for `text-overflow: ellipsis`), which clipped descenders on g/p/y.
- Set `line-height: 1.4` on both so the content box fits descenders. Row height is still dominated by the 28px icon buttons, so the header doesn't visually grow.

## Test plan
- [x] Open the reviewer on a deck whose name has descenders (e.g. \"Languages::Spanish — Top words\") and confirm the chip renders the full letters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)