### PR TITLE
Reviewer: show ease intervals on Cloze/IO and other non-FrontSide cards

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1804,8 +1804,18 @@ def _push_progress() -> None:
         default_ease = int(mw.reviewer._defaultEase())
     except Exception:
         pass
+    # Reviewer state is authoritative — `mw.reviewer.state` is "question" or
+    # "answer". Pass it explicitly so JS can drive ease-selector visibility
+    # without relying on `<hr id=answer>` (which Image Occlusion and any
+    # back template that doesn't start with `{{FrontSide}}` don't emit).
+    is_answer = False
+    try:
+        is_answer = getattr(mw.reviewer, "state", "question") == "answer"
+    except Exception:
+        pass
     import json as _json
     intervals_js = _json.dumps(intervals)
+    is_answer_js = "true" if is_answer else "false"
     try:
         mw.reviewer.web.eval(
             f"window.__reforgeProgress && window.__reforgeProgress({pct},{done},{rem});"
@@ -1813,7 +1823,7 @@ def _push_progress() -> None:
             f"var cn=$('ba-rv-c-new'),cl=$('ba-rv-c-learn'),cd=$('ba-rv-c-due');"
             f"if(cn)cn.textContent={new_n};if(cl)cl.textContent={learn_n};"
             f"if(cd)cd.textContent={rev_n};"
-            f"window.__baSetEase && window.__baSetEase({intervals_js}, {default_ease});"
+            f"window.__baSetEase && window.__baSetEase({intervals_js}, {default_ease}, {is_answer_js});"
         )
     except Exception:
         pass
@@ -2915,8 +2925,11 @@ def _dev_run_cmd(raw: str) -> None:
                 _dev_cmd_log(f"reload_page err: {e!r}")
         elif cmd == "decks_list":
             try:
-                names = [d.name for d in mw.col.decks.all_names_and_ids()]
-                _dev_cmd_log(f"decks: {names}")
+                items = [(d.id, d.name) for d in mw.col.decks.all_names_and_ids()]
+                _dev_cmd_log(f"decks: {items}")
+                _dev_cmd_log(f"col path: {mw.col.path!r}")
+                _dev_cmd_log(f"notes: {mw.col.db.scalar('SELECT COUNT(*) FROM notes')}")
+                _dev_cmd_log(f"cards: {mw.col.db.scalar('SELECT COUNT(*) FROM cards')}")
             except Exception as e:
                 _dev_cmd_log(f"decks err: {e!r}")
         elif cmd.startswith("create_test:"):
@@ -2945,6 +2958,144 @@ def _dev_run_cmd(raw: str) -> None:
                     )
             except Exception as e:
                 _dev_cmd_log(f"state_info err: {e!r}")
