### PR TITLE
Cmd-K: render palette over Browse/Add/Stats embeds without tearing them down

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -865,11 +865,22 @@ def _on_js_message(handled, message, context):
                 pass
             return (True, None)
         if cmd == "cmdk-open":
-            # Close any open embed so the palette renders above the deck
-            # homepage instead of behind the embed's Qt overlay.
+            # open_from_outside picks the right host: reviewer.web during
+            # review, the cmdk_overlay when an embed is active (so the
+            # palette floats above it), mw.web otherwise.
             try:
                 from . import cmdk as _cmdk
                 _cmdk.open_from_outside("")
+            except Exception:
+                pass
+            return (True, None)
+        if cmd == "cmdk-closed":
+            # The palette JS fires this on every close (Esc, click outside,
+            # item commit). Hide the cmdk_overlay frame if it was the host;
+            # a no-op when the palette was hosted in mw.web/reviewer.web.
+            try:
+                from . import cmdk_overlay
+                cmdk_overlay.close()
             except Exception:
                 pass
             return (True, None)

--- a/cmdk.py
+++ b/cmdk.py
@@ -505,9 +505,9 @@ def search(query: str, seq: int) -> Dict[str, Any]:
 def _push_results(payload: Dict[str, Any]) -> None:
     """Eval the result payload into whichever webview currently holds the
     palette. We try the active reviewer webview first (palette can open
-    during review), then mw.web, then bottomWeb. Each webview gets its
-    own copy — cheap, and harmless when only one of them actually has
-    the palette open."""
+    during review), then mw.web, then the cmdk overlay webview (used when
+    an embed obscures mw.web). Each webview gets its own copy — cheap,
+    and harmless when only one of them actually has the palette open."""
     try:
         data = json.dumps(payload)
     except Exception:
@@ -522,6 +522,13 @@ def _push_results(payload: Dict[str, Any]) -> None:
     w = getattr(mw, "web", None)
     if w is not None and w not in targets:
         targets.append(w)
+    try:
+        from . import cmdk_overlay
+        ow = cmdk_overlay.webview()
+        if ow is not None and ow not in targets:
+            targets.append(ow)
+    except Exception:
+        pass
     for t in targets:
         try:
             t.eval(js)
@@ -840,27 +847,65 @@ def _dispatch_top_level(key: str) -> None:
 # --------------------------------------------------------------------------- #
 # Open the palette from outside the webview (Qt shortcut → JS toggle).
 # --------------------------------------------------------------------------- #
-def open_from_outside(initial: str = "") -> None:
-    """Open the palette over the currently-visible deck/reviewer webview.
+def _any_embed_open() -> bool:
+    """True if any inline embed (Add/Browse/Stats/Settings) is currently
+    overlaid on mw.web. The embeds expose a module-level `_state` dict; an
+    "overlay" key set to a non-None QFrame means the embed is showing."""
+    for mod_name in (
+        "addcard_embed", "browse_embed", "stats_embed", "settings_embed",
+    ):
+        try:
+            from importlib import import_module
+            mod = import_module("." + mod_name, __package__)
+            st = getattr(mod, "_state", None)
+            if isinstance(st, dict) and st.get("overlay") is not None:
+                return True
+        except Exception:
+            continue
+    return False
 
-    Close any inline embed (Add/Browse/Stats/Settings) first — those embeds
-    are Qt frames overlaid on top of mw.web, so a palette opened underneath
-    them is invisible. After teardown, the reviewer's own webview (when in
-    review state) gets the palette; otherwise it lands on mw.web.
+
+def open_from_outside(initial: str = "") -> None:
+    """Open the palette over the currently-visible surface.
+
+    Routing:
+      - In review state, the reviewer's webview gets the palette (mw.web
+        is hidden during review, and no embeds can be open).
+      - If an embed (Add/Browse/Stats/Settings) is up, render in the
+        dedicated `cmdk_overlay` so the palette floats above the embed.
+        (Embeds are Qt frames on top of mw.web; a palette in mw.web would
+        be invisible behind them.)
+      - Otherwise, the palette goes into mw.web as usual.
     """
     state = getattr(mw, "state", "") or ""
-    if state != "review":
-        # Tear down any embed so the deck-browser surface is the topmost
-        # widget on the central area before the palette renders.
-        _close_all_embeds()
 
