### PR TITLE
Landing shots: snap.sh --height/--js-file + DOM-only number dressing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,42 @@ Pre-baked add-card states (handled by the request JSON, see `_dev_screenshot`):
 `--click-type`, `--embed-add`. These compose: `scripts/snap.sh out.png "add"
 --open-addcards --fill-sample --click-cog`.
 
+Sizing + scripted states:
+
+- `--width=N --height=N` resize `mw` before grabbing. **Resize and grab in two
+  separate calls** — WebEngine only paints what's currently on screen, so a
+  window that just grew renders the new area black. Warm it with a throwaway
+  snap, sleep ~3s, then take the real one.
+- `--js-file=path.js` runs a script inside `mw.web` just before the grab.
+  Unlike `echo "mweval:…" >> .context/cmd` this keeps newlines, so `//`
+  comments survive (a one-line `mweval:` comments out the rest of the script).
+
+### Marketing screenshots for anki.design
+
+`scripts/landing_shot.js` and `scripts/landing_shot_reviewer.js` dress the demo
+collection for the landing page — a curated deck list, non-zero learning
+counts, and a session histogram with a legible shape. They are **DOM-only**:
+nothing touches the collection and the next render wipes them.
+
+```bash
+make dev && make demo VARIANT=full
+# accent + theme come from a local (gitignored) meta.json:
+#   {"config": {"theme": "dark", "accent": "#dd5139", …}}
+# #dd5139 is the site's --primary, so the shot matches the page it lands on.
+
+scripts/snap.sh out/_warm.png main --width=1200 --height=1010   # warm, discard
+sleep 3
+scripts/snap.sh out/hero.png main --js-file=scripts/landing_shot.js
+```
+
+Two widths get shot: 1200px for desktop and 840px for phones. Downscaling the
+wide one to phone width just yields an illegible thumbnail, whereas re-shooting
+narrow lets Anki's own layout reflow. Reviewer equivalents use `--height=400`
+(wide) / `--height=430` (narrow) after `review:<did>` + `show`.
+
+The content column is capped at `--rf-measure: 720px`, so a window much wider
+than ~1200px just adds empty margins to the shot.
+
 ### Constraints
 
 - The Anki window must **exist and not be minimized to the dock**. WebEngine

