### PR TITLE
Release 0.2.0: publish prep + congrats polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .devmode
 .context/
 .claude/
+SUBMISSION.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,44 @@
 All notable changes to Anki Design are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versioning is semver-ish.
 
-## [Unreleased]
+## [0.2.0] — 2026-05-24
+### Added
+- Cmd-K command palette: searches actions, decks, cards, and tags from
+  anywhere (deck browser, overview, reviewer). Opens via the sidebar's
+  "Search anything…" pill, ⌘K / Ctrl-K, or Cmd-Shift-P.
+- Press-feedback animation on ease grading — soft radial bloom expands
+  from the pressed key and the interval text fades in place.
+- Redesigned congrats page (deck-finished): editorial header, single-
+  sentence result, proportional accuracy bar with legend.
+- Shared deck-list component: the home tree and the congrats "keep going"
+  list render through the same module (`web/decklist.{js,css}`).
+- `min_point_version: 250900` in `manifest.json` so older Ankis don't try
+  to install a build they can't run.
 
-## [0.1.0] — unreleased
+### Fixed
+- Ease-interval chips (`10 min`, `1 day`, etc.) now appear on Image
+  Occlusion, Cloze, and any non-FrontSide card types — previously they
+  only showed up when the back template included `{{FrontSide}}`.
+- Deck-browser single-deck mode no longer renders the deck twice (the
+  shared deck-list bails when the hero card owns the page).
+- "Search anything…" pill renders with its background and border on the
+  congrats page; Anki's Svelte/Bootstrap reset was wiping them.
+- "Try custom study" link no longer duplicates on the congrats page when
+  there are no other decks with work due.
+
+## [0.1.0]
+Initial AnkiWeb release.
 ### Added
 - Base theme injected into the deck browser, overview, and reviewer.
 - Contribution-style review-activity heatmap on the deck list, with
   today / streak / total summary.
 - Reviewer progress bar with a `done / total` label.
-- Config: `accent`, `show_heatmap`, `show_progress`, `heatmap_weeks`.
+- Themed Add Card, Browse, Stats, Preferences windows.
+- Inline rename and a custom deck-options menu on multi-deck rows.
+- Inline field editing in the reviewer (in place of the EditCurrent dialog).
+- Config: `accent`, `show_heatmap`, `show_progress`, `heatmap_weeks`,
+  `theme`, `density`, `sidebar_nav`, `heatmap_palette`,
+  `reviewer_card_width`, `reviewer_font_size`, `font_serif`, `font_sans`.
 - Declares conflicts with Onigiri, Review Heatmap, and the Progress Bar
   add-on so Anki warns users instead of silently fighting them.
 

--- a/build.py
+++ b/build.py
@@ -25,6 +25,8 @@ EXCLUDE_FILES = {
     ".devmode",
     "build.py",
     "Makefile",
+    "CLAUDE.md",
+    "SUBMISSION.md",
 }
 EXCLUDE_GLOBS = ["*.pyc"]
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "Anki Design",
   "package": "anki-design",
