### PR TITLE
Browse embed: pin editor pane visible, can't drag-collapse + make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ LINK := $(BASE)/addons21/$(NAME)
 ANKI    ?= $(HOME)/Library/Application Support/AnkiProgramFiles/.venv/bin/anki
 ANKI_PY ?= $(HOME)/Library/Application Support/AnkiProgramFiles/.venv/bin/python
 
-# Real base, used only by `make seed` as a read source.
-REAL_BASE := $(HOME)/Library/Application Support/Anki2
+# Real base, used by `make seed` as a read source and `make install` as the
+# install target (your actual Anki, NOT the dev/demo bases).
+REAL_BASE    := $(HOME)/Library/Application Support/Anki2
+REAL_INSTALL := $(REAL_BASE)/addons21/anki-design
 
-.PHONY: dev undev run run-fg logs seed demo-seed demo-run demo demo-rebuild demo-stop demo-clean demo-clean-cache demo-clean-all demo-cache-write demo-cache-restore demo-link deisolate clean-base build clean
+.PHONY: dev undev run run-fg logs seed demo-seed demo-run demo demo-rebuild demo-stop demo-clean demo-clean-cache demo-clean-all demo-cache-write demo-cache-restore demo-link deisolate clean-base build install clean
 
 # Demo bases — each variant gets its own Anki base + its own golden cache.
 # The cache lives under ~/Library/Caches so it's shared across all worktrees:
@@ -211,6 +213,28 @@ clean-base:
 # Produce dist/anki-design.ankiaddon for AnkiWeb upload.
 build:
 	@python3 build.py
