### PR TITLE
Add Cmd-K command palette

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -222,6 +222,11 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         # even in light mode. The heavy homepage layout in theme.css is
         # scoped to .ba-home / .ba-over and won't touch the reviewer.
         web_content.css.append(f"{WEB}/theme.css")
+        # Cmd-K palette is available on every themed surface (deck browser,
+        # overview, reviewer). cmdk.js owns the hotkey and the overlay DOM;
+        # the matching Python search backend lives in cmdk.py.
+        web_content.css.append(f"{WEB}/cmdk.css")
+        web_content.js.append(f"{WEB}/cmdk.js")
     if isinstance(context, DeckBrowser):
         web_content.css.append(f"{WEB}/heatmap.css")
         web_content.js.append(f"{WEB}/heatmap.js")
@@ -832,6 +837,29 @@ def _on_js_message(handled, message, context):
         return handled
     cmd = message[3:]
     try:
+        if cmd.startswith("cmdk-search:"):
+            try:
+                from . import cmdk as _cmdk
+                _cmdk.handle_search(cmd[len("cmdk-search:"):])
+            except Exception:
+                pass
+            return (True, None)
+        if cmd.startswith("cmdk-do:"):
+            try:
+                from . import cmdk as _cmdk
+                _cmdk.handle_do(cmd[len("cmdk-do:"):])
+            except Exception:
+                pass
+            return (True, None)
+        if cmd == "cmdk-open":
+            # Close any open embed so the palette renders above the deck
+            # homepage instead of behind the embed's Qt overlay.
+            try:
+                from . import cmdk as _cmdk
+                _cmdk.open_from_outside("")
+            except Exception:
+                pass
+            return (True, None)
         if cmd == "embed-ready":
             # addcard.js fires this from reveal() once the editor body is
             # ready to fade in. We drop the anti-flash curtain that
@@ -2061,6 +2089,30 @@ def _setup_sidebar_shortcuts() -> None:
         sc = QShortcut(QKeySequence(","), mw)
         sc.setAutoRepeat(False)
         sc.activated.connect(_open_settings)
+    except Exception:
+        pass
+
+    # Cmd-K / Ctrl-K — Command palette. cmdk.js already binds the hotkey
+    # inside every themed webview (deck browser, overview, reviewer), but
+    # when focus is on a Qt-native widget (Add Cards embed editor field,
+    # Browser table, a dialog) the webview never sees the keydown. Bind a
+    # Qt-level shortcut on mw so the palette is reachable from anywhere.
+    def _open_cmdk_palette() -> None:
+        try:
+            from . import cmdk as _cmdk
+            _cmdk.open_from_outside("")
+        except Exception:
+            pass
+    try:
+        from aqt.qt import QShortcut, QKeySequence, Qt
+        for seq in ("Ctrl+K", "Meta+K", "Ctrl+Shift+P", "Meta+Shift+P"):
+            try:
+                sc = QShortcut(QKeySequence(seq), mw)
+                sc.setAutoRepeat(False)
+                sc.setContext(Qt.ShortcutContext.ApplicationShortcut)
+                sc.activated.connect(_open_cmdk_palette)
+            except Exception:
+                continue
     except Exception:
         pass
 