-  "human_version": "0.1.0",
+  "human_version": "0.2.0",
+  "min_point_version": 250900,
   "conflicts": [
     "1011095603",
     "1708250053",

--- a/web/congrats.js
+++ b/web/congrats.js
@@ -182,13 +182,17 @@
     var deckName = d.deckName || 'this deck';
     var wrap = document.createElement('div');
     wrap.className = 'ba-cg';
+    // Custom-study link is offered exactly once. When otherDecks is empty,
+    // the "Everything's clear" block already includes it; the foot strip
+    // would just repeat the same call to action.
+    var hasOthers = !!(d.otherDecks && d.otherDecks.length);
     wrap.innerHTML = ''
       + headHTML(deckName, d.deckId || 0)
       + resultHTML(d)
       + accuracyHTML(d)
       + asideHTML(d)
       + decksBlockHTML(d.otherDecks)
-      + footHTML();
+      + (hasOthers ? footHTML() : '');
 
     // Render the deck list via the shared component so this view uses the
     // EXACT same code path as the home page. Click handlers (chevron, gear,

--- a/web/homedeck.js
+++ b/web/homedeck.js
@@ -51,6 +51,10 @@
   }
 
   function init() {
+    // Single-deck mode owns the page (the Python-rendered hero replaces
+    // Anki's table; CSS hides the table). Rendering the shared deck-list
+    // on top of that duplicates the deck.
+    if (document.querySelector('.ba-home.ba-single')) return;
     // Anki re-renders the deck browser by calling `mw.deckBrowser.refresh()`,
     // which causes webview_will_set_content to fire and the whole page (this
     // script included) to reload. So we only need to render once at startup.

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -78,9 +78,12 @@ body.ba-with-side {
      Bumping to 1.4 and trimming vertical padding keeps the overall height
      unchanged while giving descenders the room they need. */
   padding: 6px 10px;
-  background: var(--rf-paper-inset, rgba(255, 255, 255, 0.03));
-  border: 1px solid var(--rf-line);
-  border-radius: 8px;
+  /* !important: the congrats page is a Svelte page whose own button-reset
+     CSS lands in <head> AFTER ours and would wipe the input look. The
+     decks page has no such reset so it's untouched. */
+  background: var(--rf-paper-inset, rgba(255, 255, 255, 0.03)) !important;
+  border: 1px solid var(--rf-line) !important;
+  border-radius: 8px !important;
   color: var(--rf-ink-faint);
   font: 500 12px/1.4 var(--rf-sans);
   letter-spacing: 0.005em;
@@ -91,7 +94,8 @@ body.ba-with-side {
 }
 :root:not([data-rf-theme="dark"]) .ba-side-cmdk,
 :root[data-rf-theme="light"] .ba-side-cmdk {
-  background: rgba(0, 0, 0, 0.025);
+  background: rgba(31, 29, 24, 0.05) !important;
+  border-color: rgba(31, 29, 24, 0.12) !important;
 }
 .ba-side-cmdk:hover {
   color: var(--rf-ink-dim);


### PR DESCRIPTION
## Summary

- Bumps `human_version` to **0.2.0** and adds `min_point_version: 250900` so older Ankis don't try to install a build they can't run.
- Three small congrats-page fixes (single-deck dup, search-bar styling on Svelte page, custom-study link duplication).
- Tightens what ships in the `.ankiaddon`: `CLAUDE.md` and `SUBMISSION.md` excluded; `.gitignore` covers the latter.

## Changes

**Publishing prep**
- `manifest.json`: `human_version` 0.1.0 → 0.2.0; new `min_point_version: 250900`.
- `build.py`: exclude `CLAUDE.md` (dev notes) and `SUBMISSION.md` (AnkiWeb paste-buffer) from shipped zip.
- `.gitignore`: cover `SUBMISSION.md`.
- `CHANGELOG.md`: split into `[0.2.0]` (this release) and `[0.1.0]` (the initial AnkiWeb publication).

**Fixes**
- `web/homedeck.js`: bail when `.ba-home.ba-single` is set — the Python-rendered hero owns the page in single-deck mode, and CSS already hides Anki's `<table>`. The shared deck-list was rendering on top, duplicating the only deck.
- `web/sidebar.css`: mark the "Search anything…" pill's `background` and `border` `!important`. Anki's Svelte build pulls in Bootstrap, whose generic `button { background-color: var(--bs-tertiary-bg); border-width: 0 }` was beating our class-level styles on the congrats page (the decks page rendered the old subtle bg just visibly enough to mask the issue). New tint uses warm-gray so it shows up clearly on the cream background of both pages.
- `web/congrats.js`: only emit the "Want to study off-schedule? Custom study." foot strip when `otherDecks` is non-empty. The empty-state "Everything's clear." block already includes a custom-study link.

## Test plan
- [ ] Restart Anki against the installed copy (already installed into `addons21/1809063985/`).
- [ ] Verify Cmd-K palette opens on deck browser, overview, reviewer.
- [ ] Verify ease-interval chips appear on a Cloze/IO card.
- [ ] Verify press-feedback bloom on grading.
- [ ] Visit a single-deck setup — only the hero should render (no duplicate row).
- [ ] Finish a deck with no other due decks — only one "custom study" link should appear.
- [ ] Compare the "Search anything…" pill on deck-browser vs congrats — should look identical.

After merge: upload `dist/anki-design.ankiaddon` to AnkiWeb listing 1809063985 (existing "Anki DESIGN"), bump the version field to 0.2.0, keep branch 1 at 25.09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)