+
+# Build + drop the addon into your REAL Anki (not the dev/demo bases).
+# Removes ANY other folder under addons21/ whose manifest declares package
+# "anki-design" first — otherwise an AnkiWeb-numeric-ID copy (e.g. 1809063985)
+# and our install both register hooks, and the deck browser renders the hero
+# + heatmap twice. If real Anki is open, quit and reopen it afterwards so the
+# addon reloads.
+install: build
+	@test -f dist/anki-design.ankiaddon || { echo "build missing at dist/anki-design.ankiaddon"; exit 1; }
+	@for d in "$(REAL_BASE)/addons21"/*/; do \
+	  [ -d "$$d" ] || continue; \
+	  [ -f "$$d/manifest.json" ] || continue; \
+	  grep -q '"package":[[:space:]]*"anki-design"' "$$d/manifest.json" || continue; \
+	  [ "$$d" = "$(REAL_INSTALL)/" ] && continue; \
+	  echo "removing duplicate anki-design install: $$d"; \
+	  rm -rf "$$d"; \
+	done
+	@rm -rf "$(REAL_INSTALL)"
+	@mkdir -p "$(REAL_INSTALL)"
+	@unzip -q dist/anki-design.ankiaddon -d "$(REAL_INSTALL)"
+	@echo "installed: $(REAL_INSTALL)"
+	@echo "next     : (re)start Anki to load this build"
 
 clean:
 	@rm -rf dist __pycache__

--- a/__init__.py
+++ b/__init__.py
@@ -3804,7 +3804,7 @@ def _dev_run_cmd(raw: str) -> None:
                         _dev_cmd_log("browse_dims: no splitter")
                     else:
                         _dev_cmd_log(
-                            f"splitter: sizes={sp.sizes()} "
+                            f"outer splitter: sizes={sp.sizes()} "
                             f"count={sp.count()} handle_w={sp.handleWidth()} "
                             f"orient={sp.orientation()}"
                         )
@@ -3816,6 +3816,45 @@ def _dev_run_cmd(raw: str) -> None:
                                 f"size={w.width()}x{w.height()} "
                                 f"min={w.minimumWidth()} max={w.maximumWidth()}"
                             )
+                    # Inner Browser splitter (search/table | editor) lives
+                    # inside centralwidget. It's the one the user drags to
+                    # resize the editor pane.
+                    try:
+                        from . import browse_embed
+                        br = browse_embed._state.get("browser")
+                        if br is not None:
+                            inner = br.form.splitter
+                            _dev_cmd_log(
+                                f"inner splitter: sizes={inner.sizes()} "
+                                f"count={inner.count()} "
+                                f"collapsible={inner.childrenCollapsible()} "
+                                f"orient={inner.orientation()}"
+                            )
+                            for i in range(inner.count()):
+                                w = inner.widget(i)
+                                _dev_cmd_log(
+                                    f"  inner[{i}]: {type(w).__name__} "
+                                    f"obj={w.objectName()!r} "
+                                    f"size={w.width()}x{w.height()} "
+                                    f"visible={w.isVisible()} "
+                                    f"min={w.minimumWidth()} max={w.maximumWidth()}"
+                                )
+                            fa = getattr(br.form, "fieldsArea", None)
+                            if fa is not None:
+                                _dev_cmd_log(
+                                    f"fieldsArea: size={fa.width()}x{fa.height()} "
+                                    f"visible={fa.isVisible()} "
+                                    f"min={fa.minimumWidth()}x{fa.minimumHeight()}"
+                                )
+                            ed = getattr(br, "editor", None)
+                            ew = getattr(ed, "web", None) if ed else None
+                            if ew is not None:
+                                _dev_cmd_log(
+                                    f"editor.web: size={ew.width()}x{ew.height()} "
+                                    f"visible={ew.isVisible()}"
+                                )
+                    except Exception as e:
+                        _dev_cmd_log(f"inner dump err: {e!r}")
             except Exception as e:
                 _dev_cmd_log(f"browse_dims err: {e!r}")
         elif cmd.startswith("browse_search:"):
@@ -3840,6 +3879,24 @@ def _dev_run_cmd(raw: str) -> None:
                     _dev_cmd_log(f"browse_search: {q!r}")
             except Exception as e:
                 _dev_cmd_log(f"browse_search err: {e!r}")
+        elif cmd.startswith("browse_inner_resize:"):
+            try:
+                from . import browse_embed
+                br = browse_embed._state.get("browser")
+                parts = cmd.split(":", 1)[1].split(",")
+                want = [int(p.strip()) for p in parts]
+                if br is not None:
+                    sp = br.form.splitter
+                    sp.setSizes(want)
+                    try:
+                        sp.splitterMoved.emit(sp.sizes()[0], 1)
+                    except Exception:
+                        pass
+                    _dev_cmd_log(
+                        f"browse_inner_resize: set {want} -> got {sp.sizes()}"
+                    )
+            except Exception as e:
+                _dev_cmd_log(f"browse_inner_resize err: {e!r}")
         elif cmd.startswith("browse_resize:"):
             try:
                 from aqt.qt import QFrame, QSplitter

--- a/browse_embed.py
+++ b/browse_embed.py
@@ -56,6 +56,16 @@ SIDEBAR_DOCK_MIN = 220
 SIDEBAR_DOCK_MAX = 480  # past this the central pane (table + editor) starts to look empty
 CENTRAL_MIN = 420  # search + card table + editor pane need this much
 
+# Inner Browser splitter (search+table | editor). Anki's restoreSplitter
+# call ("editor3") often hands back [all, 0] for a fresh profile, which
+# leaves the editor pane invisible — and setChildrenCollapsible(False)
+# doesn't save us because the editor container (verticalLayoutWidget) has
+# no minimum width, so QSplitter happily shrinks it past zero. We give
+# the editor side a real minimum and force a sensible initial split.
+EDITOR_MIN = 320   # narrowest the field area stays legible
+EDITOR_PREF = 460  # default share on first open
+TABLE_MIN = 360    # card table + search bar need at least this much
+
 
 def _clamp_splitter(splitter: "QSplitter", central: Any) -> None:
     """Re-set sizes after a drag so the docks stay within [MIN, MAX] AND
@@ -85,6 +95,26 @@ def _clamp_splitter(splitter: "QSplitter", central: Any) -> None:
                 splitter.blockSignals(False)
     except Exception:
         pass
+
+
+def _apply_inner_split(inner: "QSplitter") -> None:
+    """Force a sensible [table | editor] split on the Browser's inner
+    splitter. Deferred via QTimer so inner.width() reflects the laid-out
+    overlay, not the construction-time 640px default. Without this the
+    editor pane shows up at 0px wide and looks 'missing'."""
+
+    def _set() -> None:
+        try:
+            avail = inner.width() - inner.handleWidth()
+            if avail <= 0:
+                return
+            editor_w = max(EDITOR_MIN, min(EDITOR_PREF, avail // 2))
+            table_w = max(TABLE_MIN, avail - editor_w)
+            inner.setSizes([table_w, editor_w])
+        except Exception:
+            pass
+
+    QTimer.singleShot(0, _set)
 
 
 def _apply_initial_splitter_sizes(splitter: "QSplitter", central: Any) -> None:
@@ -308,6 +338,54 @@ def open_inline(parent_mw: Any = None) -> None:
             pass
 
         central = br.centralWidget()
+
+        # Inner splitter inside central: [search+table | editor]. Three
+        # things have to be true for the editor pane to behave like a real
+        # sidebar:
+        #
+        #   1. It needs a meaningful minimum width — its parent widget
+        #      (verticalLayoutWidget) has min=0 in Anki's .ui, so
+        #      setChildrenCollapsible(False) doesn't actually stop a drag
+        #      from shrinking the editor to zero.
+        #   2. The initial split has to be non-degenerate — restoreSplitter
+        #      ("editor3") routinely hands back [all, 0] for fresh profiles
+        #      and the editor disappears on open.
+        #   3. The pane has to stay visible across selection changes —
+        #      Browser.on_all_or_selected_rows_changed calls
+        #      `splitter.widget(1).setVisible(self.singleCard)` via the
+        #      @ensure_editor_saved decorator, which defers the call
+        #      through Editor.call_after_note_saved. Overriding the method
+        #      can't catch that race, so we patch setVisible on the widget
+        #      itself to ignore False.
+        try:
+            inner = getattr(br.form, "splitter", None)
+            if (
+                inner is not None
+                and inner.count() == 2
+                and inner.orientation() == Qt.Orientation.Horizontal
+            ):
+                table_side = inner.widget(0)
+                editor_side = inner.widget(1)
+                table_side.setMinimumWidth(TABLE_MIN)
+                editor_side.setMinimumWidth(EDITOR_MIN)
+                # Pin both the splitter pane AND the editor's own widget
+                # (Editor.set_note(None, hide=True) calls self.widget.hide()
+                # — which in Browser mode is self.form.fieldsArea — so even
+                # with the splitter pane forced visible, fieldsArea would
+                # collapse to invisible whenever the selection cleared).
+                for w in (editor_side, getattr(br.form, "fieldsArea", None)):
+                    if w is None:
+                        continue
+                    _orig = w.setVisible
+
+                    def _keep_visible(_v: bool, _f=_orig) -> None:
+                        _f(True)
+
+                    w.setVisible = _keep_visible  # type: ignore[assignment]
+                    w.setVisible(True)
+                _apply_inner_split(inner)
+        except Exception:
+            pass
 
         # Browser attaches its sidebar tree (decks / tags / saved searches)
         # as a QDockWidget directly to the QMainWindow, NOT inside


### PR DESCRIPTION
## Summary

The Browse embed's editor sidebar was unreachable — invisible on open, hidden again on any selection change, and draggable past zero — caused by three stacking issues (min=0 on the editor container, [all, 0] saved splitter state, deferred `setVisible(False)` from `Editor.set_note(None)` / `on_all_or_selected_rows_changed`). Fixed by pinning minimum widths (table 360 / editor 320), forcing a non-degenerate initial split, and patching `setVisible` on the editor pane + `fieldsArea` to ignore False.

Also adds `make install` — builds the addon and drops it into the real Anki base, first deduping any other folder whose manifest declares `package="anki-design"` so an AnkiWeb-numeric-ID copy can't coexist and double-render the deck hero + heatmap.

## Test plan
- [ ] Restart real Anki, open Browse — editor pane visible at ~460px, with or without a selection.
- [ ] Drag the inner splitter handle to the right edge — editor stops at 320px instead of disappearing.
- [ ] Drag left — table stops at 360px.
- [ ] Switch selection between rows / clear selection — editor pane stays put.
- [ ] `make install` over a stale AnkiWeb-numeric-ID copy removes the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)