### PR TITLE
Reviewer: press-feedback animation on ease grading

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1831,6 +1831,25 @@ def on_reviewer_will_end() -> None:
     _session["total"] = 0
 
 
+def on_reviewer_will_answer_card(proceed_ease, reviewer, card):
+    """Kick off the press-feedback animation in the reviewer webview.
+    Fires on both keyboard (1–4) and click paths since both flow through
+    ``Reviewer._answerCard``. The eval is queued and runs before Anki's
+    next-card ``_updateQA`` (which Anki also queues, after our handler
+    returns), so the ghost + bloom appear immediately and keep playing
+    while the new card slides in beneath. Pure side effect — we return
+    ``proceed_ease`` unchanged."""
+    try:
+        proceed, ease = proceed_ease
+        if proceed and reviewer is not None and getattr(reviewer, "web", None):
+            reviewer.web.eval(
+                f"window.__baEaseFx && window.__baEaseFx({int(ease)});"
+            )
+    except Exception:
+        pass
+    return proceed_ease
+
+
 # --------------------------------------------------------------------------- #
 # Register hooks
 # --------------------------------------------------------------------------- #
@@ -1852,6 +1871,10 @@ gui_hooks.state_did_change.append(on_state_did_change)
 gui_hooks.reviewer_did_show_question.append(on_show_question)
 gui_hooks.reviewer_did_show_answer.append(on_show_answer)
 gui_hooks.reviewer_will_end.append(on_reviewer_will_end)
+try:
+    gui_hooks.reviewer_will_answer_card.append(on_reviewer_will_answer_card)
+except Exception:
+    pass
 
 # Sidebar nav: route `ba:*` pycmds to the right mw methods + settings dialog.
 gui_hooks.webview_did_receive_js_message.append(_on_js_message)

--- a/web/reviewer.css
+++ b/web/reviewer.css
@@ -378,6 +378,72 @@ body.card { max-width: none !important; }
 .ba-rv-ease-4 { --ba-key: var(--rf-easy); }
 .ba-rv-ease-key[data-default] { font-weight: 700; opacity: 1; }
 
+/* Press-feedback FX — fires when the user grades a card (keyboard 1–4 or
+   click). Two layers, both position: fixed on document.body outside #qa
+   so they survive Anki's card swap underneath:
+     • bloom — a soft radial ripple in the ease color, expanding outward
+     • ghost — the interval text from the pressed key (no background fill,
+               just colored typography), lifting upward and fading
+   Both use a single continuous transform interpolation so the motion is
+   smooth from start to finish — no compound easing at intermediate stops. */
+.ba-ease-ghost,
+.ba-ease-bloom {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9998;
+  will-change: transform, opacity;
+}
+.ba-ease-bloom {
+  width: 72px;
+  height: 72px;
+  margin-left: -36px;
+  margin-top: -36px;
+  border-radius: 50%;
+  opacity: 0;
+  background: radial-gradient(
+    circle,
+    color-mix(in oklab, var(--ba-key, var(--rf-good)) 42%, transparent) 0%,
+    color-mix(in oklab, var(--ba-key, var(--rf-good)) 14%, transparent) 45%,
+    transparent 75%
+  );
+  animation: ba-ease-bloom 560ms cubic-bezier(.2, .6, .2, 1) forwards;
+}
+.ba-ease-ghost {
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  font-family: var(--rf-sans);
+  font-weight: 600;
+  font-size: calc(14px * var(--rf-chrome-scale, 1));
+  letter-spacing: 0;
+  color: var(--ba-key, var(--rf-good));
+  opacity: 0;
+  animation: ba-ease-ghost 520ms cubic-bezier(.2, .6, .2, 1) forwards;
+}
+.ba-ease-bloom-1, .ba-ease-ghost-1 { --ba-key: var(--rf-again); }
+.ba-ease-bloom-2, .ba-ease-ghost-2 { --ba-key: var(--rf-hard); }
+.ba-ease-bloom-3, .ba-ease-ghost-3 { --ba-key: var(--rf-good); }
+.ba-ease-bloom-4, .ba-ease-ghost-4 { --ba-key: var(--rf-easy); }
+/* Bloom: smaller and softer than before. The ghost stays put — pure fade,
+   no upward drift (movement reads as "look at me" and distracts from the
+   incoming card). Single transform interpolation on the bloom, so the
+   scale eases continuously with no kinks. */
+@keyframes ba-ease-bloom {
+  0%   { transform: scale(0.6); opacity: 0;   }
+  18%  { opacity: 0.32; }
+  100% { transform: scale(2.0); opacity: 0;   }
+}
+@keyframes ba-ease-ghost {
+  0%   { opacity: 0; }
+  18%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-ease-ghost, .ba-ease-bloom { animation: none; display: none; }
+}
+
 /* Card content sits in the second grid row. We anchor it at a stable Y
    (28% from the top of the available space) so revealing the answer
    below the question never *moves* the question. */
@@ -432,15 +498,15 @@ hr#answer {
   margin: 18px auto !important;
 }
 