--- a/cmdk.py
+++ b/cmdk.py
@@ -1,0 +1,873 @@
+"""Anki Design — Command-K palette search backend.
+
+Drives the floating palette injected by web/cmdk.js. The JS sends two pycmds:
+
+  ba:cmdk-search:<seq>:<urlEncodedQuery>
+      → build a result payload (decks, cards, tags, actions) and push it
+        back via web.eval("window.__baCmdkResults(<json>);").
+
+  ba:cmdk-do:<action-spec>
+      → execute the chosen item. Action specs are simple URL-encoded
+        strings of the form "<kind>:<arg>" — e.g. "action:add",
+        "deck:1745201234", "card:1745201234", "search:tag%3Aleech".
+
+Everything here runs on Qt's main thread (the webview message hook does).
+Card searches are bounded to a small N — the goal is "show me what I want
+in <100ms", not "exhaustive results". The Browser embed is the natural
+follow-up surface when the user wants the long list."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib.parse import unquote
+
+from aqt import mw
+
+
+# Max items per section in the result payload. Cards and tags are
+# expensive; decks/actions are cheap so we let them list a bit more.
+MAX_ACTIONS = 8
+MAX_DECKS = 8
+MAX_CARDS = 8
+MAX_TAGS = 6
+
+
+# --------------------------------------------------------------------------- #
+# ACTION CATALOG — the static commands surfaced in the palette.
+# Each: (key, title, sub, icon, do, contexts?, keywords?)
+#   key:       stable id used in `do` ("action:<key>")
+#   title:     primary label
+#   sub:       small line below (optional)
+#   icon:      cmdk.js icon name
+#   contexts:  optional set; if present, action is only listed when the
+#              current mw.state is in the set (or "any" sentinel).
+#   keywords:  extra strings to match against (aliases, synonyms).
+# --------------------------------------------------------------------------- #
+_ACTIONS: List[Dict[str, Any]] = [
+    {
+        "key": "decks",
+        "title": "Go to Decks",
+        "sub": "Return to the deck homepage",
+        "icon": "home",
+        "keywords": ["home", "deck list", "back"],
+    },
+    {
+        "key": "add",
+        "title": "Add Card",
+        "sub": "Create a new note",
+        "icon": "add",
+        "keywords": ["new card", "new note", "create"],
+    },
+    {
+        "key": "browse",
+        "title": "Open Browser",
+        "sub": "Browse and search all cards",
+        "icon": "browse",
+        "keywords": ["find", "cards", "search"],
+    },
+    {
+        "key": "stats",
+        "title": "Open Stats",
+        "sub": "Review history and forecasts",
+        "icon": "stats",
+        "keywords": ["statistics", "analytics", "graphs"],
+    },
+    {
+        "key": "sync",
+        "title": "Sync now",
+        "sub": "Push and pull from AnkiWeb",
+        "icon": "sync",
+        "keywords": ["upload", "download", "ankiweb"],
+    },
+    {
+        "key": "settings",
+        "title": "Anki Design Settings",
+        "sub": "Theme, accent, density, fonts",
+        "icon": "settings",
+        "keywords": ["preferences", "options", "config", "theme"],
+    },
+    {
+        "key": "prefs-native",
+        "title": "Anki Preferences",
+        "sub": "Anki's native preferences dialog",
+        "icon": "settings",
+        "keywords": ["preferences", "options"],
+    },
+    {
+        "key": "import",
+        "title": "Import File",
+        "sub": "Import .apkg / .colpkg / .txt",
+        "icon": "import",
+        "keywords": ["upload", "open", "apkg"],
+    },
+    {
+        "key": "undo",
+        "title": "Undo last action",
+        "icon": "undo",
+        "keywords": ["revert"],
+    },
+    {
+        "key": "create",
+        "title": "New deck…",
+        "sub": "Create a fresh deck",
+        "icon": "add",
+        "keywords": ["new deck", "make deck"],
+    },
+    # Reviewer-only commands.
+    {
+        "key": "show",
+        "title": "Show Answer",
+        "sub": "Flip the current card",
+        "icon": "eye",
+        "contexts": {"review"},
+        "keywords": ["flip", "reveal", "space"],
+    },
+    {
+        "key": "again",
+        "title": "Answer: Again",
+        "icon": "play",
+        "contexts": {"review"},
+        "keywords": ["1", "rate"],
+    },
+    {
+        "key": "hard",
+        "title": "Answer: Hard",
+        "icon": "play",
+        "contexts": {"review"},
+        "keywords": ["2", "rate"],
+    },
+    {
+        "key": "good",
+        "title": "Answer: Good",
+        "icon": "play",
+        "contexts": {"review"},
+        "keywords": ["3", "rate"],
+    },
+    {
+        "key": "easy",
+        "title": "Answer: Easy",
+        "icon": "play",
+        "contexts": {"review"},
+        "keywords": ["4", "rate"],
+    },
+    {
+        "key": "flag-cycle",
+        "title": "Cycle flag color",
+        "icon": "flag",
+        "contexts": {"review"},
+        "keywords": ["mark", "color"],
+    },
+    # Theme switching — drives the addon's data-rf-theme override.
+    {
+        "key": "theme:dark",
+        "title": "Theme: Dark",
+        "icon": "theme",
+        "keywords": ["night", "appearance"],
+    },
+    {
+        "key": "theme:light",
+        "title": "Theme: Light",
+        "icon": "theme",
+        "keywords": ["day", "appearance"],
+    },
+    {
+        "key": "theme:system",
+        "title": "Theme: Match system",
+        "icon": "theme",
+        "keywords": ["auto", "appearance"],
+    },
+]
+
+
+# --------------------------------------------------------------------------- #
+# FUZZY SCORING
+# --------------------------------------------------------------------------- #
+def _score(text: str, q: str) -> int:
+    """Lightweight scoring: substring + word-start bonuses. Returns a
+    larger number for better matches; 0 = no match.
+
+    Bonuses:
+      • exact equal:         1000
+      • prefix:              700
+      • word-start hit:      500 (per token, decaying)
+      • substring hit:       200 (per token, decaying)
+      • short text bonus:    +10 per missing char (prefer concise hits)
+    """
+    if not q:
+        return 1  # everything matches an empty query (caller decides count)
+    t = text.lower()
+    qs = q.lower().strip()
+    if not qs:
+        return 1
+    if t == qs:
+        return 1000
+    if t.startswith(qs):
+        return 700 + max(0, 40 - len(t))
+
+    tokens = [tok for tok in re.split(r"\s+", qs) if tok]
+    if not tokens:
+        return 0
+    score = 0
+    matched = 0
+    for i, tok in enumerate(tokens):
+        decay = max(50, 200 - 30 * i)
+        pos = t.find(tok)
+        if pos == -1:
+            return 0  # every token must appear somewhere
+        matched += 1
+        # Word-start bonus if the token starts at the beginning of a word.
+        is_word_start = (
+            pos == 0
+            or not t[pos - 1].isalnum()
+        )
+        score += decay
+        if is_word_start:
+            score += 300 - 20 * i
+        # Earlier positions score slightly higher.
+        score += max(0, 40 - pos)
+    if matched == 0:
+        return 0
+    # Bonus for tight matches against short labels.
+    score += max(0, 30 - len(t) // 4)
+    return score
+
+
+# --------------------------------------------------------------------------- #
+# RESULT BUILDERS
+# --------------------------------------------------------------------------- #
+def _action_items(q: str, state: str) -> List[Dict[str, Any]]:
+    out: List[Tuple[int, Dict[str, Any]]] = []
+    for a in _ACTIONS:
+        contexts = a.get("contexts")
+        if contexts and state not in contexts:
+            continue
+        hay = a["title"]
+        if a.get("sub"):
+            hay += " " + a["sub"]
+        for kw in a.get("keywords", []):
+            hay += " " + kw
+        s = _score(hay, q)
+        if not q:
+            # No query: keep them in declared order, score them so we don't
+            # bury the most common ones below decks/cards.
+            s = 200 - _ACTIONS.index(a)
+        if s <= 0:
+            continue
+        out.append((s, {
+            "do": "action:" + a["key"],
+            "title": a["title"],
+            "sub": a.get("sub", ""),
+            "icon": a.get("icon", "search"),
+            "chip": "Action",
+        }))
+    out.sort(key=lambda x: -x[0])
+    return [it for _, it in out[:MAX_ACTIONS]]
+
+
+def _deck_items(q: str) -> List[Dict[str, Any]]:
+    try:
+        items = mw.col.decks.all_names_and_ids()
+    except Exception:
+        return []
+    scored: List[Tuple[int, Dict[str, Any]]] = []
+    # Precompute due tree so we can show due/new counts per top-level deck.
+    counts_by_id: Dict[int, Tuple[int, int, int]] = {}
+    try:
+        tree = mw.col.sched.deck_due_tree()
+        stack = [tree]
+        while stack:
+            node = stack.pop()
+            for child in getattr(node, "children", []) or []:
+                stack.append(child)
+                did = int(getattr(child, "deck_id", 0) or 0)
+                if did:
+                    counts_by_id[did] = (
+                        int(getattr(child, "review_count", 0) or 0),
+                        int(getattr(child, "new_count", 0) or 0),
+                        int(getattr(child, "learn_count", 0) or 0),
+                    )
+    except Exception:
+        pass
+
+    for d in items:
+        name = getattr(d, "name", "") or ""
+        if not name:
+            continue
+        # Drop filtered/internal decks from the palette (Anki may surface
+        # things like "Custom Study Session" temporarily).
+        if name == "Default" and len(items) > 1:
+            # Still allow but at low priority — Default is rarely meaningful
+            # when the user has real decks.
+            base_score = 1
+        else:
+            base_score = 0
+        s = _score(name, q)
+        if not q:
+            s = 100  # listed but quietly
+        if s <= 0:
+            continue
+        did = int(getattr(d, "id", 0) or 0)
+        if not did:
+            continue
+        # Use the leaf for the title, parents as the sub so "Spanish" with a
+        # query of "vocab" can show "Vocab" with sub "Spanish ▸ Vocab".
+        parts = name.split("::")
+        leaf = parts[-1]
+        parent_path = " ▸ ".join(parts[:-1]) if len(parts) > 1 else ""
+        rev, new, lrn = counts_by_id.get(did, (0, 0, 0))
+        total = rev + new + lrn
+        meta = (str(total) + " due") if total else ""
+        scored.append((s + base_score, {
+            "do": "deck:" + str(did),
+            "title": leaf,
+            "sub": parent_path,
+            "icon": "deck",
+            "chip": "Deck",
+            "meta": meta,
+        }))
+    scored.sort(key=lambda x: (-x[0], x[1]["title"].lower()))
+    return [it for _, it in scored[:MAX_DECKS]]
+
+
+def _tag_items(q: str) -> List[Dict[str, Any]]:
+    if not q:
+        return []
+    try:
+        all_tags = mw.col.tags.all() or []
+    except Exception:
+        return []
+    scored: List[Tuple[int, Dict[str, Any]]] = []
+    for t in all_tags:
+        s = _score(t, q)
+        if s <= 0:
+            continue
+        scored.append((s, {
+            "do": "tag:" + t,
+            "title": t,
+            "sub": "",
+            "icon": "tag",
+            "chip": "Tag",
+        }))
+    scored.sort(key=lambda x: -x[0])
+    return [it for _, it in scored[:MAX_TAGS]]
+
+
+def _strip_field(s: str) -> str:
+    """Lightweight HTML stripper for note field previews."""
+    s = re.sub(r"<br\s*/?>", " ", s, flags=re.IGNORECASE)
+    s = re.sub(r"<[^>]+>", "", s)
+    s = re.sub(r"&nbsp;", " ", s)
+    s = re.sub(r"&amp;", "&", s)
+    s = re.sub(r"&lt;", "<", s)
+    s = re.sub(r"&gt;", ">", s)
+    s = re.sub(r"&quot;", '"', s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def _card_items(q: str) -> List[Dict[str, Any]]:
+    if not q or len(q.strip()) < 2:
+        return []
+    # If the query already looks like an Anki search expression (contains
+    # `:` or quotes or boolean ops), pass it through verbatim. Otherwise
+    # wrap each token so we match anywhere in any field.
+    qs = q.strip()
+    looks_like_query = (
+        ":" in qs or '"' in qs
+        or re.search(r"\b(AND|OR|NOT|is|deck|tag|prop)\b", qs)
+    )
+    if looks_like_query:
+        search = qs
+    else:
+        # Use Anki's `*tok*` field-wildcard form so we get fuzzy substring
+        # matches without forcing exact word order.
+        toks = [tok for tok in re.split(r"\s+", qs) if tok]
+        if not toks:
+            return []
+        # Escape characters with special meaning in Anki search.
+        esc_toks = []
+        for tok in toks:
+            esc = tok.replace('"', '\\"').replace("*", "\\*")
+            esc_toks.append('"*' + esc + '*"')
+        search = " ".join(esc_toks)
+
+    try:
+        cids = list(mw.col.find_cards(search))[: MAX_CARDS]
+    except Exception:
+        return []
+    if not cids:
+        return []
+
+    out: List[Dict[str, Any]] = []
+    try:
+        for cid in cids:
+            try:
+                card = mw.col.get_card(cid)
+                note = card.note()
+                fields = list(note.fields)
+                # Use the first non-empty field as the title, the second as
+                # the sub. Many note types put the question first.
+                title = ""
+                sub = ""
+                for f in fields:
+                    txt = _strip_field(f)
+                    if not txt:
+                        continue
+                    if not title:
+                        title = txt
+                    elif not sub:
+                        sub = txt
+                        break
+                if not title:
+                    title = "(empty note)"
+                # Trim aggressively — palette rows show one line.
+                if len(title) > 90:
+                    title = title[:88] + "…"
+                if len(sub) > 90:
+                    sub = sub[:88] + "…"
+                deck_name = ""
+                try:
+                    deck_name = mw.col.decks.name(card.did)
+                except Exception:
+                    pass
+                meta_bits = []
+                if deck_name:
+                    meta_bits.append(deck_name.split("::")[-1])
+                out.append({
+                    "do": "card:" + str(cid),
+                    "title": title,
+                    "sub": sub,
+                    "icon": "card",
+                    "chip": "Card",
+                    "meta": " · ".join(meta_bits),
+                })
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return out
+
+
+def _fallback_search_item(q: str) -> Optional[Dict[str, Any]]:
+    """When the user has typed a query we couldn't strongly match, offer to
+    run it through the embedded Browser instead. Always at the bottom."""
+    qs = (q or "").strip()
+    if not qs:
+        return None
+    return {
+        "do": "search:" + qs,
+        "title": 'Search browser for "' + qs + '"',
+        "sub": "Open Browser with this exact query",
+        "icon": "search",
+        "chip": "Search",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# PUBLIC: search + dispatch
+# --------------------------------------------------------------------------- #
+def search(query: str, seq: int) -> Dict[str, Any]:
+    """Build the result payload for the given query.
+    Returned shape matches what cmdk.js expects in __baCmdkResults."""
+    q = (query or "").strip()
+    state = getattr(mw, "state", "") or ""
+
+    sections: List[Dict[str, Any]] = []
+
+    actions = _action_items(q, state)
+    if actions:
+        sections.append({"title": "Actions", "items": actions})
+
+    decks = _deck_items(q)
+    if decks:
+        sections.append({"title": "Decks", "items": decks})
+
+    cards = _card_items(q)
+    if cards:
+        sections.append({"title": "Cards", "items": cards})
+
+    tags = _tag_items(q)
+    if tags:
+        sections.append({"title": "Tags", "items": tags})
+
+    # Fallback: explicit "Search browser for X" row at the bottom.
+    fb = _fallback_search_item(q)
+    if fb:
+        sections.append({"title": "Other", "items": [fb]})
+
+    return {"seq": seq, "q": q, "sections": sections}
+
+
+def _push_results(payload: Dict[str, Any]) -> None:
+    """Eval the result payload into whichever webview currently holds the
+    palette. We try the active reviewer webview first (palette can open
+    during review), then mw.web, then bottomWeb. Each webview gets its
+    own copy — cheap, and harmless when only one of them actually has
+    the palette open."""
+    try:
+        data = json.dumps(payload)
+    except Exception:
+        return
+    js = "window.__baCmdkResults && window.__baCmdkResults(" + data + ");"
+    targets = []
+    rv = getattr(mw, "reviewer", None)
+    if rv is not None:
+        w = getattr(rv, "web", None)
+        if w is not None:
+            targets.append(w)
+    w = getattr(mw, "web", None)
+    if w is not None and w not in targets:
+        targets.append(w)
+    for t in targets:
+        try:
+            t.eval(js)
+        except Exception:
+            pass
+
+
+def handle_search(raw: str) -> None:
+    """Parse "<seq>:<urlEncodedQuery>" and emit a result payload."""
+    try:
+        sep = raw.find(":")
+        if sep < 0:
+            seq = 0
+            q = raw
+        else:
+            try:
+                seq = int(raw[:sep])
+            except Exception:
+                seq = 0
+            q = raw[sep + 1:]
+        try:
+            q = unquote(q or "")
+        except Exception:
+            pass
+        payload = search(q, seq)
+    except Exception:
+        payload = {"seq": 0, "q": "", "sections": []}
+    _push_results(payload)
+
+
+# --------------------------------------------------------------------------- #
+# DISPATCH — execute the chosen item.
+# --------------------------------------------------------------------------- #
+def _close_all_embeds() -> None:
+    """Close any inline embed (Add/Browse/Stats/Settings) so the palette's
+    action lands on a clean deck-browser surface."""
+    for mod_name in ("addcard_embed", "browse_embed", "stats_embed", "settings_embed"):
+        try:
+            from importlib import import_module
+            import_module("." + mod_name, __package__).close_inline()
+        except Exception:
+            pass
+
+
+def _open_browser_with_query(query: str) -> None:
+    """Open the embedded Browser and run a search."""
+    try:
+        from . import browse_embed
+        browse_embed.open_inline(mw)
+    except Exception:
+        try:
+            mw.onBrowse()
+        except Exception:
+            return
+    # Push the query after the Browser has settled. find_widget lazily —
+    # the embed's `_state["browser"]` is set once construction completes.
+    def _apply():
+        try:
+            from . import browse_embed as _be
+            br = _be._state.get("browser") if hasattr(_be, "_state") else None
+            if br is None:
+                # As a last resort, search Anki's native browser dialog.
+                try:
+                    from aqt import dialogs
+                    nb = dialogs._dialogs.get("Browser", [None, None])[1]
+                    br = nb
+                except Exception:
+                    br = None
+            if br is None:
+                return
+            try:
+                br.form.searchEdit.lineEdit().setText(query)
+                br.onSearchActivated()
+            except Exception:
+                pass
+        except Exception:
+            pass
+    try:
+        from aqt.qt import QTimer
+        QTimer.singleShot(60, _apply)
+    except Exception:
+        _apply()
+
+
+def _apply_theme(theme: str) -> None:
+    """Persist the user's theme choice and re-render so the change takes
+    effect immediately."""
+    if theme not in ("light", "dark", "system"):
+        return
+    try:
+        # __package__ is the addon folder name (e.g. "anki-design" or the
+        # numeric AnkiWeb ID). getConfig/writeConfig key off that.
+        cfg = mw.addonManager.getConfig(__package__) or {}
+        cfg["theme"] = theme
+        mw.addonManager.writeConfig(__package__, cfg)
+    except Exception:
+        pass
+    # Re-render the current state so the new <head> goes out.
+    try:
+        st = getattr(mw, "state", "")
+        if st in ("deckBrowser", "overview", "review"):
+            mw.moveToState(st)
+    except Exception:
+        pass
+
+
+def _reviewer_eval(js: str) -> None:
+    rv = getattr(mw, "reviewer", None)
+    if rv is None:
+        return
+    w = getattr(rv, "web", None)
+    if w is not None:
+        try:
+            w.eval(js)
+        except Exception:
+            pass
+
+
+def _answer_card(ease: int) -> None:
+    rv = getattr(mw, "reviewer", None)
+    if rv is None:
+        return
+    if getattr(rv, "card", None) is None:
+        return
+    state = getattr(rv, "state", "")
+    if state == "question":
+        # Auto-flip first.
+        try:
+            rv._showAnswer()
+        except Exception:
+            pass
+    try:
+        rv._answerCard(ease)
+    except Exception:
+        pass
+
+
+def _start_studying(did: int) -> None:
+    """Mirror __init__._start_studying without the dev logging."""
+    try:
+        mw.col.decks.select(did)
+        try:
+            mw.col.startTimebox()
+        except Exception:
+            pass
+        cur_state = getattr(mw, "state", "")
+        rv = getattr(mw, "reviewer", None)
+        if cur_state == "review" and rv is not None:
+            try:
+                rv._showQuestion()
+                return
+            except Exception:
+                pass
+        mw.moveToState("review")
+    except Exception:
+        try:
+            mw.moveToState("overview")
+        except Exception:
+            pass
+
+
+def handle_do(raw: str) -> None:
+    """Execute the chosen palette item. Action spec format:
+        action:<key>      | deck:<did> | card:<cid> |
+        tag:<name>        | search:<query>
+    """
+    try:
+        spec = unquote(raw or "")
+    except Exception:
+        spec = raw or ""
+    if not spec:
+        return
+    kind, _, arg = spec.partition(":")
+    kind = kind.strip()
+    arg = arg.strip()
+
+    if kind == "action":
+        _do_action(arg)
+        return
+    if kind == "deck" and arg.isdigit():
+        _close_all_embeds()
+        _start_studying(int(arg))
+        return
+    if kind == "card" and arg.isdigit():
+        _open_browser_with_query("cid:" + arg)
+        return
+    if kind == "tag":
+        # Anki's search wants the bare tag name; quote if spaces.
+        if " " in arg:
+            _open_browser_with_query('tag:"' + arg + '"')
+        else:
+            _open_browser_with_query("tag:" + arg)
+        return
+    if kind == "search":
+        _open_browser_with_query(arg)
+        return
+
+
+def _do_action(key: str) -> None:
+    """Run a built-in action."""
+    if not key:
+        return
+    # Theme switches.
+    if key.startswith("theme:"):
+        _apply_theme(key.split(":", 1)[1])
+        return
+
+    # Reviewer-only commands.
+    if key == "show":
+        rv = getattr(mw, "reviewer", None)
+        if rv and getattr(rv, "state", "") == "question":
+            try:
+                rv._showAnswer()
+            except Exception:
+                _reviewer_eval("pycmd('ans')")
+        return
+    if key == "again":
+        _answer_card(1); return
+    if key == "hard":
+        _answer_card(2); return
+    if key == "good":
+        _answer_card(3); return
+    if key == "easy":
+        _answer_card(4); return
+    if key == "flag-cycle":
+        try:
+            rv = getattr(mw, "reviewer", None)
+            if rv is None or getattr(rv, "card", None) is None:
+                return
+            card = rv.card
+            cur = int(card.user_flag())
+            card.set_user_flag((cur + 1) % 5)
+            try:
+                mw.col.update_card(card)
+            except Exception:
+                pass
+        except Exception:
+            pass
+        return
+
+    # Top-level navigation maps to the existing ba:* handlers.
+    if key in ("decks", "add", "browse", "stats", "sync", "settings",
+              "import", "undo", "create"):
+        try:
+            w = getattr(mw, "web", None)
+            if w is not None:
+                # Re-use the existing JS message routing so all the
+                # embed-teardown / state-fixup logic stays in one place.
+                w.eval("pycmd('ba:" + key + "');")
+            else:
+                _dispatch_top_level(key)
+        except Exception:
+            _dispatch_top_level(key)
+        return
+    if key == "prefs-native":
+        try:
+            from aqt import dialogs
+            dialogs.open("Preferences", mw)
+        except Exception:
+            try:
+                # mw.onPrefs was patched by the addon to open our settings;
+                # call the underlying dialog via the Anki API instead.
+                from aqt.preferences import Preferences
+                Preferences(mw)
+            except Exception:
+                pass
+        return
+
+
+def _dispatch_top_level(key: str) -> None:
+    """Fallback for top-level actions when mw.web isn't available
+    (e.g. between renders)."""
+    try:
+        if key == "decks":
+            mw.moveToState("deckBrowser")
+        elif key == "add":
+            try:
+                from . import addcard_embed
+                addcard_embed.open_inline(mw)
+            except Exception:
+                mw.onAddCard()
+        elif key == "browse":
+            try:
+                from . import browse_embed
+                browse_embed.open_inline(mw)
+            except Exception:
+                mw.onBrowse()
+        elif key == "stats":
+            try:
+                from . import stats_embed
+                stats_embed.open_inline(mw)
+            except Exception:
+                mw.onStats()
+        elif key == "sync":
+            mw.on_sync_button_clicked()
+        elif key == "settings":
+            try:
+                from . import settings_embed
+                settings_embed.open_inline(mw)
+            except Exception:
+                pass
+        elif key == "import":
+            mw.onImport()
+        elif key == "undo":
+            mw.undo()
+        elif key == "create":
+            try:
+                from aqt.operations.deck import add_deck_dialog
+                add_deck_dialog(parent=mw)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# Open the palette from outside the webview (Qt shortcut → JS toggle).
+# --------------------------------------------------------------------------- #
+def open_from_outside(initial: str = "") -> None:
+    """Open the palette over the currently-visible deck/reviewer webview.
+
+    Close any inline embed (Add/Browse/Stats/Settings) first — those embeds
+    are Qt frames overlaid on top of mw.web, so a palette opened underneath
+    them is invisible. After teardown, the reviewer's own webview (when in
+    review state) gets the palette; otherwise it lands on mw.web.
+    """
+    state = getattr(mw, "state", "") or ""
+    if state != "review":
+        # Tear down any embed so the deck-browser surface is the topmost
+        # widget on the central area before the palette renders.
+        _close_all_embeds()
+
+    target = None
+    if state == "review":
+        rv = getattr(mw, "reviewer", None)
+        if rv is not None:
+            target = getattr(rv, "web", None)
+    if target is None:
+        target = getattr(mw, "web", None)
+    if target is None:
+        return
+    try:
+        js = (
+            "if (window.__baCmdkOpen) window.__baCmdkOpen("
+            + json.dumps(initial or "") + ");"
+        )
+        target.eval(js)
+    except Exception:
+        pass

--- a/web/cmdk.css
+++ b/web/cmdk.css
@@ -1,0 +1,307 @@
+/* Anki Design — Cmd-K palette.
+   Self-contained floating modal injected into every themed webview. Pulls
+   colors from the addon's design tokens (--rf-paper, --rf-ink, --rf-line,
+   --rf-accent) so dark/light + accent recolor automatically. */
+
+.ba-cmdk-back {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  background: rgba(8, 8, 12, 0.42);
+  backdrop-filter: blur(6px) saturate(1.05);
+  -webkit-backdrop-filter: blur(6px) saturate(1.05);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  font-family: var(--rf-sans, ui-sans-serif, -apple-system, system-ui, sans-serif);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+:root[data-rf-theme="light"] .ba-cmdk-back,
+:root:not([data-rf-theme="dark"]) .ba-cmdk-back {
+  background: rgba(36, 32, 22, 0.22);
+}
+.ba-cmdk-back[data-open="true"] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ba-cmdk {
+  /* Reset inherited text-align — reviewer's body centers text and we want
+     the palette's own left-aligned typography to win regardless of host. */
+  text-align: left;
+  width: min(640px, 92vw);
+  max-height: 64vh;
+  background: var(--rf-paper, #14161b);
+  color: var(--rf-ink, #eceae2);
+  border: 1px solid var(--rf-line-2, rgba(236, 234, 226, 0.18));
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 24px 64px -16px rgba(0, 0, 0, 0.55),
+    0 6px 18px -8px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transform: translateY(-6px) scale(0.985);
+  transition: transform 140ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.ba-cmdk-back[data-open="true"] .ba-cmdk {
+  transform: translateY(0) scale(1);
+}
+
+/* ---------------------------- INPUT ROW ---------------------------- */
+.ba-cmdk-input-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rf-line, rgba(236, 234, 226, 0.09));
+  background: var(--rf-paper, #14161b);
+}
+.ba-cmdk-glyph {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  color: var(--rf-ink-dim, #9b978a);
+  opacity: 0.85;
+}
+.ba-cmdk-glyph svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.ba-cmdk-input {
+  flex: 1 1 auto;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: var(--rf-ink, #eceae2);
+  font: 500 16px/1.4 var(--rf-sans);
+  letter-spacing: 0.01em;
+  padding: 0;
+  min-width: 0;
+}
+.ba-cmdk-input::placeholder {
+  color: var(--rf-ink-faint, #5d5a51);
+  font-weight: 500;
+}
+.ba-cmdk-hint {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: 500 10.5px/1 var(--rf-sans);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--rf-ink-faint, #5d5a51);
+}
+.ba-cmdk-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 4px;
+  border: 1px solid var(--rf-line-2, rgba(236, 234, 226, 0.18));
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--rf-ink-dim, #9b978a);
+  font: 600 10.5px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+}
+:root[data-rf-theme="light"] .ba-cmdk-kbd,
+:root:not([data-rf-theme="dark"]) .ba-cmdk-kbd {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* ---------------------------- RESULTS ---------------------------- */
+.ba-cmdk-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px 0 10px;
+  scrollbar-width: thin;
+}
+.ba-cmdk-list::-webkit-scrollbar {
+  width: 8px;
+}
+.ba-cmdk-list::-webkit-scrollbar-thumb {
+  background: var(--rf-line-2, rgba(236, 234, 226, 0.18));
+  border-radius: 4px;
+}
+
+.ba-cmdk-section {
+  padding: 10px 16px 4px;
+  font: 600 10px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-faint, #5d5a51);
+}
+.ba-cmdk-section:first-child {
+  padding-top: 8px;
+}
+
+.ba-cmdk-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 16px;
+  margin: 0 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+  color: var(--rf-ink, #eceae2);
+  border: 1px solid transparent;
+}
+.ba-cmdk-item[data-active="true"] {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--rf-line-2, rgba(236, 234, 226, 0.18));
+  box-shadow: inset 2px 0 0 var(--rf-accent, #6c8cff);
+}
+:root[data-rf-theme="light"] .ba-cmdk-item[data-active="true"],
+:root:not([data-rf-theme="dark"]) .ba-cmdk-item[data-active="true"] {
+  background: rgba(0, 0, 0, 0.04);
+}
+.ba-cmdk-item:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+:root[data-rf-theme="light"] .ba-cmdk-item:hover,
+:root:not([data-rf-theme="dark"]) .ba-cmdk-item:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.ba-cmdk-ico {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--rf-ink-dim, #9b978a);
+}
+.ba-cmdk-ico svg {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.ba-cmdk-item[data-active="true"] .ba-cmdk-ico {
+  color: var(--rf-accent, #6c8cff);
+}
+
+.ba-cmdk-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ba-cmdk-title {
+  font: 500 13.5px/1.3 var(--rf-sans);
+  color: var(--rf-ink, #eceae2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ba-cmdk-title em {
+  font-style: normal;
+  color: var(--rf-accent, #6c8cff);
+  font-weight: 700;
+}
+.ba-cmdk-sub {
+  font: 500 11.5px/1.3 var(--rf-sans);
+  color: var(--rf-ink-faint, #5d5a51);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ba-cmdk-sub em {
+  font-style: normal;
+  color: var(--rf-ink-dim, #9b978a);
+  font-weight: 600;
+}
+
+.ba-cmdk-meta {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 600 10.5px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  color: var(--rf-ink-faint, #5d5a51);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.ba-cmdk-meta .ba-cmdk-kbd {
+  background: transparent;
+}
+
+/* Type chip on the right (e.g. "deck", "card", "tag"). */
+.ba-cmdk-chip {
+  flex: 0 0 auto;
+  font: 600 10px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-faint, #5d5a51);
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--rf-line, rgba(236, 234, 226, 0.09));
+}
+
+/* Empty / loading states. */
+.ba-cmdk-empty,
+.ba-cmdk-loading {
+  padding: 24px 18px;
+  text-align: center;
+  font: 500 13px/1.5 var(--rf-sans);
+  color: var(--rf-ink-faint, #5d5a51);
+}
+.ba-cmdk-empty strong {
+  color: var(--rf-ink-dim, #9b978a);
+  font-weight: 600;
+}
+
+/* ---------------------------- FOOTER ---------------------------- */
+.ba-cmdk-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--rf-line, rgba(236, 234, 226, 0.09));
+  font: 500 10.5px/1 var(--rf-sans);
+  color: var(--rf-ink-faint, #5d5a51);
+  background: var(--rf-paper, #14161b);
+}
+.ba-cmdk-foot-l,
+.ba-cmdk-foot-r {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+.ba-cmdk-foot-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* Trim chrome on small viewports (Anki reviewer can be tight). */
+@media (max-height: 600px) {
+  .ba-cmdk-back { padding-top: 8vh; }
+  .ba-cmdk { max-height: 78vh; }
+}
+@media (max-width: 540px) {
+  .ba-cmdk-hint { display: none; }
+}

--- a/web/cmdk.js
+++ b/web/cmdk.js
@@ -1,0 +1,384 @@
+/* Anki Design — Cmd-K palette.
+   Self-contained overlay injected on every themed webview. Listens for
+   Cmd-K / Ctrl-K globally on the page; opens a centered modal with an
+   input + ranked result list. Python is asked for results via
+   pycmd("ba:cmdk-search:<q>"); it pushes back through
+   window.__baCmdkResults({...}). Selecting an item sends
+   pycmd("ba:cmdk-do:<encoded-action>"). */
+(function () {
+  "use strict";
+  if (window.__baCmdk) return;
+  window.__baCmdk = true;
+
+  // ---------------------------------------------------------------- //
+  // ICONS
+  // ---------------------------------------------------------------- //
+  var ICONS = {
+    search:
+      '<svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="6.5"/>' +
+      '<path d="M20 20l-4.3-4.3"/></svg>',
+    deck:
+      '<svg viewBox="0 0 24 24"><path d="M3 7l9-4 9 4-9 4-9-4z"/>' +
+      '<path d="M3 12l9 4 9-4"/><path d="M3 17l9 4 9-4"/></svg>',
+    card:
+      '<svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"/>' +
+      '<path d="M3 10h18"/></svg>',
+    tag:
+      '<svg viewBox="0 0 24 24"><path d="M20 13L13 20a2 2 0 0 1-2.8 0L3 12.8V4h8.8L20 12.2a1 1 0 0 1 0 .8z"/>' +
+      '<circle cx="7.5" cy="7.5" r="1.2"/></svg>',
+    add:
+      '<svg viewBox="0 0 24 24"><path d="M12 5v14"/><path d="M5 12h14"/></svg>',
+    browse:
+      '<svg viewBox="0 0 24 24"><circle cx="11" cy="11" r="6.5"/>' +
+      '<path d="M20 20l-4.3-4.3"/></svg>',
+    stats:
+      '<svg viewBox="0 0 24 24"><path d="M4 19V9"/><path d="M10 19V5"/>' +
+      '<path d="M16 19v-8"/><path d="M22 19h-22"/></svg>',
+    sync:
+      '<svg viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-3-6.7"/>' +
+      '<path d="M21 4v5h-5"/></svg>',
+    settings:
+      '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/>' +
+      '<path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5 1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h0a1.6 1.6 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h0a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v0a1.6 1.6 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>',
+    import:
+      '<svg viewBox="0 0 24 24"><path d="M12 4v12"/>' +
+      '<path d="M6 10l6-6 6 6"/><path d="M4 20h16"/></svg>',
+    undo:
+      '<svg viewBox="0 0 24 24"><path d="M3 12a8 8 0 1 0 3-6.2"/>' +
+      '<path d="M3 4v5h5"/></svg>',
+    home:
+      '<svg viewBox="0 0 24 24"><path d="M3 11l9-7 9 7"/>' +
+      '<path d="M5 10v9h14v-9"/></svg>',
+    flag:
+      '<svg viewBox="0 0 24 24"><path d="M4 4v17"/>' +
+      '<path d="M4 4h12l-2 5 2 5H4"/></svg>',
+    play:
+      '<svg viewBox="0 0 24 24"><path d="M7 4l13 8-13 8z"/></svg>',
+    eye:
+      '<svg viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8S1 12 1 12z"/>' +
+      '<circle cx="12" cy="12" r="3"/></svg>',
+    theme:
+      '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/>' +
+      '<path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>',
+  };
+  function svg(kind) { return ICONS[kind] || ICONS.search; }
+
+  // ---------------------------------------------------------------- //
+  // DOM
+  // ---------------------------------------------------------------- //
+  var root, input, list, hintEl;
+  var isOpen = false;
+  var activeIdx = 0;
+  var currentResults = [];     // flat list (sections + items interleaved)
+  var currentItems = [];       // items only, in display order
+  var seq = 0;                 // server query counter (latest-wins)
+
+  function build() {
+    if (root) return root;
+    root = document.createElement("div");
+    root.className = "ba-cmdk-back";
+    root.setAttribute("data-open", "false");
+    root.innerHTML =
+      '<div class="ba-cmdk" role="dialog" aria-label="Command palette">' +
+      '  <div class="ba-cmdk-input-row">' +
+      '    <span class="ba-cmdk-glyph">' + svg("search") + "</span>" +
+      '    <input class="ba-cmdk-input" type="text" autocomplete="off" ' +
+      '           spellcheck="false" autocapitalize="off" ' +
+      '           placeholder="Search decks, cards, tags, actions…" />' +
+      '    <span class="ba-cmdk-hint">' +
+      '      <span class="ba-cmdk-kbd">Esc</span> to close' +
+      "    </span>" +
+      "  </div>" +
+      '  <div class="ba-cmdk-list" role="listbox"></div>' +
+      '  <div class="ba-cmdk-foot">' +
+      '    <span class="ba-cmdk-foot-l">' +
+      '      <span class="ba-cmdk-foot-item">' +
+      '        <span class="ba-cmdk-kbd">↑</span>' +
+      '        <span class="ba-cmdk-kbd">↓</span> navigate' +
+      "      </span>" +
+      '      <span class="ba-cmdk-foot-item">' +
+      '        <span class="ba-cmdk-kbd">↵</span> select' +
+      "      </span>" +
+      "    </span>" +
+      '    <span class="ba-cmdk-foot-r">Anki Design</span>' +
+      "  </div>" +
+      "</div>";
+
+    document.body.appendChild(root);
+    input = root.querySelector(".ba-cmdk-input");
+    list = root.querySelector(".ba-cmdk-list");
+    hintEl = root.querySelector(".ba-cmdk-hint");
+
+    // Click outside the panel closes.
+    root.addEventListener("mousedown", function (e) {
+      if (e.target === root) close();
+    });
+    // Suppress accidental form submission inside the host page.
+    root.addEventListener("submit", function (e) { e.preventDefault(); });
+
+    input.addEventListener("input", onInput);
+    input.addEventListener("keydown", onKey);
+
+    list.addEventListener("mousemove", function (e) {
+      var row = e.target.closest(".ba-cmdk-item");
+      if (!row) return;
+      var idx = parseInt(row.getAttribute("data-idx"), 10);
+      if (!isNaN(idx) && idx !== activeIdx) {
+        activeIdx = idx;
+        repaintActive();
+      }
+    });
+    list.addEventListener("click", function (e) {
+      var row = e.target.closest(".ba-cmdk-item");
+      if (!row) return;
+      var idx = parseInt(row.getAttribute("data-idx"), 10);
+      if (!isNaN(idx)) {
+        activeIdx = idx;
+        commit();
+      }
+    });
+
+    return root;
+  }
+
+  function pycmdSend(cmd) {
+    try { if (typeof pycmd === "function") pycmd("ba:" + cmd); } catch (e) {}
+  }
+
+  // ---------------------------------------------------------------- //
+  // INPUT / KEYS
+  // ---------------------------------------------------------------- //
+  var debounceTimer = null;
+  function onInput() {
+    clearTimeout(debounceTimer);
+    var q = input.value;
+    debounceTimer = setTimeout(function () { runSearch(q); }, 60);
+  }
+  function runSearch(q) {
+    seq += 1;
+    // Encode the query through URI so colons in user text (e.g. "deck:foo")
+    // don't collide with our pycmd colon delimiter on the Python side.
+    pycmdSend("cmdk-search:" + seq + ":" + encodeURIComponent(q || ""));
+  }
+
+  function onKey(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveActive(+1);
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveActive(-1);
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+      return;
+    }
+    if ((e.key === "n" || e.key === "p") && (e.ctrlKey || e.metaKey)) {
+      // Ctrl-N / Ctrl-P (Emacs-style), parallels common palette UX.
+      e.preventDefault();
+      moveActive(e.key === "n" ? +1 : -1);
+      return;
+    }
+    if (e.key === "Tab") {
+      // Tab kills focus traps in some host pages — keep focus on the input.
+      e.preventDefault();
+    }
+  }
+
+  function moveActive(delta) {
+    if (!currentItems.length) return;
+    activeIdx = (activeIdx + delta + currentItems.length) % currentItems.length;
+    repaintActive();
+    scrollActiveIntoView();
+  }
+  function repaintActive() {
+    if (!list) return;
+    var rows = list.querySelectorAll(".ba-cmdk-item");
+    for (var i = 0; i < rows.length; i++) {
+      var idx = parseInt(rows[i].getAttribute("data-idx"), 10);
+      rows[i].setAttribute("data-active", idx === activeIdx ? "true" : "false");
+    }
+  }
+  function scrollActiveIntoView() {
+    var row = list.querySelector('.ba-cmdk-item[data-idx="' + activeIdx + '"]');
+    if (!row) return;
+    var rTop = row.offsetTop;
+    var rBot = rTop + row.offsetHeight;
+    var lTop = list.scrollTop;
+    var lBot = lTop + list.clientHeight;
+    if (rTop < lTop + 8) list.scrollTop = Math.max(0, rTop - 8);
+    else if (rBot > lBot - 8) list.scrollTop = rBot - list.clientHeight + 8;
+  }
+
+  function commit() {
+    var item = currentItems[activeIdx];
+    if (!item) return;
+    // Hide immediately so the user feels the click; the Python action will
+    // run and may navigate (closing the webview anyway).
+    var action = item.do || "";
+    close();
+    if (action) pycmdSend("cmdk-do:" + action);
+  }
+
+  // ---------------------------------------------------------------- //
+  // RENDER
+  // ---------------------------------------------------------------- //
+  function escapeHtml(s) {
+    return String(s || "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+  // Wraps occurrences of `q`'s tokens in <em> for the title field. Server
+  // returns the title plain — we highlight client-side so it always tracks
+  // the current input even when the server response races ahead.
+  function highlight(text, q) {
+    var s = escapeHtml(text);
+    if (!q) return s;
+    var tokens = String(q).trim().split(/\s+/).filter(Boolean);
+    tokens.sort(function (a, b) { return b.length - a.length; });
+    for (var i = 0; i < tokens.length; i++) {
+      var t = tokens[i].replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      if (!t) continue;
+      try {
+        s = s.replace(new RegExp("(" + t + ")", "ig"), "<em>$1</em>");
+      } catch (e) {}
+    }
+    return s;
+  }
+
+  function renderResults(payload) {
+    var sections = (payload && payload.sections) || [];
+    var q = (payload && payload.q) || "";
+    currentItems = [];
+    var html = "";
+    var idx = 0;
+
+    for (var s = 0; s < sections.length; s++) {
+      var sec = sections[s] || {};
+      var items = sec.items || [];
+      if (!items.length) continue;
+      html += '<div class="ba-cmdk-section">' + escapeHtml(sec.title || "") + "</div>";
+      for (var i = 0; i < items.length; i++) {
+        var it = items[i];
+        currentItems.push(it);
+        var meta = it.meta ? '<span class="ba-cmdk-meta">' + escapeHtml(it.meta) + "</span>" : "";
+        var chip = it.chip ? '<span class="ba-cmdk-chip">' + escapeHtml(it.chip) + "</span>" : "";
+        var sub = it.sub
+          ? '<div class="ba-cmdk-sub">' + highlight(it.sub, q) + "</div>"
+          : "";
+        html +=
+          '<div class="ba-cmdk-item" role="option" data-idx="' + idx + '" data-active="false">' +
+          '  <span class="ba-cmdk-ico">' + svg(it.icon || "search") + "</span>" +
+          '  <div class="ba-cmdk-body">' +
+          '    <div class="ba-cmdk-title">' + highlight(it.title, q) + "</div>" +
+          sub +
+          "  </div>" +
+          meta + chip +
+          "</div>";
+        idx += 1;
+      }
+    }
+
+    if (!currentItems.length) {
+      var emptyMsg = q
+        ? '<div class="ba-cmdk-empty">No matches for <strong>'
+            + escapeHtml(q) + "</strong></div>"
+        : '<div class="ba-cmdk-empty">Type to search decks, cards, tags, actions.</div>';
+      list.innerHTML = emptyMsg;
+      activeIdx = 0;
+      return;
+    }
+
+    list.innerHTML = html;
+    activeIdx = Math.min(activeIdx, currentItems.length - 1);
+    if (activeIdx < 0) activeIdx = 0;
+    repaintActive();
+    list.scrollTop = 0;
+  }
+
+  // Python pushes here. Payload: { seq, q, sections: [{title, items: [...]}] }
+  // Items: { do, title, sub?, meta?, chip?, icon? }
+  window.__baCmdkResults = function (payload) {
+    if (!root || !isOpen) return;
+    if (!payload) return;
+    // Latest-wins: drop replies older than the input we currently care about.
+    if (payload.seq && payload.seq < seq - 1) return;
+    renderResults(payload);
+  };
+
+  // ---------------------------------------------------------------- //
+  // OPEN / CLOSE
+  // ---------------------------------------------------------------- //
+  function open(initialQuery) {
+    build();
+    if (isOpen) {
+      if (initialQuery != null) input.value = initialQuery;
+      input.focus();
+      input.select();
+      runSearch(input.value);
+      return;
+    }
+    isOpen = true;
+    activeIdx = 0;
+    if (initialQuery != null) input.value = initialQuery;
+    root.setAttribute("data-open", "true");
+    list.innerHTML =
+      '<div class="ba-cmdk-empty">Loading…</div>';
+    // Async focus so the open animation kicks in before the keyboard caret.
+    requestAnimationFrame(function () {
+      input.focus();
+      input.select();
+      runSearch(input.value);
+    });
+  }
+  function close() {
+    if (!root || !isOpen) return;
+    isOpen = false;
+    root.setAttribute("data-open", "false");
+    try { input.blur(); } catch (e) {}
+  }
+  function toggle(initialQuery) {
+    if (isOpen) close();
+    else open(initialQuery);
+  }
+  window.__baCmdkOpen = open;
+  window.__baCmdkClose = close;
+  window.__baCmdkToggle = toggle;
+
+  // ---------------------------------------------------------------- //
+  // GLOBAL HOTKEY (Cmd-K / Ctrl-K; also Cmd-Shift-P like VS Code)
+  // ---------------------------------------------------------------- //
+  // Capture-phase listener so we win even when a host element wants the
+  // event. We accept the modifier on either Meta (macOS) or Ctrl. Route
+  // through Python (`ba:cmdk-open`) when opening so any Qt-side embed
+  // (Add Cards, Browser, Stats, Settings) is torn down before the
+  // palette renders — otherwise the embed overlay sits on top of mw.web
+  // and obscures the palette.
+  document.addEventListener("keydown", function (e) {
+    var mod = e.metaKey || e.ctrlKey;
+    if (!mod) return;
+    var k = (e.key || "").toLowerCase();
+    if (k === "k" || (e.shiftKey && k === "p")) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (isOpen) {
+        close();
+      } else {
+        pycmdSend("cmdk-open");
+      }
+    }
+  }, true);
+
+  // Build lazily on first toggle to keep DOM clean until needed.
+})();

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -61,6 +61,98 @@ body.ba-with-side {
   border-radius: 4px;
 }
 
+/* ---------------------------- CMD-K LAUNCHER ---------------------------- */
+/* Styled as a search input — magnifying glass on the left, placeholder
+   text, ⌘K key chips on the right. Clicking it opens the command palette
+   (web/cmdk.js). Sits between the wordmark and the totals so it reads as
+   the primary discovery surface of the sidebar. */
+.ba-side-cmdk {
+  -webkit-appearance: none;
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin: 0 0 16px;
+  /* line-height 1 was clipping descenders ("y" / "g" in the placeholder).
+     Bumping to 1.4 and trimming vertical padding keeps the overall height
+     unchanged while giving descenders the room they need. */
+  padding: 6px 10px;
+  background: var(--rf-paper-inset, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--rf-line);
+  border-radius: 8px;
+  color: var(--rf-ink-faint);
+  font: 500 12px/1.4 var(--rf-sans);
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  text-align: left;
+  box-shadow: none;
+  transition: border-color 200ms ease, color 200ms ease, background 200ms ease;
+}
+:root:not([data-rf-theme="dark"]) .ba-side-cmdk,
+:root[data-rf-theme="light"] .ba-side-cmdk {
+  background: rgba(0, 0, 0, 0.025);
+}
+.ba-side-cmdk:hover {
+  color: var(--rf-ink-dim);
+  border-color: var(--rf-line-2);
+  background: var(--rf-row-hover);
+}
+.ba-side-cmdk:focus-visible {
+  outline: 2px solid var(--rf-accent, #6c8cff);
+  outline-offset: 2px;
+}
+.ba-side-cmdk-ico {
+  flex: none;
+  color: var(--rf-ink-faint);
+  transition: color 200ms ease, transform 320ms cubic-bezier(.2,.8,.2,1);
+}
+.ba-side-cmdk:hover .ba-side-cmdk-ico {
+  color: var(--rf-ink-dim);
+  transform: rotate(-8deg);
+}
+.ba-side-cmdk-l {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ba-side-cmdk-kbd {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+.ba-side-cmdk:hover .ba-side-cmdk-kbd,
+.ba-side-cmdk:focus-visible .ba-side-cmdk-kbd {
+  opacity: 1;
+}
+.ba-side-cmdk-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+  border: 1px solid var(--rf-line-2);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--rf-ink-faint);
+  font: 600 10px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+}
+/* "Ctrl" needs a wider chip than a single glyph. */
+.ba-side-cmdk-key--w {
+  padding: 0 5px;
+  letter-spacing: 0.02em;
+}
+:root:not([data-rf-theme="dark"]) .ba-side-cmdk-key,
+:root[data-rf-theme="light"] .ba-side-cmdk-key {
+  background: rgba(0, 0, 0, 0.04);
+}
+
 /* ---------------------------- CROSS-DECK TOTALS ---------------------------- */
 /* Hidden in single-deck mode (hero owns the numbers). */
 .ba-side-totals {

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -276,6 +276,42 @@
       }
     }
 
+    // Command-K palette launcher. Rendered as a button styled like a
+    // search input so it reads as "click here to search anything", and
+    // hints the ⌘K shortcut on the right. Actual palette UI is in
+    // web/cmdk.js (injected on every themed page). Sending the pycmd
+    // routes through Python so any open embed (AddCards/Browser/Stats/
+    // Settings) is torn down before the palette opens.
+    var cmdk = document.createElement("button");
+    cmdk.type = "button";
+    cmdk.className = "ba-side-cmdk";
+    cmdk.setAttribute("aria-label", "Open command palette");
+    // Mac users see ⌘K; everyone else sees Ctrl+K (both bindings fire).
+    var modGlyph = /Mac|iPod|iPhone|iPad/i.test(navigator.platform || "")
+      ? '<span class="ba-side-cmdk-key">⌘</span>'
+      : '<span class="ba-side-cmdk-key ba-side-cmdk-key--w">Ctrl</span>';
+    cmdk.innerHTML =
+      '<svg class="ba-side-cmdk-ico" viewBox="0 0 24 24" width="14" height="14" ' +
+        'fill="none" stroke="currentColor" stroke-width="1.7" ' +
+        'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+        '<circle cx="11" cy="11" r="6.5"/><path d="M20 20l-4.3-4.3"/>' +
+      '</svg>' +
+      '<span class="ba-side-cmdk-l">Search anything…</span>' +
+      '<span class="ba-side-cmdk-kbd">' +
+        modGlyph +
+        '<span class="ba-side-cmdk-key">K</span>' +
+      '</span>';
+    cmdk.addEventListener("click", function (e) {
+      e.preventDefault();
+      if (typeof window.__baCmdkOpen === "function") {
+        // Same-webview: open immediately, no Python round-trip.
+        window.__baCmdkOpen("");
+      } else {
+        send("cmdk-open");
+      }
+    });
+    aside.appendChild(cmdk);
+
     // Primary nav
     var nav = document.createElement("nav");
     nav.className = "ba-side-nav";


### PR DESCRIPTION
## Summary
- Floating command palette injected on every themed surface (deck browser, overview, reviewer); searches actions, decks, cards, and tags from a single input.
- Triggered by ⌘K / Ctrl-K anywhere, ⌘⇧P / Ctrl-Shift-P, or the new "Search anything…" pill in the sidebar; both a webview-level hotkey and a Qt-level QShortcut so the palette is reachable even when a Qt embed has focus.
- Card search uses \`mw.col.find_cards\` with wildcard wrapping and opens the embedded Browser at \`cid:<id>\`; deck search shows due counts; reviewer-only actions (Show Answer, ease ratings, flag cycle) auto-surface when \`mw.state == "review"\`; theme switching persists to config and re-renders live.
- Pulls colors from existing \`--rf-*\` tokens so dark/light/custom-accent recolor automatically; ships a backdrop-blurred modal with section headers, type chips, match highlighting, and keyboard nav (↑↓, Enter, Esc, Ctrl-N/P).

## Test plan
- [x] Open via ⌘K, sidebar pill, and Cmd-Shift-P in deck browser, overview, and reviewer.
- [x] Verify deck/card/tag/action results, highlighting, and the "Search browser for X" fallback.
- [x] Confirm card selection opens the embedded Browser at the right card; deck selection starts studying.
- [x] Open while an embed (Add/Browse/Stats/Settings) is up — palette closes the embed then renders on top.
- [x] Reviewer-only actions appear only in review state; Show Answer / ease via palette flip and rate the card.
- [x] Theme: Light/Dark/System persists across re-renders.
- [x] Sidebar pill: descenders clear, shortcut hint appears only on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)