-    target = None
     if state == "review":
         rv = getattr(mw, "reviewer", None)
-        if rv is not None:
-            target = getattr(rv, "web", None)
-    if target is None:
-        target = getattr(mw, "web", None)
+        target = getattr(rv, "web", None) if rv is not None else None
+        if target is None:
+            return
+        try:
+            js = (
+                "if (window.__baCmdkOpen) window.__baCmdkOpen("
+                + json.dumps(initial or "") + ");"
+            )
+            target.eval(js)
+        except Exception:
+            pass
+        return
+
+    if _any_embed_open():
+        # The overlay is a transparent webview parented to centralwidget;
+        # it raises itself above any embed so the palette is visible while
+        # the embed (Browse/Add/etc.) stays in place underneath.
+        try:
+            from . import cmdk_overlay
+            cmdk_overlay.open(initial)
+        except Exception:
+            pass
+        return
+
+    target = getattr(mw, "web", None)
     if target is None:
         return
     try:

--- a/cmdk_overlay.py
+++ b/cmdk_overlay.py
@@ -1,0 +1,292 @@
+"""Anki Design — keep embeds in place while the Cmd-K palette is up.
+
+The palette is rendered in mw.web's DOM, and the embeds (Add/Browse/Stats/
+Settings) are Qt frames overlaid on top of mw.web. Opening the palette while
+an embed is up would normally leave the palette invisible behind the embed —
+the original workaround (tearing the embed down) is what produced the
+"switches to the decks page" complaint.
+
+This module avoids the destroy/recreate and avoids the abrupt visual
+swap that comes with just hiding the embed:
+
+  1. Inject a stylesheet into mw.web that hides every body child except
+     the sidebar and the palette, AND hides `body::before` (which carries
+     the addon's `--rf-glow` radial gradient — a yellow blob at the top
+     in light mode).
+  2. Snapshot the embed (QWidget.grab() works on QWebEngineView via the
+     backing store) and display the snapshot as a QLabel above the
+     embed. Hide the embed underneath the snapshot.
+  3. Fade the snapshot QLabel from opacity 1 → 0 over ~240ms while the
+     palette springs in via its existing CSS animation. The user sees a
+     smooth cross-fade from embed to paper-bg + palette, instead of
+     an instant snap.
+  4. On close: snapshot the (hidden) embed again, fade the snapshot from
+     0 → 1, then swap to the real embed and strip the hide-content CSS.
+
+QGraphicsOpacityEffect applied directly to the embed's QFrame would be
+simpler, but the embed contains a QWebEngineView whose GPU-composited
+surface doesn't honour QGraphicsEffect on macOS Qt6 — the chrome would
+fade while the webview area stayed opaque, an ugly visual glitch. The
+QLabel-pixmap approach sidesteps that entirely: a QLabel is plain Qt
+and accepts opacity effects without surprises.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from aqt import mw
+from aqt.qt import (
+    QEasingCurve,
+    QGraphicsOpacityEffect,
+    QLabel,
+    QPropertyAnimation,
+    Qt,
+    QTimer,
+)
+
+
+# Embed overlays that we hid when the palette opened (in stack order;
+# in practice only one embed is ever up at a time).
+_hidden: List = []
+
+# Whether the hide-content CSS is currently injected into mw.web.
+_css_active: bool = False
+
+# Active QPropertyAnimations kept alive while running (Qt will GC them
+# otherwise and the fade stops mid-way).
+_animations: list = []
+
+# Cross-fade duration. Matches the modal entrance long enough to feel
+# continuous, short enough to stay snappy.
+_FADE_MS = 280
+
+
+def _embed_modules() -> List[str]:
+    return ["addcard_embed", "browse_embed", "stats_embed", "settings_embed"]
+
+
+def _start_fade(snap: QLabel, start: float, end: float, on_done=None) -> None:
+    """Animate a QLabel's opacity from `start` to `end` over _FADE_MS,
+    calling `on_done` when finished."""
+    effect = QGraphicsOpacityEffect(snap)
+    snap.setGraphicsEffect(effect)
+    effect.setOpacity(start)
+    anim = QPropertyAnimation(effect, b"opacity", snap)
+    anim.setDuration(_FADE_MS)
+    anim.setStartValue(start)
+    anim.setEndValue(end)
+    anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+    def _cleanup():
+        try:
+            _animations.remove(anim)
+        except ValueError:
+            pass
+        if on_done is not None:
+            try:
+                on_done()
+            except Exception:
+                pass
+
+    anim.finished.connect(_cleanup)
+    _animations.append(anim)
+    anim.start()
+
+
+def _hide_embeds_with_fade() -> None:
+    """Snapshot each visible embed, display the snapshot above it as a
+    QLabel, hide the real embed, fade the snapshot out. The real embed is
+    hidden immediately so cmdk can take focus; the snapshot is what the
+    user actually sees fading."""
+    for mod_name in _embed_modules():
+        try:
+            from importlib import import_module
+            mod = import_module("." + mod_name, __package__)
+            st = getattr(mod, "_state", None)
+            if not isinstance(st, dict):
+                continue
+            overlay = st.get("overlay")
+            if overlay is None or not overlay.isVisible():
+                continue
+            parent = overlay.parent()
+            if parent is None:
+                continue
+            try:
+                pixmap = overlay.grab()
+                snap = QLabel(parent)
+                # WA_NativeWindow forces the QLabel to have its own native
+                # window so it stacks correctly above mw.web's QWebEngineView,
+                # whose GPU-composited surface otherwise paints over sibling
+                # Qt widgets that are technically above it in z-order.
+                snap.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, True)
+                snap.setPixmap(pixmap)
+                snap.setGeometry(overlay.geometry())
+                snap.show()
+                snap.raise_()
+                overlay.hide()
+                _start_fade(snap, 1.0, 0.0, on_done=snap.deleteLater)
+                _hidden.append(overlay)
+            except Exception:
+                # Fall back to instant hide if grab/QLabel setup fails.
+                try:
+                    overlay.hide()
+                    _hidden.append(overlay)
+                except Exception:
+                    pass
+        except Exception:
+            continue
+
+
+def _show_embeds_with_fade() -> None:
+    """For each previously-hidden embed: snapshot its current state,
+    display the snapshot at opacity 0 above where the embed will appear,
+    fade snapshot to opacity 1, then swap the snapshot for the real
+    embed (visually identical at opacity 1, so the swap is invisible)."""
+    while _hidden:
+        overlay = _hidden.pop()
+        try:
+            parent = overlay.parent()
+            if parent is None:
+                # No parent to host the snapshot — just show the embed.
+                overlay.show()
+                overlay.raise_()
+                continue
+            try:
+                # grab() on a hidden widget renders to a pixmap regardless
+                # of its visibility — perfect for a fade-in snapshot.
+                pixmap = overlay.grab()
+                snap = QLabel(parent)
+                snap.setAttribute(Qt.WidgetAttribute.WA_NativeWindow, True)
+                snap.setPixmap(pixmap)
+                snap.setGeometry(overlay.geometry())
+                snap.show()
+                snap.raise_()
+
+                def _swap(ov=overlay, sn=snap):
+                    try:
+                        ov.show()
+                        ov.raise_()
+                    except Exception:
+                        pass
+                    try:
+                        sn.deleteLater()
+                    except Exception:
+                        pass
+
+                _start_fade(snap, 0.0, 1.0, on_done=_swap)
+            except Exception:
+                # Fall back to instant show if grab/QLabel setup fails.
+                try:
+                    overlay.show()
+                    overlay.raise_()
+                except Exception:
+                    pass
+        except RuntimeError:
+            # Embed was destroyed (e.g. action torn it down). Nothing to do.
+            pass
+        except Exception:
+            pass
+
+
+# CSS injected into mw.web while the palette is open. Two rules:
+#   1. Hide body's direct children except the sidebar and palette so
+#      mw.web reads as a blank paper page once the embed is hidden.
+#   2. Hide `body::before`, which paints the addon's --rf-glow radial
+#      gradient over the whole viewport (visible as a big yellow blob
+#      at the top in light mode). Pseudo-elements aren't matched by
+#      the first rule's `body > *` selector, hence the separate
+#      `display:none`.
+# visibility (not display) on body children so the layout isn't reflowed.
+_INJECT_CSS_JS = (
+    "(function(){if(document.getElementById('ba-cmdk-overlay-mode'))return true;"
+    "var s=document.createElement('style');s.id='ba-cmdk-overlay-mode';"
+    "s.textContent='body>*:not(.ba-side):not(.ba-cmdk-back)"
+    "{visibility:hidden !important;}"
+    "body::before{display:none !important;}';"
+    "document.head.appendChild(s);return true;})();"
+)
+
+_REMOVE_CSS_JS = (
+    "(function(){var s=document.getElementById('ba-cmdk-overlay-mode');"
+    "if(s)s.remove();})();"
+)
+
+
+def open(initial: str = "") -> None:
+    """Inject the hide-content CSS, snapshot+fade the embed out, then open
+    the palette. Sequenced via evalWithCallback so the stylesheet is in
+    the DOM before the embed disappears — without that ordering, mw.web
+    becomes visible for one paint frame with the deck-browser content
+    still painted, which is the flash this module is built to avoid."""
+    global _css_active
+    target = getattr(mw, "web", None)
+    if target is None:
+        return
+
+    palette_js = (
+        "if (window.__baCmdkOpen) window.__baCmdkOpen("
+        + json.dumps(initial or "") + ");"
+    )
+
+    def _continue() -> None:
+        _hide_embeds_with_fade()
+        try:
+            target.eval(palette_js)
+        except Exception:
+            pass
+
+    def _on_inject(_r) -> None:
+        global _css_active
+        _css_active = True
+        _continue()
+
+    try:
+        target.evalWithCallback(_INJECT_CSS_JS, _on_inject)
+    except Exception:
+        # No callback support — synchronous inject (may show 1-frame flash).
+        try:
+            target.eval(_INJECT_CSS_JS)
+        except Exception:
+            pass
+        _css_active = True
+        _continue()
+
+
+def close() -> None:
+    """Snapshot+fade the embed back in while the palette CSS-animates
+    closed; once the embed snapshot is fully opaque (covers mw.web), strip
+    the hide-content CSS. The defer keeps the deck-browser content from
+    becoming visible during the cross-fade."""
+    global _css_active
+    _show_embeds_with_fade()
+    if not _css_active:
+        return
+    target = getattr(mw, "web", None)
+    if target is None:
+        _css_active = False
+        return
+    # Wait for the snapshot fade-in (+ a small buffer) so the body content
+    # in mw.web's DOM is always covered when the CSS hide rule drops.
+    QTimer.singleShot(_FADE_MS + 40, lambda: _strip_css(target))
+
+
+def _strip_css(target) -> None:
+    global _css_active
+    try:
+        target.eval(_REMOVE_CSS_JS)
+    except Exception:
+        pass
+    _css_active = False
+
+
+def webview():
+    """For symmetry with the earlier AnkiWebView-backed version: no
+    dedicated webview exists in this implementation, so cmdk.py's
+    `_push_results` correctly skips it."""
+    return None
+
+
+def is_visible() -> bool:
+    return bool(_hidden) or _css_active

--- a/web/cmdk.css
+++ b/web/cmdk.css
@@ -7,25 +7,37 @@
   position: fixed;
   inset: 0;
   z-index: 9000;
-  background: rgba(8, 8, 12, 0.42);
-  backdrop-filter: blur(6px) saturate(1.05);
-  -webkit-backdrop-filter: blur(6px) saturate(1.05);
+  /* Backdrop animates from clear → dim with the blur intensifying in lock
+     step, so the page "settles" behind the palette rather than snapping
+     into a dim. Both states have their colour declared so the transition
+     interpolates cleanly between them in either light or dark mode. */
+  background: rgba(8, 8, 12, 0);
+  backdrop-filter: blur(0) saturate(1);
+  -webkit-backdrop-filter: blur(0) saturate(1);
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding-top: 14vh;
   font-family: var(--rf-sans, ui-sans-serif, -apple-system, system-ui, sans-serif);
-  opacity: 0;
   pointer-events: none;
-  transition: opacity 120ms ease;
+  transition:
+    background 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    backdrop-filter 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    -webkit-backdrop-filter 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 :root[data-rf-theme="light"] .ba-cmdk-back,
 :root:not([data-rf-theme="dark"]) .ba-cmdk-back {
-  background: rgba(36, 32, 22, 0.22);
+  background: rgba(36, 32, 22, 0);
 }
 .ba-cmdk-back[data-open="true"] {
-  opacity: 1;
   pointer-events: auto;
+  background: rgba(8, 8, 12, 0.42);
+  backdrop-filter: blur(8px) saturate(1.05);
+  -webkit-backdrop-filter: blur(8px) saturate(1.05);
+}
+:root[data-rf-theme="light"] .ba-cmdk-back[data-open="true"],
+:root:not([data-rf-theme="dark"]) .ba-cmdk-back[data-open="true"] {
+  background: rgba(36, 32, 22, 0.22);
 }
 
 .ba-cmdk {
@@ -45,11 +57,34 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transform: translateY(-6px) scale(0.985);
-  transition: transform 140ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  /* Spring-like entrance: rises from below with a slight overshoot, fades
+     in concurrently. The cubic-bezier(0.34, 1.56, 0.64, 1) is a backOut
+     curve — it overshoots ~12% then settles, giving the modal a small
+     bounce that reads as "delightful but not bouncy." Opacity uses a
+     shorter, plainer ease so the modal becomes solid before the spring
+     finishes settling. */
+  transform: translateY(18px) scale(0.94);
+  opacity: 0;
+  transition:
+    transform 340ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 200ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 .ba-cmdk-back[data-open="true"] .ba-cmdk {
   transform: translateY(0) scale(1);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ba-cmdk-back,
+  .ba-cmdk {
+    transition-duration: 80ms;
+  }
+  .ba-cmdk {
+    transform: none;
+  }
+  .ba-cmdk-back[data-open="true"] .ba-cmdk {
+    transform: none;
+  }
 }
 
 /* ---------------------------- INPUT ROW ---------------------------- */

--- a/web/cmdk.js
+++ b/web/cmdk.js
@@ -347,6 +347,10 @@
     isOpen = false;
     root.setAttribute("data-open", "false");
     try { input.blur(); } catch (e) {}
+    // Notify Python so the cmdk overlay (a Qt frame holding a dedicated
+    // webview for use over embeds) can hide itself. No-op when the palette
+    // is hosted in mw.web / reviewer.web.
+    pycmdSend("cmdk-closed");
   }
   function toggle(initialQuery) {
     if (isOpen) close();

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -303,12 +303,11 @@
       '</span>';
     cmdk.addEventListener("click", function (e) {
       e.preventDefault();
-      if (typeof window.__baCmdkOpen === "function") {
-        // Same-webview: open immediately, no Python round-trip.
-        window.__baCmdkOpen("");
-      } else {
-        send("cmdk-open");
-      }
+      // Always route through Python so it can pick the right host: mw.web
+      // when there's no embed, or the dedicated cmdk_overlay when an embed
+      // (Browse/Add/Stats/Settings) is up. Opening __baCmdkOpen directly in
+      // mw.web would render the palette behind the embed.
+      send("cmdk-open");
     });
     aside.appendChild(cmdk);
 


### PR DESCRIPTION
## Summary
- Cmd-K on an embed page (Browse/Add/Stats/Settings) no longer destroys the embed and snaps back to the deck browser. A new `cmdk_overlay` module snapshots the embed, displays it as a `QLabel` with `WA_NativeWindow` (so it stacks above mw.web's `QWebEngineView` GPU surface), hides the embed underneath, opens the palette in mw.web, then cross-fades back on close — so the user lands back on the same page they invoked Cmd-K from.
- Hides `body::before`'s `--rf-glow` gradient while the palette is up (was bleeding through as a yellow blob at the top in light mode), and gives the modal a spring entrance (`cubic-bezier(0.34, 1.56, 0.64, 1)`) so the open feels organic.
- Sidebar search button now routes through `pycmd` so embed-aware host selection applies to both click and Cmd-K paths.

## Test plan
- [ ] Cmd-K on Browse: palette appears over the page; backdrop dims it; Esc returns to Browse, not Decks.
- [ ] Same on Add Cards and Stats embeds.
- [ ] Click the sidebar search field while on Browse — same behavior as Cmd-K.
- [ ] No yellow gradient at the top while the palette is open in light mode.
- [ ] Decks page and Reviewer palettes still work normally (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)