-/* The answer reveal — a soft fade + 4px slide. Fast (220ms), no easing
-   that lingers. The question above doesn't move because the wrap sits
-   below it in normal flow; only `.ba-rv-answer` animates. */
+/* The answer reveal — a soft pure fade, no movement. The question above
+   doesn't move because the wrap sits below it in normal flow; only
+   `.ba-rv-answer` animates. */
 .ba-rv-answer {
-  animation: ba-rv-reveal 220ms cubic-bezier(.2, .7, .2, 1) both;
+  animation: ba-rv-reveal 240ms cubic-bezier(.2, .6, .2, 1) both;
 }
 @keyframes ba-rv-reveal {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
   .ba-rv-answer { animation: none; }

--- a/web/reviewer.js
+++ b/web/reviewer.js
@@ -117,6 +117,62 @@
     }, { passive: true });
   }
 
+  // Press-feedback FX. Two overlays, both position: fixed on document.body
+  // so they survive Anki's #qa swap:
+  //   • bloom — a soft radial ripple in the ease color, sized at the key
+  //   • ghost — the interval text from the pressed key, faded in place
+  // Pointer-events: none on both — never gates anything.
+  //
+  // Triggered from two paths:
+  //   1. Click: mousedown handler on each ease key calls this synchronously,
+  //      so the FX starts before the pycmd → Python roundtrip. Without
+  //      this, the button is already hidden by the card swap by the time
+  //      the FX fires.
+  //   2. Keyboard: Python's reviewer_will_answer_card hook calls this via
+  //      web.eval. The pre-roundtrip click path may have already fired —
+  //      the lock below makes the eval call a no-op in that case.
+  window.__baEaseFx = function (ease) {
+    var n = parseInt(ease, 10);
+    if (!(n >= 1 && n <= 4)) return;
+    if (window.__baEaseFxLock) return;
+    window.__baEaseFxLock = true;
+    setTimeout(function () { window.__baEaseFxLock = false; }, 250);
+    var keys = document.querySelectorAll(".ba-rv-ease-key");
+    if (!keys.length) return;
+    var target = null;
+    for (var i = 0; i < keys.length; i++) {
+      if (parseInt(keys[i].getAttribute("data-ease"), 10) === n) {
+        target = keys[i];
+        break;
+      }
+    }
+    if (!target || target.hidden) return;
+    var rect = target.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    var cx = rect.left + rect.width / 2;
+    var cy = rect.top + rect.height / 2;
+
+    var bloom = document.createElement("div");
+    bloom.className = "ba-ease-bloom ba-ease-bloom-" + n;
+    bloom.style.left = cx + "px";
+    bloom.style.top = cy + "px";
+
+    var ghost = document.createElement("div");
+    ghost.className = "ba-ease-ghost ba-ease-ghost-" + n;
+    ghost.style.left = rect.left + "px";
+    ghost.style.top = rect.top + "px";
+    ghost.style.width = rect.width + "px";
+    ghost.style.height = rect.height + "px";
+    ghost.textContent = (target.textContent || "").trim();
+
+    document.body.appendChild(bloom);
+    document.body.appendChild(ghost);
+    setTimeout(function () {
+      bloom.remove();
+      ghost.remove();
+    }, 760);
+  };
+
   window.__reforgeProgress = function (pct, done, rem) {
     ensureBar();
     var fill = document.getElementById("reforge-progress-fill");
@@ -345,10 +401,30 @@
     try { pycmd("ba:edit-state:off"); } catch (_) {}
   }
 
+  // Run the press FX immediately on mousedown for each ease key, so a
+  // mouse click feels as snappy as a keyboard shortcut — without this, the
+  // FX only fires after the pycmd → Python → web.eval roundtrip, by which
+  // time the button has already been hidden by the card swap and the
+  // animation appears to start "after the button disappeared". The
+  // Python-side `reviewer_will_answer_card` still fires, but the FX lock
+  // makes it a no-op for the click path.
+  function hookEaseClicks() {
+    var keys = document.querySelectorAll(".ba-rv-ease-key");
+    for (var i = 0; i < keys.length; i++) {
+      keys[i].addEventListener("mousedown", function () {
+        var n = parseInt(this.getAttribute("data-ease"), 10);
+        if (n >= 1 && n <= 4) {
+          try { window.__baEaseFx(n); } catch (_) {}
+        }
+      });
+    }
+  }
+
   function boot() {
     ensureBar();
     wrapAnswer();
     clickToReveal();
+    hookEaseClicks();
     watchBody();
   }
 


### PR DESCRIPTION
## Summary
- When the user grades a card (keys 1–4 or click on an ease chip), a soft radial bloom expands from the pressed key and the key's interval text fades in place — both in the key's color (Again red, Hard amber, Good green, Easy blue).
- Click path fires the FX synchronously from a `mousedown` listener in `web/reviewer.js` so the animation starts before the pycmd roundtrip; keyboard path fires via `gui_hooks.reviewer_will_answer_card` in `__init__.py`; a 250ms JS lock dedupes when both end up triggering for the same answer.
- Also drops the 4px upward translate from the answer-reveal animation in `web/reviewer.css` — pure fade now, matching the no-movement direction. Both new animations honor `prefers-reduced-motion`.

## Test plan
- [ ] Restart Anki (Python hook registers at import).
- [ ] In the reviewer, reveal an answer and press 1/2/3/4 — bloom + interval-text ghost appear in the correct color at the pressed key, and the next card swap underneath is unaffected.
- [ ] Click each ease chip with the mouse — FX appears with no lag (no "button disappears then animation starts").
- [ ] Toggle OS reduce-motion — bloom + ghost disappear; answer reveal is still a fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)