### PR TITLE
Sync: silent sidebar lifecycle + deck options popup position fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist/
 .context/
 .claude/
 SUBMISSION.md
+# Local scratch output (screenshots from snap.sh, HTML dumps from dump.sh,
+# headless-Chrome captures for design iteration). Previously tracked
+# screenshots stay in history; new files in here are ignored.
+out/

--- a/__init__.py
+++ b/__init__.py
@@ -1353,6 +1353,155 @@ def _refresh_sync_status() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Sync — silent, sidebar-driven UX.
+#
+# Anki's default flow opens a modal QProgressDialog (titled "Checking…" then
+# "Uploading…" etc.) while sync runs, and pops a `tooltip("Sync complete")`
+# after it closes. Both yank focus and break the page's visual flow. We
+# replace `mw._sync_collection_and_media` with a version that runs the same
+# sync via `taskman.run_in_background` (no modal, no tooltip) and feeds the
+# lifecycle to the sidebar instead — the existing "active" pulse on the
+# Sync row carries the load while a 150 ms timer mirrors normal_sync stage
+# strings to JS, and a final result push triggers the "Synced" reveal.
+#
+# Confirmation paths that legitimately need a dialog (login when no auth,
+# full-upload/full-download choice) still surface via Anki's own UI — we
+# only suppress the *progress* dialog and the *post-sync* tooltip.
+# --------------------------------------------------------------------------- #
+def _push_sidebar_sync_progress(stage: str, added: str, removed: str) -> None:
+    """Mirror normal_sync progress strings to the sidebar's Sync row."""
+    import json as _json
+    payload = _json.dumps({"stage": stage or "", "added": added or "",
+                           "removed": removed or ""})
+    js = "window.__baSetSyncProgress && window.__baSetSyncProgress(%s);" % payload
+    w = getattr(mw, "web", None)
+    if w is not None:
+        try:
+            w.eval(js)
+        except Exception:
+            pass
+
+
+def _push_sidebar_sync_result(kind: str) -> None:
+    """Trigger the sidebar's end-of-sync reveal. kind ∈ {"ok","noop","error"}."""
+    safe = "".join(ch for ch in kind if ch.isalnum())
+    js = "window.__baSetSyncResult && window.__baSetSyncResult('%s');" % safe
+    w = getattr(mw, "web", None)
+    if w is not None:
+        try:
+            w.eval(js)
+        except Exception:
+            pass
+
+
+def _ad_sync_collection_silent(mw_arg: Any, on_done) -> None:
+    """Drop-in for `aqt.sync.sync_collection` — no modal, no tooltip.
+
+    Calls `mw.col.sync_collection(auth, media_enabled)` directly through
+    `taskman.run_in_background`, polls `latest_progress().normal_sync`
+    every 150 ms, and routes the result to the sidebar. Full-sync paths
+    still delegate to `aqt.sync.full_sync` (which owns its own dialog)."""
+    from aqt.sync import full_sync as _full_sync, handle_sync_error
+    from aqt.qt import QTimer, qconnect
+    from aqt.utils import showText
+
+    auth = mw_arg.pm.sync_auth()
+    if not auth:
+        # Should never happen: callers gate on auth. Defensive no-op.
+        return on_done()
+
+    seen = {"added": "", "removed": "", "stage": ""}
+    timer = QTimer(mw_arg)
+
+    def on_timer() -> None:
+        try:
+            progress = mw_arg.col.latest_progress()
+            if progress.HasField("normal_sync"):
+                p = progress.normal_sync
+                if p.added:   seen["added"]   = p.added
+                if p.removed: seen["removed"] = p.removed
+                if p.stage:   seen["stage"]   = p.stage
+                _push_sidebar_sync_progress(p.stage, p.added, p.removed)
+        except Exception:
+            pass
+    qconnect(timer.timeout, on_timer)
+    timer.start(150)
+
+    def on_future_done(fut) -> None:
+        try:
+            mw_arg.col._load_scheduler()
+        except Exception:
+            pass
+        timer.stop()
+        try:
+            out = fut.result()
+        except Exception as err:
+            _push_sidebar_sync_result("error")
+            handle_sync_error(mw_arg, err)
+            return on_done()
+
+        try:
+            mw_arg.pm.set_host_number(out.host_number)
+            if out.new_endpoint:
+                mw_arg.pm.set_current_sync_url(out.new_endpoint)
+            if out.server_message:
+                showText(out.server_message, parent=mw_arg)
+        except Exception:
+            pass
+
+        if out.required == out.NO_CHANGES:
+            # Distinguish "real changes were synced" vs "heartbeat, nothing
+            # happened" so the reveal can be louder vs quieter accordingly.
+            had_changes = bool(seen["added"] or seen["removed"])
+            _push_sidebar_sync_result("ok" if had_changes else "noop")
+            try:
+                mw_arg.media_syncer.start_monitoring()
+            except Exception:
+                pass
+            return on_done()
+        else:
+            # Full upload/download paths legitimately need a confirmation
+            # dialog — fall back to Anki's native flow. The sidebar's
+            # "active" pulse is cleared by on_done()'s gui_hooks.sync_did_finish.
+            _push_sidebar_sync_result("ok")
+            _full_sync(mw_arg, out, on_done)
+
+    mw_arg.taskman.run_in_background(
+        lambda: mw_arg.col.sync_collection(auth, mw_arg.pm.media_syncing_enabled()),
+        on_future_done,
+    )
+
+
+def _install_silent_sync() -> None:
+    """Patch mw._sync_collection_and_media to use our silent flow.
+
+    Both manual sync (Sync button / Y) and automatic sync on profile
+    open/close route through this method, so a single patch covers all
+    entry points."""
+    import types
+
+    def _silent(self, after_sync) -> None:
+        def on_collection_sync_finished() -> None:
+            try:
+                self.col.models._clear_cache()
+            except Exception:
+                pass
+            gui_hooks.sync_did_finish()
+            try:
+                self.reset()
+            except Exception:
+                pass
+            after_sync()
+        gui_hooks.sync_will_start()
+        _ad_sync_collection_silent(self, on_done=on_collection_sync_finished)
+
+    try:
+        mw._sync_collection_and_media = types.MethodType(_silent, mw)
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
 # Congrats page (Overview's empty state) — redesigned.
 # Anki's "Congratulations! You have finished this deck for now." is a Svelte
 # page loaded via `web.load_sveltekit_page("congrats")`. That bypasses the