--- a/scripts/landing_shot.js
+++ b/scripts/landing_shot.js
@@ -1,0 +1,114 @@
+/* landing_shot.js — dress the deck home for the anki.design landing shot.
+ *
+ * Runs inside mw.web (via snap.sh --js-file=) right before the Qt grab. It
+ * does NOT touch the collection: every edit here is DOM-only and disappears
+ * on the next render. The demo collection's own numbers are already realistic
+ * (see scripts/seed_demo.py); this just curates them into one frame —
+ * a shorter deck list, non-zero learning counts, and a session histogram with
+ * a legible shape — so the whole product story fits a single 16:10 crop.
+ *
+ * The streak and heatmap are left exactly as the seeder generated them.
+ *
+ * Usage: scripts/snap.sh out/hero.png main --width=1280 --height=860 \
+ *          --js-file=scripts/landing_shot.js
+ */
+(function () {
+  var qa = function (s, r) { return Array.prototype.slice.call((r || document).querySelectorAll(s)); };
+
+  // ---------------------------------------------------------------- decks --
+  // [new, learning, due]. Parents are the exact sum of their children so the
+  // table survives a close read.
+  var DECKS = {
+    "Languages":                    [26, 7, 198],
+    "French — Top words":           [5, 1, 31],
+    "Japanese — JLPT N5":           [8, 2, 57],
+    "Spanish — Top words":          [13, 4, 110],
+    "Medicine":                     [19, 5, 151],
+    "Anatomy — Bones":              [4, 1, 28],
+    "Pathology & Clinical":         [10, 3, 82],
+    "Pharmacology":                 [5, 1, 41],
+    "Science":                      [8, 2, 63],
+    "Chemistry — Constants & Laws": [3, 1, 25],
+    "Periodic Table":               [5, 1, 38],
+  };
+
+  var setCount = function (el, n) {
+    if (!el) return;
+    el.textContent = String(n);
+    el.classList.toggle("zero", n === 0);
+  };
+
+  qa(".ad-list-row").forEach(function (row) {
+    var nameEl = row.querySelector(".ad-list-name");
+    var name = nameEl ? nameEl.textContent.trim() : "";
+    var plan = DECKS[name];
+    if (!plan) { row.remove(); return; }          // trim to the curated set
+    var counts = row.querySelector(".ad-list-counts");
+    if (!counts) return;
+    setCount(counts.querySelector(".new"), plan[0]);
+    setCount(counts.querySelector(".learn"), plan[1]);
+    setCount(counts.querySelector(".review"), plan[2]);
+  });
+
+  // -------------------------------------------------------------- sidebar --
+  // Column totals across the curated table: 53 new / 14 learning / 412 due.
+  var totals = { due: 412, new: 53, learn: 14 };
+  Object.keys(totals).forEach(function (k) {
+    var el = document.querySelector('dd[data-x="' + k + '"]');
+    if (el) el.textContent = String(totals[k]);
+  });
+
+  // ---------------------------------------------------------------- today --
+  // A believable day: a strong morning block, a real break (the empty stub at
+  // noon), then an afternoon second wind. The header total is summed from
+  // these, so the panel stays internally consistent if you retune them.
+  var HOURS = [
+    ["7 AM", 22], ["8 AM", 45], ["9 AM", 73], ["10 AM", 58], ["11 AM", 27],
+    ["12 PM", 0], ["1 PM", 35], ["2 PM", 54], ["3 PM", 41], ["4 PM", 15],
+    ["5 PM", 26], ["6 PM", 48], ["7 PM", 36], ["8 PM", 17],
+  ];
+  var TOTAL = HOURS.reduce(function (a, h) { return a + h[1]; }, 0);
+  var MINUTES = 78;
+  var peak = HOURS.reduce(function (a, h) { return Math.max(a, h[1]); }, 1);
+
+  var headNums = qa(".ba-today-head .ba-today-n");
+  if (headNums[0]) headNums[0].textContent = TOTAL.toLocaleString();
+  if (headNums[1]) headNums[1].textContent = String(MINUTES);
+
+  var barWrap = document.querySelector(".ba-today-bars");
+  var cols = qa(".ba-today-bar-col", barWrap);
+  if (barWrap && cols.length) {
+    var template = cols[0];
+    cols.slice(HOURS.length).forEach(function (c) { c.remove(); });
+    while (qa(".ba-today-bar-col", barWrap).length < HOURS.length) {
+      barWrap.appendChild(template.cloneNode(true));
+    }
+    qa(".ba-today-bar-col", barWrap).forEach(function (col, i) {
+      var label = HOURS[i][0], n = HOURS[i][1];
+      var bar = col.querySelector(".ba-today-bar");
+      var count = col.querySelector(".ba-today-bar-count");
+      var tipH = col.querySelector(".ba-today-bar-tip-h");
+      var tipD = col.querySelector(".ba-today-bar-tip-d");
+      if (count) count.textContent = n > 0 ? String(n) : "";
+      if (bar) {
+        // Mirrors _pulse_html(): bars cap at 88% so the count label above
+        // never collides; empty hours collapse to a 4% tick.
+        bar.style.height = (n > 0 ? Math.max(8, (n / peak) * 88) : 4).toFixed(1) + "%";
+        bar.classList.toggle("is-empty", n === 0);
+      }
+      if (tipH) tipH.textContent = label;
+      if (tipD) tipD.innerHTML = "<b>" + n + "</b> cards · <b>" + Math.round(n / 6) + " min</b>";
+    });
+  }
+
+  var labels = qa(".ba-today-labels span");
+  if (labels[0] && !labels[0].classList.contains("ba-today-now")) {
+    labels[0].textContent = HOURS[0][0];
+  }
+
+  // ------------------------------------------------------------ chrome fix --
+  // The grab includes the scrollbar gutter; hide it so the frame edge is clean.
+  var st = document.createElement("style");
+  st.textContent = "::-webkit-scrollbar{width:0!important;height:0!important}";
+  document.head.appendChild(st);
+})();

--- a/scripts/landing_shot_reviewer.js
+++ b/scripts/landing_shot_reviewer.js
@@ -1,0 +1,19 @@
+/* landing_shot_reviewer.js — dress the reviewer for the anki.design landing shot.
+ *
+ * Companion to landing_shot.js. DOM-only, discarded on the next render. The
+ * only edit is the header queue counts, so they agree with the deck table in
+ * the hero shot (Medicine::Pathology & Clinical → 10 new / 3 learn / 82 due).
+ *
+ * Usage: scripts/snap.sh out/reviewer.png main --js-file=scripts/landing_shot_reviewer.js
+ */
+(function () {
+  var COUNTS = { "ba-rv-c-new": 10, "ba-rv-c-learn": 3, "ba-rv-c-due": 82 };
+  Object.keys(COUNTS).forEach(function (id) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = String(COUNTS[id]);
+  });
+
+  var st = document.createElement("style");
+  st.textContent = "::-webkit-scrollbar{width:0!important;height:0!important}";
+  document.head.appendChild(st);
+})();