+        elif cmd.startswith("unbury_deck:"):
+            did = int(cmd.split(":", 1)[1])
+            try:
+                mw.col.sched.unbury_deck(did)
+                _dev_cmd_log(f"unburied deck {did}")
+            except Exception as e:
+                _dev_cmd_log(f"unbury err: {e!r}")
+        elif cmd == "dump_fit":
+            out = os.path.join(ADDON_SRC, ".context", "fit.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "var qa=document.getElementById('qa');"
+                    "var card=qa?qa.querySelector('.card'):null;"
+                    "var bodyCls=document.body?document.body.className:'';"
+                    "var qaCS=qa?getComputedStyle(qa):null;"
+                    "var cardCS=card?getComputedStyle(card):null;"
+                    "return JSON.stringify({"
+                    "bodyClasses:bodyCls,"
+                    "isLong:document.body.classList.contains('ba-rv-long'),"
+                    "qaScrollHeight:qa?qa.scrollHeight:null,"
+                    "qaClientHeight:qa?qa.clientHeight:null,"
+                    "qaPaddingTop:qaCS?qaCS.paddingTop:null,"
+                    "qaPaddingBottom:qaCS?qaCS.paddingBottom:null,"
+                    "cardFontSize:cardCS?cardCS.fontSize:null,"
+                    "cardInlineFontSize:card?card.style.fontSize:null"
+                    "});})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd == "dump_html":
+            out = os.path.join(ADDON_SRC, ".context", "html.txt")
+            rv = getattr(mw, "reviewer", None)
+            w = mw.web if mw else None
+            if w is not None:
+                js = (
+                    "JSON.stringify({"
+                    "title:document.title,"
+                    "url:location.href,"
+                    "bodyHead:document.body?document.body.innerHTML.substring(0,500):'no body'"
+                    "})"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                w.evalWithCallback(js, _cb)
+        elif cmd == "dump_body_css":
+            out = os.path.join(ADDON_SRC, ".context", "body_css.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "var b=document.body;"
+                    "var cs=getComputedStyle(b);"
+                    "var links=Array.from(document.querySelectorAll('link[rel=stylesheet]'))"
+                    ".map(function(l){return l.href;});"
+                    "return JSON.stringify({"
+                    "height:cs.height,maxHeight:cs.maxHeight,"
+                    "minHeight:cs.minHeight,overflow:cs.overflow,"
+                    "display:cs.display,gridTemplateRows:cs.gridTemplateRows,"
+                    "links:links"
+                    "});})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd == "dump_layout":
+            out = os.path.join(ADDON_SRC, ".context", "layout.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "function rect(el){if(!el)return null;"
+                    "var r=el.getBoundingClientRect();"
+                    "var cs=getComputedStyle(el);"
+                    "return {x:r.x,y:r.y,w:r.width,h:r.height,"
+                    "display:cs.display,visibility:cs.visibility,"
+                    "overflow:cs.overflow,gridRow:cs.gridRow};}"
+                    "return JSON.stringify({"
+                    "viewport:{w:window.innerWidth,h:window.innerHeight},"
+                    "body:rect(document.body),"
+                    "qa:rect(document.getElementById('qa')),"
+                    "head:rect(document.querySelector('.ba-rv-head')),"
+                    "ease:rect(document.querySelector('.ba-rv-ease')),"
+                    "scroll:{x:window.scrollX,y:window.scrollY,"
+                    "docH:document.documentElement.scrollHeight}"
+                    "});})()"
+                )
+                def _cb(r, _p=out):
+                    try: open(_p,"w").write(str(r))
+                    except Exception: pass
+                rv.web.evalWithCallback(js, _cb)
+        elif cmd == "dump_state":
+            # Quick state probe: writes JSON to .context/state.txt with
+            # window.__baReviewerState, ease.hidden, populated intervals,
+            # whether `hr#answer` is present, and the rendered card type.
+            out = os.path.join(ADDON_SRC, ".context", "state.txt")
+            rv = getattr(mw, "reviewer", None)
+            if rv and getattr(rv, "web", None):
+                js = (
+                    "(function(){"
+                    "var ease=document.querySelector('.ba-rv-ease');"
+                    "var qa=document.getElementById('qa');"
+                    "var hr=qa?qa.querySelector('hr#answer'):null;"
+                    "var wrap=qa?qa.querySelector('.ba-rv-answer'):null;"
+                    "var bodyCls=document.body?document.body.className:'';"
+                    "var intervals=Array.from(document.querySelectorAll("
+                    "'.ba-rv-ease-int')).map(function(s){return s.textContent;});"
+                    "var hidden=ease?ease.hidden:null;"
+                    "var visibleKeys=Array.from(document.querySelectorAll("
+                    "'.ba-rv-ease-key')).filter(function(b){return !b.hidden;})"
+                    ".map(function(b){return b.getAttribute('data-ease')+':'"
+                    "+(b.querySelector('.ba-rv-ease-int')||{textContent:''})"
+                    ".textContent;});"
+                    "return JSON.stringify({"
+                    "jsState:window.__baReviewerState,"
+                    "easeHidden:hidden,"
+                    "hasHrAnswer:!!hr,"
+                    "hasWrap:!!wrap,"
+                    "bodyClasses:bodyCls,"
+                    "intervals:intervals,"
+                    "visibleKeys:visibleKeys"
+                    "});})()"
+                )
+                def _cb(r, _p=out, _rv=rv):
+                    try:
+                        rv_state = getattr(_rv, "state", "?")
+                        cid = _rv.card.id if _rv.card else "?"
+                        open(_p, "w").write(
+                            f"pyState={rv_state} card={cid}\njs={r}\n"
+                        )
+                    except Exception:
+                        pass
+                rv.web.evalWithCallback(js, _cb)
         elif cmd.startswith("dump_ease_main"):
             out = os.path.join(ADDON_SRC, ".context", "ease_main.txt")
             rv = getattr(mw, "reviewer", None)

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1711,6 +1711,93 @@ def prepare_base(base: Path, profile: str, force: bool) -> Path:
     return col_path
 
 
+def _seed_cloze_and_io(col, all_card_ids: list[int]) -> None:
+    """Seed a Cloze note (and best-effort IO note) so the demo exercises
+    template structures that don't emit `<hr id=answer>` — important for
+    verifying the reviewer chrome doesn't lose the ease selector on those
+    card types. Cards land in their own decks; new card ids feed back into
+    the simulator pool just like every other deck."""
+    # ---- Cloze: a Danish anatomy card with 6 clozes ---- #
+    cloze_nt = col.models.by_name("Cloze")
+    if cloze_nt is not None:
+        cloze_did = col.decks.id("Medicine::Anatomy — Skull (Cloze)")
+        note = col.new_note(cloze_nt)
+        note["Text"] = (
+            "<b>Hjernekassen — Overblik</b><br><br>"
+            "Hjernekassen omslutter som en beskyttende kapsel "
+            "{{c1::hjernen}} og {{c2::høre-ligevægtsorganet}}. "
+            "Den hviler på atlas (art. {{c3::atlantooccipitalis}}) og "
+            "er dannet af {{c4::6 (8)}} knogler — uparrede "
+            "({{c5::frontale, occipitale, sphenoidale, ethmoidale}}) "
+            "og parrede ({{c6::parietale, temporale}})."
+        )
+        note["Back Extra"] = (
+            "Opdeles i <i>theca cranii</i> og <i>basis cranii</i>."
+        )
+        try:
+            col.add_note(note, cloze_did)
+            all_card_ids.extend(note.card_ids())
+        except Exception as e:
+            print(f"  cloze seed failed: {e!r}")
+
+    # ---- Image Occlusion: best-effort. The Rust backend parses the SVG
+    # into cloze form; the exact SVG attribute schema isn't part of the
+    # published API and changes between versions, so this can fail to
+    # produce visible cards. We try, log, and move on — the Cloze sample
+    # above already exercises the no-hr#answer code path. ---- #
+    try:
+        col.add_image_occlusion_notetype()
+    except Exception:
+        pass
+    io_nt = col.models.by_name("Image Occlusion")
+    if io_nt is None:
+        return
+    # Tiny placeholder image so the IO note can be saved without an external
+    # asset dependency. 1x1 transparent PNG, base64-decoded inline.
+    import base64
+    import tempfile
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+        "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+    tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    tmp.write(png)
+    tmp.close()
+    occlusions_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480">'
+        '<rect x="110" y="80" width="160" height="70" fill="#ffeba2" '
+        'data-occlusion-id="1" data-shape="rect"/>'
+        '<rect x="380" y="80" width="160" height="70" fill="#ffeba2" '
+        'data-occlusion-id="2" data-shape="rect"/>'
+        '</svg>'
+    )
+    io_did = col.decks.id("Medicine::Anatomy — Skull (IO)")
+    col.decks.select(io_did)
+    try:
+        col.add_image_occlusion_note(
+            notetype_id=io_nt["id"],
+            image_path=tmp.name,
+            occlusions=occlusions_svg,
+            header="Hjernekassen — Overblik",
+            back_extra=(
+                "<p><b>Dannet af 6 (8) knogler:</b></p>"
+                "<ul><li>Uparrede: frontale, occipitale, sphenoidale, "
+                "ethmoidale</li><li>Parrede: parietale, temporale</li></ul>"
+                "<p>Opdeles i <i>theca cranii</i> og <i>basis cranii</i>.</p>"
+            ),
+            tags=["demo", "io"],
+        )
+        # The IO API places cards on the currently-selected deck. Pull their
+        # IDs from the deck so they participate in the simulator.
+        io_cards = col.db.list("SELECT id FROM cards WHERE did=?", io_did)
+        all_card_ids.extend(io_cards)
+    except Exception as e:
+        # IO format quirks across Anki versions can make this fail; the Cloze
+        # case above is sufficient to exercise the missing-hr#answer path.
+        print(f"  IO seed best-effort failed (Cloze covers the same case): "
+              f"{e!r}")
+
+
 def seed_collection(col_path: Path, years: float, rng: random.Random,
                     variant: str = "full") -> dict:
     """Open a fresh collection at col_path and populate it.
@@ -1740,6 +1827,12 @@ def seed_collection(col_path: Path, years: float, rng: random.Random,
                 note["Back"] = back
                 col.add_note(note, did)
                 all_card_ids.extend(note.card_ids())
+
+        # Cloze + Image Occlusion samples. Both card types use back templates
+        # that don't start with `{{FrontSide}}`, so Anki doesn't emit the
+        # `<hr id=answer>` divider — the reviewer chrome needs to handle that
+        # without losing the ease selector. See reviewer.js + _push_progress.
+        _seed_cloze_and_io(col, all_card_ids)
 
         # Carve off a small "still new" pool from the freshly-added cards
         # so the reviewer has untouched cards to introduce when the user

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -59,9 +59,19 @@ html, body {
    padding-bottom. */
 body {
   font-family: var(--rf-serif) !important;
+  /* Lock the body to the viewport so the ease selector at grid-row 3 stays
+     pinned to the bottom even on long cards. `min-height: 100vh` alone lets
+     the body grow past the viewport when card content overflows, and the
+     `1fr` row grows with it — pushing the ease keys below the fold. With
+     `minmax(0, 1fr)` the middle row honors `overflow-y: auto` inside #qa
+     and the user scrolls the card instead of the page. The friend's
+     "can't find the 10 min / 1 dag / 3 dage / 7 dage" feedback was driven
+     by exactly this — long IO/Cloze answers pushing the keys out of view. */
+  height: 100vh !important;
   min-height: 100vh !important;
+  max-height: 100vh !important;
   display: grid !important;
-  grid-template-rows: auto 1fr auto !important;
+  grid-template-rows: auto minmax(0, 1fr) auto !important;
   background-position: 0 0 !important;
   background-attachment: scroll !important;
   background-size: auto !important;
@@ -73,6 +83,7 @@ body {
      Font size); the value comes through as --rf-card-font-size. */
   font-size: var(--rf-card-font-size, 28px);
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 /* Anki's reviewer.css sets margin:20px and a hairline `hr` rule — we wipe
@@ -378,16 +389,18 @@ body.card { max-width: none !important; }
 .ba-rv-ease-4 { --ba-key: var(--rf-easy); }
 .ba-rv-ease-key[data-default] { font-weight: 700; opacity: 1; }
 
-/* Card content sits in the second grid row. We anchor it at a stable Y
-   (28% from the top of the available space) so revealing the answer
-   below the question never *moves* the question. */
+/* Card content sits in the second grid row. We intentionally do NOT impose
+   flex/grid layout here — Anki puts card text and inline elements directly
+   inside #qa (no wrapper), and a flex container wraps each text run and
+   each inline element in an anonymous flex item, which breaks multi-line
+   cloze paragraphs into one centered word per line. So this is a plain
+   block scroller; Anki's note-type CSS owns the visual layout of the
+   content itself (text-align, .cloze color/weight, etc). The body's
+   `text-align: center` carries over for templates that expect it. */
 #qa {
   grid-row: 2;
-  display: flex !important;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  padding: max(96px, 18vh) 32px 64px;
+  display: block;
+  padding: 48px 32px 32px;
   width: 100%;
   max-width: var(--rf-card-max-width, 680px);
   margin: 0 auto;

--- a/web/reviewer.js
+++ b/web/reviewer.js
@@ -29,16 +29,26 @@
     }
   }
 
+  // Reviewer state mirror. Set authoritatively by Python (via __baSetEase)
+  // because not every card type emits `<hr id=answer>` (Image Occlusion's
+  // built-in template doesn't, and any back template that doesn't start with
+  // {{FrontSide}} won't either). Used by:
+  //   - ease selector visibility
+  //   - clickToReveal: skip when already on answer
+  //   - hasAnswerRevealed: edit-mode gate
+  // Initial value is "question" — Python always confirms once it gets a hook.
+  window.__baReviewerState = window.__baReviewerState || "question";
+
   // Wrap everything from the answer divider onward in a single .ba-rv-answer
   // element so CSS can fade it in without moving the question above it.
+  // For card types without `hr#answer` (Image Occlusion etc.) this is a
+  // no-op; the answer simply appears without the fade — visibility of the
+  // ease selector is driven by __baSetEase, not by this wrap.
   function wrapAnswer() {
     var qa = document.getElementById("qa");
     if (!qa) return;
-    var ease = document.querySelector(".ba-rv-ease");
-    var hr = qa.querySelector("hr#answer");
-    var hasAnswer = !!hr || !!qa.querySelector(".ba-rv-answer");
-    if (ease) ease.hidden = !hasAnswer;
     if (qa.querySelector(".ba-rv-answer")) return;  // already wrapped
+    var hr = qa.querySelector("hr#answer");
     if (!hr) return;
     var wrap = document.createElement("div");
     wrap.className = "ba-rv-answer";
@@ -55,10 +65,15 @@
 
   // Receive {ease: interval_string} + defaultEase from Python and write
   // the interval strings into the ease chips, hiding chips with no
-  // matching ease (i.e., 2/3-button new cards).
-  window.__baSetEase = function (intervals, defaultEase) {
+  // matching ease (i.e., 2/3-button new cards). The `isAnswer` flag comes
+  // from mw.reviewer.state on the Python side and is the authoritative
+  // signal for whether to show the ease container — DOM heuristics
+  // (hr#answer) miss Image Occlusion and any non-FrontSide template.
+  window.__baSetEase = function (intervals, defaultEase, isAnswer) {
+    window.__baReviewerState = isAnswer ? "answer" : "question";
     var ease = document.querySelector(".ba-rv-ease");
     if (!ease) return;
+    ease.hidden = !isAnswer;
     ease.querySelectorAll(".ba-rv-ease-key").forEach(function (btn) {
       var e = btn.getAttribute("data-ease");
       var label = intervals && intervals[e];
@@ -102,7 +117,12 @@
     qa.addEventListener("click", function (e) {
       // Don't advance the card while the user is editing it.
       if (document.body.classList.contains("ba-editing")) return;
-      if (qa.querySelector(".ba-rv-answer")) return;  // already answered
+      // Already on the answer side? Skip — pycmd("ans") on an already-shown
+      // answer just re-renders the same content (wasteful). Check Python's
+      // authoritative state first; fall back to DOM for the first paint
+      // before the hook has fired.
+      if (window.__baReviewerState === "answer") return;
+      if (qa.querySelector(".ba-rv-answer")) return;
       var t = e.target;
       while (t && t !== qa) {
         var tag = (t.tagName || "").toLowerCase();
@@ -234,6 +254,10 @@
   }
 
   function hasAnswerRevealed() {
+    // Trust Python's signal first — covers Image Occlusion and any custom
+    // template that doesn't emit `hr#answer`. Fall back to DOM detection
+    // for the brief window before the first hook fires.
+    if (window.__baReviewerState === "answer") return true;
     var qa = document.getElementById("qa");
     if (!qa) return false;
     return !!(qa.querySelector(".ba-rv-answer")


### PR DESCRIPTION
## Summary
- The ease-interval chips below the answer were only un-hiding when Anki emitted `<hr id=answer>`, which it only does for back templates that use `{{FrontSide}}`. Built-in Image Occlusion, Cloze, and custom templates without FrontSide left the chips hidden, leaving users no obvious way to rate those cards.
- Reviewer state is now threaded explicitly from Python (`mw.reviewer.state`) into JS via `__baSetEase`, mirrored on `window.__baReviewerState`, and that drives `ease.hidden`. `clickToReveal` and `hasAnswerRevealed` also consult the mirror so inline-edit + click-to-reveal behave correctly on those card types.
- `body` is locked to `100vh` with `grid-template-rows: auto minmax(0, 1fr) auto`, so long answers scroll inside `#qa` and the ease chips stay pinned to the viewport bottom instead of being pushed off-screen.
- `#qa` is now a plain block scroller. The previous `display: flex; align-items: center` was wrapping every text run and inline element in an anonymous flex item, which broke multi-line cloze paragraphs into one centered word per line; Anki's note-type CSS is back in charge of content layout.
- `seed_demo` now seeds a Cloze "Hjernekassen" sample (six clozes) that exercises the no-`hr#answer` path, plus a best-effort IO sample and a few `dump_*` dev cmds for future inspection.

## Test plan
- [ ] `make demo VARIANT=single` → study **Languages::Spanish — Top words**; reveal an answer; four colored interval chips (`<10m / 7.1mo / 7.9mo / 10.5mo`) appear below the answer.
- [ ] Study **Medicine::Anatomy — Skull (Cloze)**; reveal an answer; cloze text flows inline (no "one word per line"); chips show with `<1m / <6m / <10m / 5d`.
- [ ] On any deck, study a card with very long content; `#qa` scrolls internally; chips remain pinned at the bottom of the viewport.
- [ ] On a Basic card, click anywhere on `#qa` in question state → answer reveals; click again in answer state → no-op (no spurious re-render).
- [ ] Press `e` while on a Cloze card to enter inline edit mode without the 2-second delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)