@@ -2273,6 +2422,14 @@ gui_hooks.main_window_did_init.append(_setup_sidebar_shortcuts)
 try:
     gui_hooks.sync_will_start.append(lambda *a: _push_sidebar_sync("active"))
     gui_hooks.sync_did_finish.append(lambda *a: _refresh_sync_status())
+except Exception:
+    pass
+
+# Silent sync (no modal progress dialog, no post-sync tooltip). Patches
+# mw._sync_collection_and_media, so it needs mw to exist — install on
+# main_window_did_init.
+try:
+    gui_hooks.main_window_did_init.append(lambda *a: _install_silent_sync())
 except Exception:
     pass
 

--- a/web/deckopts.js
+++ b/web/deckopts.js
@@ -232,7 +232,20 @@
       evt.preventDefault();
       evt.stopPropagation();
     }
-    var anchor = evt && evt.currentTarget;
+    // The shared deck-list (__adDeckList.render) delegates clicks on the
+    // row container, so evt.currentTarget there is the whole list — too
+    // wide to anchor a menu off, which puts the menu at the bottom of the
+    // list instead of next to the clicked gear. Walk up from the real
+    // click target to the gear button first; fall back to currentTarget
+    // for the non-delegated callers (single-deck hero, Anki's native
+    // gear anchor, the congrats title).
+    var anchor = null;
+    if (evt) {
+      if (evt.target && evt.target.closest) {
+        anchor = evt.target.closest('.ad-list-gear');
+      }
+      if (!anchor) anchor = evt.currentTarget;
+    }
     // Toggle off if clicking the same gear that opened the menu.
     if (CURRENT && CURRENT._anchor === anchor) {
       close();

--- a/web/sidebar.css
+++ b/web/sidebar.css
@@ -533,10 +533,21 @@ body.ba-with-side {
 }
 
 /* ---------------------------- SYNC ----------------------------
-   Three states the sidebar reflects:
-   • pending  — local changes to push; soft accent dot, slow breathe
-   • full     — full re-sync required; amber dot (stronger signal, no pulse)
-   • active   — sync in progress; icon spins
+   Standing states on the Sync row:
+   • pending     — local changes to push; soft accent dot, slow breathe
+   • full        — full re-sync required; amber dot (stronger signal, no pulse)
+   • active      — sync in progress; icon spins, label morphs to "Syncing…"
+   Transient end-of-sync reveals (data-sync-result attribute):
+   • ok          — real changes synced; cloud icon cross-fades to a green
+                   check that pops in (overshoot), label morphs to "Synced",
+                   the row briefly tints success-green, then settles back.
+   • noop        — heartbeat; nothing changed. The cloud icon does a
+                   gentle "settle" bounce as the spin stops, label fades
+                   silently back to "Sync". No check, no color shift —
+                   the quietest possible "done."
+   • error       — icon tints red and shakes, label morphs to "Sync failed".
+                   The actual error detail still surfaces via Anki's
+                   handle_sync_error warning dialog.
    The dot lives at the row's right edge (next to the label) so it doesn't
    visually compete with the icon, and gets a faint ring matching the row
    background so it reads as a token rather than a colored speck. */
@@ -566,7 +577,46 @@ body.ba-with-side {
   box-shadow: 0 0 0 2px color-mix(in srgb,
                 var(--rf-learn) 22%, transparent);
 }
-/* Active sync — icon spins. */
+
+/* Icon wrap — stacks the cloud-spinner and the success-check in the same
+   14px box so they can cross-fade in place during the reveal. */
+.ba-side-item[data-cmd="sync"] .ba-sync-iconwrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+.ba-side-item[data-cmd="sync"] .ba-sync-iconwrap > .ba-side-icon {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  transition: opacity 220ms ease, color 220ms ease;
+}
+.ba-side-item[data-cmd="sync"] .ba-sync-check {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  color: var(--rf-good, #34c759);
+  opacity: 0;
+  transform: scale(0.5);
+  transform-origin: 50% 50%;
+  pointer-events: none;
+}
+
+/* Label morph — cross-fade text changes ("Sync" ↔ "Syncing…" ↔ "Synced"). */
+.ba-side-item[data-cmd="sync"] .ba-side-l-text {
+  display: inline-block;
+  transition: color 220ms ease;
+}
+.ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-l-text {
+  color: var(--rf-accent, #6c8cff);
+}
+
+/* Active sync — icon spins. (Stays on through the reveal so the rotation
+   doesn't snap back to 0deg the moment the check fades in.) */
 .ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon {
   animation: ba-spin 1.4s linear infinite;
 }
@@ -581,9 +631,55 @@ body.ba-with-side {
   0%, 100% { opacity: 1;    transform: scale(1); }
   50%      { opacity: 0.55; transform: scale(0.88); }
 }
+
+/* ---- Reveal: OK (real changes happened) ---- */
+.ba-side-item[data-cmd="sync"][data-sync-result="ok"] > .ba-sync-iconwrap > .ba-side-icon {
+  opacity: 0;
+}
+.ba-side-item[data-cmd="sync"][data-sync-result="ok"] .ba-sync-check {
+  animation: ba-sync-check-in 420ms cubic-bezier(.34, 1.56, .64, 1) forwards;
+}
+.ba-side-item[data-cmd="sync"][data-sync-result="ok"] .ba-side-l-text {
+  color: var(--rf-good, #34c759);
+}
+@keyframes ba-sync-check-in {
+  0%   { opacity: 0; transform: scale(0.3) rotate(-8deg); }
+  60%  { opacity: 1; transform: scale(1.18) rotate(0deg); }
+  100% { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+
+/* ---- Reveal: noop (heartbeat, nothing changed) ---- */
+.ba-side-item[data-cmd="sync"][data-sync-result="noop"] .ba-side-icon {
+  animation: ba-sync-settle 680ms cubic-bezier(.34, 1.56, .64, 1) forwards;
+}
+@keyframes ba-sync-settle {
+  /* Inherits the spin's current rotation, decelerates, gentle bounce, rest. */
+  0%   { transform: rotate(0deg)   scale(1); }
+  50%  { transform: rotate(180deg) scale(1.15); }
+  100% { transform: rotate(360deg) scale(1); }
+}
+
+/* ---- Reveal: error ---- */
+.ba-side-item[data-cmd="sync"][data-sync-result="error"] .ba-side-icon {
+  color: var(--rf-bad, #ff453a);
+  animation: ba-sync-shake 380ms ease-in-out forwards;
+}
+.ba-side-item[data-cmd="sync"][data-sync-result="error"] .ba-side-l-text {
+  color: var(--rf-bad, #ff453a);
+}
+@keyframes ba-sync-shake {
+  0%, 100% { transform: translateX(0); }
+  20%      { transform: translateX(-2.5px); }
+  60%      { transform: translateX(2.5px); }
+  80%      { transform: translateX(-1.5px); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .ba-side-item[data-cmd="sync"].ba-sync-pending .ba-side-dot,
-  .ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon {
+  .ba-side-item[data-cmd="sync"].ba-sync-active .ba-side-icon,
+  .ba-side-item[data-cmd="sync"][data-sync-result="ok"] .ba-sync-check,
+  .ba-side-item[data-cmd="sync"][data-sync-result="noop"] .ba-side-icon,
+  .ba-side-item[data-cmd="sync"][data-sync-result="error"] .ba-side-icon {
     animation: none;
   }
 }

--- a/web/sidebar.js
+++ b/web/sidebar.js
@@ -75,6 +75,17 @@
   }
 
   // ---- nav rows -------------------------------------------------------- //
+  // Sync row needs an extra <svg> for the success-check overlay that fades
+  // in over the cloud icon when a sync completes with real changes. Both
+  // glyphs live in a positioned wrapper so we can cross-fade them without
+  // shifting the row layout.
+  var SYNC_CHECK_SVG =
+    '<svg class="ba-sync-check" viewBox="0 0 24 24" width="14" height="14" ' +
+      'fill="none" stroke="currentColor" stroke-width="2.2" ' +
+      'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M5 12.5l4.5 4.5L19 7"/>' +
+    '</svg>';
+
   function makeRow(it) {
     var b = document.createElement("button");
     b.type = "button";
@@ -82,8 +93,14 @@
     b.setAttribute("data-cmd", it.cmd);
     if (it.active) b.setAttribute("data-active", "true");
     if (it.cls) b.classList.add(it.cls);
-    var inner = iconSVG(it.cmd)
-              + '<span class="ba-side-l">' + it.label + "</span>";
+    var iconBlock = (it.cmd === "sync")
+      ? '<span class="ba-sync-iconwrap">' + iconSVG(it.cmd) + SYNC_CHECK_SVG + '</span>'
+      : iconSVG(it.cmd);
+    // .ba-side-l-text wraps the label so the sync row can rewrite it in
+    // place ("Sync" → "Syncing…" → "Synced") without touching siblings.
+    var inner = iconBlock
+              + '<span class="ba-side-l"><span class="ba-side-l-text">'
+              + it.label + '</span></span>';
     if (it.dot) inner += '<span class="ba-side-dot"></span>';
     if (it.key) inner += '<span class="ba-side-key">' + it.key + "</span>";
     b.innerHTML = inner;
@@ -379,13 +396,74 @@
       else els[i].removeAttribute("data-active");
     }
   }
+  // The sync row drives a small state machine:
+  //
+  //   idle  ──click──▶  active  ──result(ok)──▶  reveal-ok   ──▶  idle
+  //                          └──result(noop)──▶ reveal-noop ──▶  idle
+  //                          └──result(error)─▶ reveal-err  ──▶  idle
+  //
+  // applySync() owns the standing class state (pending/full/active) and
+  // the resting label. applySyncResult() owns the brief "Synced" reveal
+  // — and during that reveal it locks the label so applySync() can't
+  // overwrite it from a parallel `gui_hooks.sync_did_finish` refresh.
+  var syncResultTimer = null;
+
   function applySync(state) {
     var el = document.querySelector('.ba-side-item[data-cmd="sync"]');
     if (!el) return;
-    el.classList.remove("ba-sync-pending", "ba-sync-full", "ba-sync-active");
+    var revealing = el.hasAttribute("data-sync-result");
+    var text = el.querySelector(".ba-side-l-text");
+    el.classList.remove("ba-sync-pending", "ba-sync-full");
+    // Keep the spin going while the reveal plays — it cross-fades into
+    // the check, no abrupt stop.
+    if (!revealing) el.classList.remove("ba-sync-active");
     if (state === "pending") el.classList.add("ba-sync-pending");
     else if (state === "full") el.classList.add("ba-sync-full");
-    else if (state === "active") el.classList.add("ba-sync-active");
+    else if (state === "active") {
+      el.classList.add("ba-sync-active");
+      if (text && !revealing) text.textContent = "Syncing…";
+    } else if (!revealing && text) {
+      text.textContent = "Sync";
+    }
+  }
+
+  function applySyncProgress(d) {
+    // Anki's `progress.normal_sync.stage` is a localized full sentence
+    // ("Checking…", "Uploading notes…") that would jitter the row width
+    // if shown directly. We stash it on a data attr for inspection /
+    // future use; the visible feedback is the spinning icon + "Syncing…"
+    // label, which is enough to convey "work is in flight."
+    if (!d) return;
+    var el = document.querySelector('.ba-side-item[data-cmd="sync"]');
+    if (!el) return;
+    if (d.stage) el.setAttribute("data-sync-stage", d.stage);
+    if (d.added) el.setAttribute("data-sync-added", d.added);
+    if (d.removed) el.setAttribute("data-sync-removed", d.removed);
+  }
+
+  function applySyncResult(kind) {
+    var el = document.querySelector('.ba-side-item[data-cmd="sync"]');
+    if (!el) return;
+    var text = el.querySelector(".ba-side-l-text");
+    el.setAttribute("data-sync-result", kind);
+    // Different reveals for "real changes happened" vs "heartbeat / no
+    // changes" vs "error" — see styles below for the actual motion.
+    if (kind === "ok" && text) text.textContent = "Synced";
+    else if (kind === "error" && text) text.textContent = "Sync failed";
+    // "noop" — keep the label as it was (usually "Syncing…"); we let it
+    // fade back to "Sync" with the icon's settle bounce.
+
+    var hold = (kind === "noop") ? 800 : 1800;
+    clearTimeout(syncResultTimer);
+    syncResultTimer = setTimeout(function () {
+      el.removeAttribute("data-sync-result");
+      el.classList.remove("ba-sync-active");
+      el.removeAttribute("data-sync-stage");
+      el.removeAttribute("data-sync-added");
+      el.removeAttribute("data-sync-removed");
+      var t = el.querySelector(".ba-side-l-text");
+      if (t) t.textContent = "Sync";
+    }, hold);
   }
 
   function inject() {
@@ -414,6 +492,12 @@
   window.__baSetSync = function (state) {
     pending.sync = state;
     applySync(state);
+  };
+  window.__baSetSyncProgress = function (d) {
+    applySyncProgress(d);
+  };
+  window.__baSetSyncResult = function (kind) {
+    applySyncResult(kind);
   };
 
   // Bootstrap from the <head>-embedded standing data (set by the addon


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled on this branch:

### 1. Sync UX — replace modal dialog + tooltip with sidebar lifecycle

Anki's native Sync flow opens a modal QProgressDialog ("Checking…", "Uploading…") and ends with a separate tooltip flash. Both yank focus and break the page's visual flow.

Same sync now runs through `taskman.run_in_background` (no modal) with a 150 ms timer mirroring `normal_sync` stage/added/removed strings to the sidebar Sync row:

- **active** — icon spins, label morphs to "Syncing…" in accent blue.
- **ok** — cloud cross-fades to a green check (overshoot pop), label becomes "Synced" green, holds 1.8 s, settles.
- **noop** — quiet settle-bounce on the icon, label fades silently back to "Sync" (no check, no color — heartbeat).
- **error** — red tint + shake, label becomes "Sync failed". Anki's own `handle_sync_error` still surfaces the actual detail.

Full-upload / full-download still delegate to `aqt.sync.full_sync` so the confirmation dialog gates anything destructive. `prefers-reduced-motion` is honored on every new animation.

Also gitignores `out/` — used by `snap.sh` and other dev capture scripts; existing tracked screenshots stay in history, new captures are silent.

### 2. Deck options popup — anchor to the gear, not the row container

The shared `__adDeckList.render()` uses one delegated click handler on the row container, so `evt.currentTarget` is the whole list — the menu was dropping below the entire list instead of next to the clicked gear. Walk up from `evt.target` to `.ad-list-gear` first; fall back to `currentTarget` for the direct-bound call sites (single-deck hero, Anki's native gear anchor, congrats title).

## Test plan

- [ ] Manual sync (Sync button / **Y**) runs without showing the QProgressDialog or post-sync tooltip
- [ ] Real changes pushed/pulled → green check + "Synced" reveal on the sidebar
- [ ] Heartbeat sync with no changes → quiet settle-bounce, no check
- [ ] Sync with network off → red shake + "Sync failed" + Anki's own warning dialog with detail
- [ ] Full-upload / full-download path still prompts via the original confirmation dialog
- [ ] Auto-sync on open/close also runs without a modal
- [ ] Multi-deck home page: clicking the gear on any deck opens the options menu **next to that gear** (not below the entire list)
- [ ] Single-deck hero gear still opens at the hero title
- [ ] Congrats Keep-going list gear still opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)