--- a/scripts/snap.sh
+++ b/scripts/snap.sh
@@ -3,6 +3,10 @@
 #
 # Usage:
 #   scripts/snap.sh <out.png> <title-substring|"main"> [--open-addcards] [--fill-sample]
+#   scripts/snap.sh <out.png> main --width=1280 --height=860 --js-file=path/to.js
+#
+# --width/--height resize the main window before grabbing; --js-file runs a
+# script inside mw.web first (see scripts/landing_shot.js).
 #
 # Writes a JSON request into .context/screenshot-requests/; the Anki Design
 # dev-watch thread picks it up, grabs the matching top-level widget on the
@@ -20,6 +24,8 @@ EMBED_FLAG="false"
 CLOSE_FLAG="false"
 TRIGGER_KEY=""
 MW_WIDTH="0"
+MW_HEIGHT="0"
+JS_FILE=""
 for arg in "$@"; do
   case "$arg" in
     --open-addcards) OPEN_FLAG="true" ;;
@@ -31,6 +37,8 @@ for arg in "$@"; do
     --close-after) CLOSE_FLAG="true" ;;
     --trigger=*) TRIGGER_KEY="${arg#--trigger=}" ;;
     --width=*) MW_WIDTH="${arg#--width=}" ;;
+    --height=*) MW_HEIGHT="${arg#--height=}" ;;
+    --js-file=*) JS_FILE="${arg#--js-file=}" ;;
     --hover-add-btn) HOVER_FLAG="true" ;;
     --test-add) TEST_ADD="true" ;;
   esac
@@ -41,6 +49,13 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 DIR="$REPO/.context/screenshot-requests"
 mkdir -p "$DIR" "$(dirname "$OUT")"
 ABS_OUT="$(cd "$(dirname "$OUT")" && pwd)/$(basename "$OUT")"
+
+# --js-file ships arbitrary JS to run in mw.web just before the grab, so it
+# has to be JSON-escaped rather than interpolated raw into the heredoc.
+RUN_JS="null"
+if [[ -n "$JS_FILE" ]]; then
+  RUN_JS="$(python3 -c 'import json,sys; print(json.dumps(open(sys.argv[1]).read()))' "$JS_FILE")"
+fi
 
 # Stable filename ⇒ unique stamp per request
 REQ="$DIR/req-$(date +%s%N).json"
@@ -56,6 +71,8 @@ cat > "$REQ" <<JSON
   "close_after": ${CLOSE_FLAG},
   "trigger_shortcut": "${TRIGGER_KEY}",
   "mw_width": ${MW_WIDTH},
+  "mw_height": ${MW_HEIGHT},
+  "run_js": ${RUN_JS},
   "hover_add": ${HOVER_FLAG},
   "test_add": ${TEST_ADD},
   "delay_ms": 6500


### PR DESCRIPTION
Tooling to produce the product screenshots for [anki.design](https://anki.design) without touching the demo collection. Companion to NoahLloyd/anki-design-landing#8, which consumes the output.

## What's here

**`scripts/snap.sh`** gains two flags:

- `--height=N` — `mw_height` was already handled in `_dev_screenshot`, just never exposed.
- `--js-file=path` — JSON-escapes a script into the request so it runs in `mw.web` right before the grab. Unlike a one-line `mweval:`, newlines survive, so `//` comments don't swallow the rest of the script.

**`scripts/landing_shot.js`** curates the deck home into a single frame: 11 rows, non-zero learning counts, and a session histogram with a legible shape (morning block → lunch gap → afternoon second wind). Parent rows sum exactly to their children and the sidebar totals sum to the table, so it survives a close read.

**`scripts/landing_shot_reviewer.js`** aligns the reviewer's queue counts with the deck row the card came from.

Both are **DOM-only**. Nothing touches the collection; the next render wipes them.

## Two constraints worth knowing

Documented in `CLAUDE.md` because both cost real time to rediscover:

- **Resize and grab must be separate calls.** WebEngine only paints what's currently on screen, so a window that just grew renders the new area black. Warm it with a throwaway snap, sleep ~3s, then take the real one.
- **The content column is capped at `--rf-measure: 720px`**, so a window much wider than ~1200px just adds empty margins to the shot.

## Verification

Ran end-to-end against `make demo VARIANT=full` with the accent set to the site's `--primary` (`#dd5139`) via a local gitignored `meta.json`. Four captures produced and inspected — deck home at 1200×1010 and 840×1010, reviewer at 1600×400 and 840×430. All four are committed in the landing repo under `src/assets/shots/`.

```
scripts/snap.sh out/_warm.png main --width=1200 --height=1010   # warm, discard
sleep 3
scripts/snap.sh out/hero.png main --js-file=scripts/landing_shot.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
