### PR TITLE
Homepage stats: today session bars + separated streak chip

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -674,9 +674,14 @@ def on_deck_browser_will_render_content(
             hero = _single_deck_hero()
     except Exception:
         pass
+    # Pulse strip (cards today · lifetime · streak) leads the practice
+    # section. Same shape in single-deck and multi-deck because it sits
+    # inside .ba-practice (which is the same in both modes).
+    pulse = _pulse_html()
+    practice_inner = pulse + heatmap
     practice = (
-        f'<section class="ba-practice">{heatmap}</section>'
-        if heatmap else ""
+        f'<section class="ba-practice">{practice_inner}</section>'
+        if practice_inner else ""
     )
     content.stats = hero + content.stats + practice
 
@@ -1266,6 +1271,195 @@ def _single_deck_hero() -> str:
         """
     except Exception:
         return ""
+
+
+def _pulse_html() -> str:
+    """Today panel (totals + hourly session-bars) and a separated streak
+    element. Renders for both single-deck and multi-deck modes; sits
+    inside .ba-practice so it inherits the section's width and entry
+    animation.
+
+    Today panel: a soft-bg card holding two things — an editorial header
+    of "N cards · M min" in the .ba-cg-result mixed-type vocabulary, and
+    below it a histogram of cards-per-hour from the user's first studied
+    hour through the current hour. Empty hours mid-session render as a
+    short dim stub so breaks read as gaps, not as missing data.
+
+    Streak: a separate flat element (no panel chrome) below the today
+    panel — thematically grouped with the heatmap below, since both
+    speak to long-term consistency rather than immediate effort."""
+    try:
+        s = _standing()
+    except Exception:
+        return ""
+    today_total = int(s.get("today", 0) or 0)
+    streak = int(s.get("streak", 0) or 0)
+    try:
+        mins = int(_minutes_today() or 0)
+    except Exception:
+        mins = 0
+    by_hour = _today_by_hour()
+    rollover = _rollover_hour()
+
+    # Build the streak chip once — always present (a streak persists across
+    # days of inactivity until it actually breaks).
+    zs = " is-zero" if streak == 0 else ""
+    # Heroicons "fire" (solid) — a recognizable two-arc flame with an
+    # inner ember. Reads as fire at any size without the cartoon-emoji
+    # vibe; matches the addon's filled-icon family weight.
+    fire_svg = (
+        '<svg class="ba-streak-fire" viewBox="0 0 24 24" '
+        'fill="currentColor" aria-hidden="true">'
+        '<path fill-rule="evenodd" clip-rule="evenodd" '
+        'd="M12.963 2.286a.75.75 0 0 0-1.071-.136 9.742 9.742 0 0 0-3.539 '
+        '6.177A7.547 7.547 0 0 1 6.648 6.61a.75.75 0 0 0-1.152-.082A9 9 0 '
+        '1 0 15.68 4.534a7.46 7.46 0 0 1-2.717-2.248zM15.75 14.25a3.75 '
+        '3.75 0 1 1-7.313-1.172c.628.465 1.35.81 2.133 1A5.99 5.99 0 0 1 '
+        '12.366 10.4a3.75 3.75 0 0 1 3.384 3.85z"/>'
+        '</svg>'
+    )
+    streak_html = (
+        f'<div class="ba-streak{zs}" role="group" '
+        f'aria-label="{streak} day streak">'
+        f'{fire_svg}'
+        f'<span class="ba-streak-n">{streak:,}</span>'
+        f'</div>'
+    )
+
+    # If there are no reviews today, omit the today panel entirely —
+    # an empty card just to say "nothing yet" reads as filler, and the
+    # streak + heatmap below already tell the relevant story for an
+    # un-studied day.
+    if not by_hour:
+        return f'<div class="ba-pulse">{streak_html}</div>'
+
+    # Build the today panel body. by_hour is guaranteed non-empty here
+    # because we returned early above when it was empty.
+    first_h = min(by_hour.keys())
+    # "Current hour" — where we should end the chart. If the user has a row
+    # in an hour past `now` (e.g. dev-fixture timestamp drift), respect that
+    # as the right edge so the data doesn't get clipped.
+    shift = _day_shift_seconds()
+    now_h_within = int(((time.time() + shift) % 86400) / 3600)
+    last_h = max(now_h_within, max(by_hour.keys()))
+    hours = list(range(first_h, last_h + 1))
+    max_count = max((n for n, _ in by_hour.values()), default=1) or 1
+    # Render bars. Each bar is a column wrapper holding a count label that
+    # rides above the bar, the bar itself, and a custom hover tooltip with
+    # hour + cards + minutes. The tooltip is plain DOM (not the browser's
+    # title attr) so we can style it to match the page.
+    bar_html = []
+    for h in hours:
+        n, ms = by_hour.get(h, (0, 0))
+        # Cap heights at 88% so the count label above always has room
+        # without the bar visually colliding with it; empty hours get a
+        # tiny stub so breaks remain visible as ticks.
+        if n > 0:
+            pct = max(8.0, (n / max_count) * 88.0)
+        else:
+            pct = 4.0
+        cls = "ba-today-bar" + ("" if n > 0 else " is-empty")
+        count_str = str(n) if n > 0 else ""
+        hour_label = _format_hour_of_day((rollover + h) % 24)
+        # Minutes for the tooltip — sub-30s rounds to "<1", otherwise
+        # rounded minutes. We don't show a tooltip on empty stubs.
+        if n > 0:
+            if ms < 30_000:
+                mins_str = "<1 min"
+            else:
+                mins_str = f"{round(ms / 60_000)} min"
+            tip_html = (
+                f'<span class="ba-today-bar-tip" aria-hidden="true">'
+                f'<span class="ba-today-bar-tip-h">{hour_label}</span>'
+                f'<span class="ba-today-bar-tip-d">'
+                f'<b>{n:,}</b> cards · <b>{mins_str}</b>'
+                f'</span>'
+                f'</span>'
+            )
+        else:
+            tip_html = ""
+        bar_html.append(
+            f'<span class="ba-today-bar-col">'
+            f'{tip_html}'
+            f'<span class="ba-today-bar-count">{count_str}</span>'
+            f'<span class="{cls}" style="height:{pct:.1f}%"></span>'
+            f'</span>'
+        )
+    bars = "".join(bar_html)
+    # Labels: collapse to a single centered "NOW" when the session sits in
+    # one hour (the user-just-started case). Otherwise the start hour
+    # anchors the left and "NOW" the right.
+    if first_h == last_h:
+        labels = (
+            f'<div class="ba-today-labels ba-today-labels--solo">'
+            f'<span class="ba-today-now">NOW</span>'
+            f'</div>'
+        )
+    else:
+        first_label = _format_hour_of_day((rollover + first_h) % 24)
+        labels = (
+            f'<div class="ba-today-labels">'
+            f'<span>{first_label}</span>'
+            f'<span class="ba-today-now">NOW</span>'
+            f'</div>'
+        )
+
+    # Header row: editorial mixed-type totals. Uses the .ba-cg-result
+    # vocabulary (serif numbers + sans uppercase units + mid-dot).
+    head = (
+        f'<div class="ba-today-head">'
+        f'<span class="ba-today-n">{today_total:,}</span>'
+        f'<span class="ba-today-u">cards</span>'
+        f'<span class="ba-today-sep">·</span>'
+        f'<span class="ba-today-n">{mins:,}</span>'
+        f'<span class="ba-today-u">min</span>'
+        f'</div>'
+    )
+
+    return f"""
+    <div class="ba-pulse">
+      <section class="ba-today" aria-label="Your study today">
+        {head}
+        <div class="ba-today-bars">{bars}</div>
+        {labels}
+      </section>
+      {streak_html}
+    </div>
+    """
+
+
+def _today_by_hour() -> Dict[int, tuple]:
+    """Cards reviewed in each hour-within-today, keyed by hour-offset from
+    the day rollover. Returns {hour: (card_count, total_time_ms)} so the
+    today-panel hover tooltips can show per-hour minutes alongside counts
+    without a second SQL round-trip. Empty dict on any error."""
+    try:
+        shift = _day_shift_seconds()
+        today_idx = int((time.time() + shift) // 86400)
+        rows = mw.col.db.all(
+            "select cast(((id/1000 + ?) - ? * 86400) / 3600 as int) as hr, "
+            "       count(), sum(time) "
+            "from revlog "
+            "where cast((id/1000 + ?) / 86400 as int) = ? "
+            "group by hr",
+            shift, today_idx, shift, today_idx,
+        )
+        return {int(h): (int(n), int(t or 0)) for h, n, t in rows}
+    except Exception:
+        return {}
+
+
+def _format_hour_of_day(h: int) -> str:
+    """12-hour time label with AM/PM suffix only at the boundary. `h` is
+    a 0..23 hour-of-day in user local time."""
+    h = h % 24
+    if h == 0:
+        return "12 AM"
+    if h == 12:
+        return "12 PM"
+    if h < 12:
+        return f"{h} AM"
+    return f"{h - 12} PM"
 
 
 def _minutes_today() -> int:

--- a/web/theme.css
+++ b/web/theme.css
@@ -420,7 +420,7 @@ body::before {
 }
 .ba-home #studiedToday { display: none !important; }
 
-/* ---------------- PRACTICE — heatmap-only section below the decks --------- */
+/* ---------------- PRACTICE — pulse strip + heatmap below the decks --------- */
 .ba-practice {
   width: 100%;
   max-width: var(--rf-measure);
@@ -441,6 +441,350 @@ body::before {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--rf-ink-faint);
+}
+
+/* ---------------- PULSE — today panel + separated streak -------------------
+   Two stacked elements above the heatmap:
+     • .ba-today  — soft-bg card with totals header + hourly session bars
+     • .ba-streak — flat editorial chip with the streak count
+   They sit inside .ba-practice so they share the section's width and
+   entrance with the heatmap, and render the same in single-deck and
+   multi-deck mode (no per-mode branches).
+
+   Why two elements (not one): today's stats describe *immediate effort*
+   (cards reviewed in this session, time spent right now). The streak
+   describes *long-term consistency* — same theme as the heatmap below.
+   Pairing the streak with the heatmap, rather than with today, makes the
+   visual story read top-to-bottom as: deck list → what you did today
+   → what you've been doing all along. */
+.ba-pulse {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 22px;
+  padding: 4px 0 22px;
+  margin: 0;
+}
+
+/* ---------- TODAY PANEL ---------- */
+.ba-today {
+  background: var(--rf-panel);
+  border: 1px solid var(--rf-line);
+  border-radius: 14px;
+  padding: 20px 26px 22px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+/* Header: "47 CARDS · 12 MIN" — exact .ba-cg-result vocabulary, scaled
+   down so it reads as a panel header rather than a top-of-page hero.
+   align-items: center keeps the unit labels and mid-dot on the same y-
+   line as the digit middles. */
+.ba-today-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 18px;
+  font-family: var(--rf-serif);
+  color: var(--rf-ink);
+  line-height: 1;
+  letter-spacing: -0.018em;
+  font-weight: 500;
+  font-size: 30px;
+  /* When the user hovers a bar, fade the header to make room for the
+     per-hour tooltip that lands in the same y-area. The header
+     reappears the instant the hover ends. Cleaner than the alternative
+     of pushing the chart down 60px just so a tooltip can clear the
+     totals on the rare tall-bar case. */
+  transition: opacity 180ms ease;
+}
+.ba-today:has(.ba-today-bar-col:hover) .ba-today-head {
+  opacity: 0;
+}
+.ba-today-n {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+/* Same -2px trick as .ba-cg-result: keep the trailing unit tight against
+   its digit ("47 cards"). */
+.ba-today-n + .ba-today-u {
+  margin-left: -2px;
+}
+.ba-today-u,
+.ba-today-sep {
+  font-family: var(--rf-sans);
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 600;
+  color: var(--rf-ink-faint);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.ba-today-sep {
+  margin: 0 4px;
+}
+
+/* Bars: thin verticals, one per hour from first studied → current. Each
+   hour is its own column wrapper so the bar can grow from the baseline
+   while a small count label rides at the top of the column without ever
+   colliding with the bar. The column heights are fixed; bar heights are
+   set inline as a percentage capped at 88% so the count above always has
+   breathing room.
+
+   Layout: a flex row of columns. Columns get a generous width budget
+   (max ~38px) so a 1-hour session reads as a confident single bar
+   rather than a sliver lost in the panel. Bars push to the LEFT edge
+   so the visualization always reads chronologically from the first
+   studied hour. */
+.ba-today-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 72px;
+  margin: 4px 0 10px;
+  justify-content: flex-start;
+}
+.ba-today-bar-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1 1 0;
+  min-width: 14px;
+  max-width: 38px;
+  height: 100%;
+  position: relative;
+}
+.ba-today-bar-count {
+  /* Tiny tabular sans count riding the top of each column; sits just
+     above the bar. Uses --rf-ink-dim so it reads as a quiet annotation
+     rather than competing with the panel header. */
+  font: 600 9.5px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  color: var(--rf-ink-dim);
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+  min-height: 9.5px;
+  /* Don't reserve space when the count is empty (zero-hour). */
+  opacity: 1;
+}
+.ba-today-bar-col:has(.ba-today-bar.is-empty) .ba-today-bar-count {
+  /* Hide the count above empty-hour stubs — there's nothing to count
+     and the slot would just print a blank gap. */
+  opacity: 0;
+}
+.ba-today-bar {
+  width: 100%;
+  /* Bar color follows whichever heatmap palette the user picked in
+     settings — same token the heatmap below uses for its peak-intensity
+     cells. Picking accent/green/teal/violet/rose/amber for the heatmap
+     re-colors the bars in lockstep, so the section reads as one
+     coordinated piece instead of two unrelated visualisations. */
+  background: var(--rf-hm-l4);
+  border-radius: 3px 3px 0 0;
+  transition: background 160ms ease, filter 160ms ease;
+}
+/* Hover lift: brighten the bar so the user can see which column the
+   tooltip belongs to, while the count label above warms to ink to
+   reinforce the focus. Light/dark themes both have headroom on a
+   brightness(1.15) — l4 is the heatmap's most-saturated shade, not
+   already white, so it still has somewhere to go. */
+.ba-today-bar-col:hover .ba-today-bar {
+  filter: brightness(1.15);
+}
+.ba-today-bar-col:hover .ba-today-bar-count {
+  color: var(--rf-ink);
+}
+
+/* ---------- TOOLTIP ----------
+   Custom hover card above each bar with hour + cards + minutes. Built
+   from real DOM (not the browser's title attr) so the typography and
+   chrome match the page — cream panel bg, subtle border, soft shadow,
+   tiny down-arrow pointing at the bar. Slides up a few pixels on
+   reveal so the hover feels alive without bouncing. */
+.ba-today-bar-tip {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  pointer-events: none;
+  background: var(--rf-panel);
+  border: 1px solid var(--rf-line-2);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08),
+              0 1px 2px  rgba(0, 0, 0, 0.04);
+  padding: 9px 13px 10px;
+  border-radius: 8px;
+  white-space: nowrap;
+  text-align: center;
+  z-index: 10;
+  transition: opacity 160ms ease, transform 200ms cubic-bezier(.2,.8,.2,1);
+}
+.ba-today-bar-col:hover .ba-today-bar-tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  transition-delay: 60ms; /* tiny pause so quick scrub-overs don't strobe */
+}
+.ba-today-bar-tip-h {
+  display: block;
+  font: 600 9.5px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--rf-ink-faint);
+  margin-bottom: 6px;
+}
+.ba-today-bar-tip-d {
+  display: block;
+  font: 500 12.5px/1 var(--rf-sans);
+  color: var(--rf-ink-dim);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.005em;
+}
+.ba-today-bar-tip-d b {
+  font-weight: 700;
+  color: var(--rf-ink);
+}
+/* Down-pointing arrow attached to the tooltip — two stacked pseudos
+   build a 1px line + fill triangle so the arrow inherits the same
+   border/fill as the tooltip body. */
+.ba-today-bar-tip::before,
+.ba-today-bar-tip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+}
+.ba-today-bar-tip::before {
+  border-top: 7px solid var(--rf-line-2);
+}
+.ba-today-bar-tip::after {
+  margin-top: -1px;
+  border-top: 7px solid var(--rf-panel);
+}
+/* Empty-hour stub — a thin dim tick along the baseline. */
+.ba-today-bar.is-empty {
+  background: var(--rf-line-2);
+  border-radius: 999px;
+  /* Override the inline height with a fixed thin stub so empty hours
+     visually collapse to a "tick" rather than a tiny bar. */
+  height: 3px !important;
+  width: 60%;
+}
+
+/* Hour labels under the bars — first hour at the left, "NOW" at the
+   right, mirroring the bars container. Small uppercase sans, dim.
+   The --solo variant centers a single "NOW" when the session sits in
+   one hour, since "5 PM ... NOW" would be redundant. */
+.ba-today-labels {
+  display: flex;
+  justify-content: space-between;
+  font: 600 9.5px/1 var(--rf-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--rf-ink-faint);
+}
+.ba-today-labels--solo {
+  justify-content: flex-start;
+  /* Align the "NOW" label under the (single) bar column at the left,
+     not the panel's right edge. Approximate column width = 38px max. */
+  padding-left: 6px;
+}
+.ba-today-now {
+  color: var(--rf-ink-dim);
+}
+
+/* Empty state — when today has 0 reviews. Italic serif, quiet, takes
+   the place of the bar strip so the panel doesn't go hollow. */
+.ba-today-empty {
+  font: italic 400 14px/1.5 var(--rf-serif);
+  color: var(--rf-ink-dim);
+  padding: 10px 0 6px;
+}
+
+/* ---------- STREAK (separate flat element) ----------
+   Fire glyph + number, no caption. Uses sans bold instead of the
+   today panel's serif so the streak reads as a distinct second voice
+   on the page — the panel is editorial, the streak is a confident
+   badge. Color: --rf-hm-l4 throughout so the icon and digits track
+   whichever heatmap palette the user picked in settings; the whole
+   pulse section then reads as one coordinated palette instead of
+   three independently coloured pieces. */
+.ba-streak {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 8px 0 2px;
+  color: var(--rf-hm-l4);
+}
+.ba-streak-fire {
+  width: 36px;
+  height: 36px;
+  flex: none;
+  color: var(--rf-hm-l4);
+  /* Pivot near the base so the flicker reads as the tip dancing,
+     not the whole glyph drifting. */
+  transform-origin: 50% 82%;
+  animation: ba-streak-flicker 4.4s ease-in-out infinite;
+}
+.ba-streak-n {
+  font: 700 36px/1 var(--rf-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  letter-spacing: -0.015em;
+  color: var(--rf-hm-l4);
+}
+/* Zero-streak: drop the warm accent and hide the fire — nothing earned
+   yet, nothing to celebrate. The number alone in faint ink reads as
+   "0" without any visual fanfare. */
+.ba-streak.is-zero {
+  color: var(--rf-ink-faint);
+}
+.ba-streak.is-zero .ba-streak-n {
+  color: var(--rf-ink-faint);
+  font-weight: 600;
+}
+.ba-streak.is-zero .ba-streak-fire {
+  display: none;
+}
+@keyframes ba-streak-flicker {
+  0%, 100% { transform: scale(1)    rotate(0);       opacity: 1;    }
+  35%      { transform: scale(0.96) rotate(-1.5deg); opacity: 0.92; }
+  65%      { transform: scale(1.03) rotate(1.5deg);  opacity: 1;    }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-streak-fire { animation: none; }
+}
+
+/* Pulse and heatmap stack with breathing space — no hairline. */
+.ba-home .ba-practice .ba-pulse + .rf-heatmap {
+  padding-top: 16px !important;
+  margin-top: 0 !important;
+}
+
+/* Match the practice section's staggered entrance. */
+.ba-home .ba-pulse {
+  animation: ba-rise 0.55s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  animation-delay: 0.18s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ba-home .ba-pulse { animation: none; }
+}
+
+/* Responsive — keep the panel shape, just tighten typography and bars
+   at narrow widths. */
+@media (max-width: 620px) {
+  .ba-today        { padding: 16px 18px 18px; }
+  .ba-today-head   { font-size: 24px; }
+  .ba-today-bars   { height: 52px; }
+  .ba-streak-n     { font-size: 24px; }
 }
 
 /* Anki's "Studied N cards today" caption — hide; superfluous next to deck list. */


### PR DESCRIPTION
## Summary
- New today panel above the heatmap with hour-by-hour bars from the user's first studied hour through the current hour, plus an editorial "N cards · M min" header in the existing `.ba-cg-result` mixed-type vocabulary. Empty-mid-session hours render as thin dim stubs so breaks read as visible gaps.
- Per-bar hover shows a tooltip with the hour, cards, and minutes; the daily header fades via `:has(.ba-today-bar-col:hover)` so the tooltip slides into the same y-space without overlapping. Hovered bar brightens and its count warms to ink so the column being read is unambiguous.
- Separated streak element below the panel — a Heroicons-style fire glyph and the streak count in sans bold, with a gentle flicker. All three (bars, fire, number) use `--rf-hm-l4` so the section retunes in lockstep with whichever heatmap palette the user picked in settings; the today panel is omitted entirely on zero-review days.

## Test plan
- [ ] Open the deck browser with 0 reviews today — only the streak chip and heatmap should appear; no empty "today" card.
- [ ] Review a few cards, return to the deck browser — today panel appears with at least one bar; count label sits above each bar.
- [ ] Review across multiple hours (or seed via `.context/seed_today.py`) — bars span first-studied-hour through "NOW"; mid-session empty hours render as thin dim ticks at the baseline.
- [ ] Hover any bar — daily header fades, tooltip appears with hour + cards + minutes, bar brightens, count warms to ink. Mouse-out reverses cleanly.
- [ ] Change `heatmap_palette` in settings (accent / green / amber / etc.) — bars, fire icon, streak number, and heatmap cells all re-color together.
- [ ] Check both single-deck and multi-deck modes — pulse renders identically in both since it sits inside `.ba-practice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)